### PR TITLE
feat: wallet auth before topup

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ logos-scaffold help
 - `localnet start` waits until localnet is actually ready (`pid alive` + `127.0.0.1:3040` reachable), otherwise fails with diagnostics.
 - `localnet status` distinguishes managed process, stale state, and foreign listeners.
 - `wallet list` shows known wallet accounts (`wallet account list`).
-- `wallet topup` uses a single Piñata faucet claim (`wallet pinata claim --to ...`). If address is omitted, scaffold uses project default wallet from `.scaffold/state/wallet.state`.
+- `wallet topup` checks account state first (`wallet account get --account-id ...`), runs `wallet auth-transfer init --account-id ...` only when the destination is uninitialized, then performs Piñata faucet claim (`wallet pinata claim --to ...`). If address is omitted, scaffold uses project default wallet from `.scaffold/state/wallet.state`.
 - `wallet default set` stores a project-scoped default wallet address in `.scaffold/state/wallet.state`.
 - `wallet -- ...` forwards raw wallet CLI commands while preserving project wallet environment.
 - `doctor` prints actionable checks and next steps; `--json` is for CI/machine parsing.

--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -7,10 +7,10 @@ use crate::project::load_project;
 use crate::DynResult;
 
 use super::wallet_support::{
-    extract_tx_identifier, is_confirmation_timeout_failure, is_connectivity_failure,
-    load_wallet_runtime, read_default_wallet_address, resolve_wallet_address,
-    sequencer_unreachable_hint, summarize_command_failure, wallet_password, wallet_state_path,
-    write_default_wallet_address,
+    extract_tx_identifier, is_already_initialized_failure, is_confirmation_timeout_failure,
+    is_connectivity_failure, is_uninitialized_account_output, load_wallet_runtime,
+    read_default_wallet_address, resolve_wallet_address, sequencer_unreachable_hint,
+    summarize_command_failure, wallet_password, wallet_state_path, write_default_wallet_address,
 };
 
 #[derive(Debug, Clone)]
@@ -99,13 +99,28 @@ fn cmd_wallet_topup(
         .sequencer_addr
         .clone()
         .unwrap_or_else(|| "http://127.0.0.1:3040".to_string());
+    let wallet_home = wallet.wallet_home.as_os_str().to_string_lossy().to_string();
+    let password_input = format!("{}\n", wallet_password());
 
-    let mut command = Command::new(&wallet.wallet_binary);
-    command
-        .env(
-            "NSSA_WALLET_HOME_DIR",
-            wallet.wallet_home.as_os_str().to_string_lossy().to_string(),
-        )
+    let mut preflight_command = Command::new(&wallet.wallet_binary);
+    preflight_command
+        .env("NSSA_WALLET_HOME_DIR", wallet_home.clone())
+        .arg("account")
+        .arg("get")
+        .arg("--account-id")
+        .arg(&resolved_to);
+
+    let mut init_command = Command::new(&wallet.wallet_binary);
+    init_command
+        .env("NSSA_WALLET_HOME_DIR", wallet_home.clone())
+        .arg("auth-transfer")
+        .arg("init")
+        .arg("--account-id")
+        .arg(&resolved_to);
+
+    let mut pinata_command = Command::new(&wallet.wallet_binary);
+    pinata_command
+        .env("NSSA_WALLET_HOME_DIR", wallet_home.clone())
         .arg("pinata")
         .arg("claim")
         .arg("--to")
@@ -113,18 +128,63 @@ fn cmd_wallet_topup(
 
     if dry_run {
         println!("dry-run: wallet topup command will not be executed");
+        println!("NSSA_WALLET_HOME_DIR={wallet_home}");
+        println!("$ {}", render_command(&preflight_command));
+        println!("planned preflight: check destination wallet initialization");
         println!(
-            "NSSA_WALLET_HOME_DIR={}",
-            wallet.wallet_home.as_os_str().to_string_lossy()
+            "planned conditional step: run only if uninitialized -> {}",
+            render_command(&init_command)
         );
-        println!("$ {}", render_command(&command));
+        println!("$ {}", render_command(&pinata_command));
         println!("planned wallet: {resolved_to}");
         println!("planned method: pinata faucet claim");
         println!("planned network: local sequencer ({sequencer_addr})");
         return Ok(());
     }
 
-    let output = run_with_stdin(command, format!("{}\n", wallet_password()))
+    let preflight_output = run_with_stdin(preflight_command, password_input.clone())
+        .context("failed to execute wallet topup preflight command")?;
+    if !preflight_output.status.success() {
+        let summary = summarize_command_failure(&preflight_output.stdout, &preflight_output.stderr);
+        let combined = format!("{}\n{}", preflight_output.stdout, preflight_output.stderr);
+        if is_connectivity_failure(&combined) {
+            bail!(
+                "wallet topup failed during account preflight: {summary}\n{}",
+                sequencer_unreachable_hint(&sequencer_addr)
+            );
+        }
+
+        bail!(
+            "wallet topup failed while checking account initialization: {summary}\nHint: verify the destination with `logos-scaffold wallet -- account get --account-id {resolved_to}`."
+        );
+    }
+
+    let preflight_combined = format!("{}\n{}", preflight_output.stdout, preflight_output.stderr);
+    if is_uninitialized_account_output(&preflight_combined) {
+        println!(
+            "wallet topup preflight: destination is uninitialized; running auth-transfer init"
+        );
+        let init_output = run_with_stdin(init_command, password_input.clone())
+            .context("failed to execute wallet topup init command")?;
+
+        if !init_output.status.success() {
+            let summary = summarize_command_failure(&init_output.stdout, &init_output.stderr);
+            let combined = format!("{}\n{}", init_output.stdout, init_output.stderr);
+            if is_connectivity_failure(&combined) {
+                bail!(
+                    "wallet topup failed during account initialization: {summary}\n{}",
+                    sequencer_unreachable_hint(&sequencer_addr)
+                );
+            }
+            if is_already_initialized_failure(&combined) {
+                println!("wallet topup preflight: destination already initialized; continuing");
+            } else {
+                bail!("wallet topup failed while initializing destination wallet: {summary}");
+            }
+        }
+    }
+
+    let output = run_with_stdin(pinata_command, password_input)
         .context("failed to execute wallet topup command")?;
 
     if !output.status.success() {

--- a/src/commands/wallet_support.rs
+++ b/src/commands/wallet_support.rs
@@ -227,6 +227,23 @@ pub(crate) fn is_connectivity_failure(text: &str) -> bool {
     .any(|needle| lower.contains(needle))
 }
 
+pub(crate) fn is_uninitialized_account_output(text: &str) -> bool {
+    text.to_lowercase().contains("account is uninitialized")
+}
+
+pub(crate) fn is_already_initialized_failure(text: &str) -> bool {
+    let lower = text.to_lowercase();
+    [
+        "already initialized",
+        "account must be uninitialized",
+        "account is already initialized",
+        "cannot claim an initialized account",
+        "only uninitialized accounts can be initialized",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
+}
+
 pub(crate) fn is_confirmation_timeout_failure(text: &str) -> bool {
     text.to_lowercase()
         .contains("transaction not found in preconfigured amount of blocks")
@@ -431,9 +448,9 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        extract_tx_identifier, first_public_wallet_address, normalize_address_ref,
-        read_default_wallet_address, resolve_wallet_address, wallet_state_path,
-        write_default_wallet_address,
+        extract_tx_identifier, first_public_wallet_address, is_already_initialized_failure,
+        is_uninitialized_account_output, normalize_address_ref, read_default_wallet_address,
+        resolve_wallet_address, wallet_state_path, write_default_wallet_address,
     };
 
     const ACCOUNT_ID: &str = "6iArKUXxhUJqS7kCaPNhwMWt3ro71PDyBj7jwAyE2VQV";
@@ -632,5 +649,17 @@ details: [1, 2, 3]
 
         let tx = extract_tx_identifier(stdout, "");
         assert_eq!(tx.as_deref(), Some("tx_hash: plain-id-789"));
+    }
+
+    #[test]
+    fn detects_uninitialized_account_output() {
+        let combined = "some output\nAccount is Uninitialized\nmore output";
+        assert!(is_uninitialized_account_output(combined));
+    }
+
+    #[test]
+    fn detects_already_initialized_failure_output() {
+        let combined = "Error: Account must be uninitialized";
+        assert!(is_already_initialized_failure(combined));
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -796,6 +796,10 @@ fn wallet_topup_dry_run_renders_pinata_claim_command() {
         .success()
         .stdout(
             predicate::str::contains("dry-run: wallet topup command will not be executed")
+                .and(predicate::str::contains(
+                    "planned preflight: check destination wallet initialization",
+                ))
+                .and(predicate::str::contains("auth-transfer init --account-id"))
                 .and(predicate::str::contains("pinata claim --to"))
                 .and(predicate::str::contains(
                     "planned method: pinata faucet claim",
@@ -821,6 +825,90 @@ fn wallet_topup_runs_pinata_claim_with_explicit_address() {
             predicate::str::contains("pinata claim --to Public/")
                 .and(predicate::str::contains("wallet topup complete")),
         );
+}
+
+#[test]
+fn wallet_topup_initializes_when_account_uninitialized_before_pinata() {
+    let temp = tempdir().expect("tempdir");
+    let wallet_stub = write_wallet_stub(temp.path());
+    setup_wallet_project(temp.path(), &wallet_stub, Some("http://127.0.0.1:3040"));
+
+    let assert = Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .env("TOPUP_ACCOUNT_STATE", "uninitialized")
+        .env("TOPUP_GUARD_REQUIRE_INIT", "1")
+        .arg("wallet")
+        .arg("topup")
+        .arg("--address")
+        .arg(VALID_PUBLIC_ADDRESS)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("wallet topup complete"));
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8 stdout");
+    let init_pos = stdout
+        .find("auth-transfer init --account-id Public/")
+        .expect("init command should be present");
+    let pinata_pos = stdout
+        .find("pinata claim --to Public/")
+        .expect("pinata command should be present");
+    assert!(
+        init_pos < pinata_pos,
+        "auth-transfer init must run before pinata claim, got output:\n{stdout}"
+    );
+}
+
+#[test]
+fn wallet_topup_skips_init_when_account_already_initialized() {
+    let temp = tempdir().expect("tempdir");
+    let wallet_stub = write_wallet_stub(temp.path());
+    setup_wallet_project(temp.path(), &wallet_stub, Some("http://127.0.0.1:3040"));
+
+    let assert = Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .env("TOPUP_ACCOUNT_STATE", "initialized")
+        .arg("wallet")
+        .arg("topup")
+        .arg("--address")
+        .arg(VALID_PUBLIC_ADDRESS)
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8 stdout");
+    assert!(
+        !stdout.contains("auth-transfer init --account-id"),
+        "init command must not run for initialized accounts, got output:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("pinata claim --to Public/"),
+        "pinata claim should still run, got output:\n{stdout}"
+    );
+}
+
+#[test]
+fn wallet_topup_preflight_failure_blocks_pinata() {
+    let temp = tempdir().expect("tempdir");
+    let wallet_stub = write_wallet_stub(temp.path());
+    setup_wallet_project(temp.path(), &wallet_stub, Some("http://127.0.0.1:3040"));
+
+    let assert = Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .env("TOPUP_PREFLIGHT_FAIL", "1")
+        .arg("wallet")
+        .arg("topup")
+        .arg("--address")
+        .arg(VALID_PUBLIC_ADDRESS)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "wallet topup failed while checking account initialization",
+        ));
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8 stdout");
+    assert!(
+        !stdout.contains("pinata claim --to"),
+        "pinata must not run when preflight fails, got output:\n{stdout}"
+    );
 }
 
 #[test]
@@ -942,6 +1030,63 @@ fn wallet_topup_shows_sequencer_hint_on_connectivity_failure() {
                 .and(predicate::str::contains("logos-scaffold localnet start"))
                 .and(predicate::str::contains("Another project's sequencer")),
         );
+}
+
+#[test]
+fn wallet_topup_init_connectivity_failure_shows_sequencer_hint() {
+    let temp = tempdir().expect("tempdir");
+    let wallet_stub = write_wallet_stub(temp.path());
+    setup_wallet_project(temp.path(), &wallet_stub, Some("http://127.0.0.1:3040"));
+
+    let assert = Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .env("TOPUP_ACCOUNT_STATE", "uninitialized")
+        .env("TOPUP_INIT_FAIL_CONNECT", "1")
+        .arg("wallet")
+        .arg("topup")
+        .arg("--address")
+        .arg(VALID_PUBLIC_ADDRESS)
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("sequencer appears unavailable")
+                .and(predicate::str::contains("logos-scaffold localnet start"))
+                .and(predicate::str::contains("Another project's sequencer")),
+        );
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8 stdout");
+    assert!(
+        !stdout.contains("pinata claim --to"),
+        "pinata must not run when init fails with connectivity error, got output:\n{stdout}"
+    );
+}
+
+#[test]
+fn wallet_topup_continues_when_init_reports_already_initialized() {
+    let temp = tempdir().expect("tempdir");
+    let wallet_stub = write_wallet_stub(temp.path());
+    setup_wallet_project(temp.path(), &wallet_stub, Some("http://127.0.0.1:3040"));
+
+    let assert = Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .env("TOPUP_ACCOUNT_STATE", "uninitialized")
+        .env("TOPUP_INIT_FAIL_ALREADY", "1")
+        .arg("wallet")
+        .arg("topup")
+        .arg("--address")
+        .arg(VALID_PUBLIC_ADDRESS)
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("destination already initialized; continuing")
+                .and(predicate::str::contains("wallet topup complete")),
+        );
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8 stdout");
+    assert!(
+        stdout.contains("pinata claim --to Public/"),
+        "pinata should run after tolerated init race, got output:\n{stdout}"
+    );
 }
 
 #[test]
@@ -1301,8 +1446,44 @@ if [ "$#" -ge 2 ] && [ "$1" = "account" ] && [ "$2" = "list" ]; then
   exit 0
 fi
 
+if [ "$#" -ge 2 ] && [ "$1" = "account" ] && [ "$2" = "get" ]; then
+  if [ "${TOPUP_PREFLIGHT_FAIL:-0}" = "1" ]; then
+    echo "simulated account get failure" >&2
+    exit 4
+  fi
+  if [ "${TOPUP_ACCOUNT_STATE:-initialized}" = "uninitialized" ]; then
+    echo "Account is Uninitialized"
+  else
+    echo "Account state: Initialized"
+  fi
+  exit 0
+fi
+
+if [ "$#" -ge 3 ] && [ "$1" = "auth-transfer" ] && [ "$2" = "init" ] && [ "$3" = "--account-id" ]; then
+  require_password_if_configured
+  if [ "${TOPUP_INIT_FAIL_CONNECT:-0}" = "1" ]; then
+    echo "connection refused" >&2
+    exit 1
+  fi
+  if [ "${TOPUP_INIT_FAIL_ALREADY:-0}" = "1" ]; then
+    echo "Error: Account must be uninitialized" >&2
+    exit 1
+  fi
+  marker_path="${NSSA_WALLET_HOME_DIR:-.}/.topup-init-ran"
+  : > "$marker_path"
+  echo "init ok"
+  exit 0
+fi
+
 if [ "$#" -ge 2 ] && [ "$1" = "pinata" ] && [ "$2" = "claim" ]; then
   require_password_if_configured
+  if [ "${TOPUP_GUARD_REQUIRE_INIT:-0}" = "1" ]; then
+    marker_path="${NSSA_WALLET_HOME_DIR:-.}/.topup-init-ran"
+    if [ ! -f "$marker_path" ]; then
+      echo "pinata called before init" >&2
+      exit 9
+    fi
+  fi
   if [ "${TOPUP_FAIL_CONNECT:-0}" = "1" ]; then
     echo "connection refused" >&2
     exit 1


### PR DESCRIPTION
## Description

Due to wallet transfers requiring accounts to be initialized we need to make sure additional steps are executed when `pinata` is called.