### PR TITLE
fix: wallet config filename mismatch between setup and runtime

### DIFF
--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -5,6 +5,7 @@ use std::process::{Command, Stdio};
 use anyhow::bail;
 
 use super::wallet_support::wallet_password;
+use crate::commands::wallet_support::WALLET_CONFIG_PRIMARY;
 use crate::constants::DEFAULT_LSSA_PIN;
 use crate::doctor_checks::{
     check_binary, check_container_runtime, check_path, check_port_warn, check_repo,
@@ -14,7 +15,6 @@ use crate::model::{CheckRow, CheckStatus, DoctorReport, DoctorSummary};
 use crate::process::{pid_running, run_capture, run_with_stdin, set_command_echo, which};
 use crate::project::load_project;
 use crate::state::read_localnet_state;
-use crate::commands::wallet_support::WALLET_CONFIG_PRIMARY;
 use crate::DynResult;
 
 const STEP_SETUP: &str = "logos-scaffold setup";

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -14,6 +14,7 @@ use crate::model::{CheckRow, CheckStatus, DoctorReport, DoctorSummary};
 use crate::process::{pid_running, run_capture, run_with_stdin, set_command_echo, which};
 use crate::project::load_project;
 use crate::state::read_localnet_state;
+use crate::commands::wallet_support::WALLET_CONFIG_PRIMARY;
 use crate::DynResult;
 
 const STEP_SETUP: &str = "logos-scaffold setup";
@@ -175,7 +176,7 @@ pub(crate) fn build_doctor_report() -> DynResult<DoctorReport> {
         });
     }
 
-    let wallet_cfg = wallet_home.join("config.json");
+    let wallet_cfg = wallet_home.join(WALLET_CONFIG_PRIMARY);
     if wallet_cfg.exists() {
         let cfg_text = fs::read_to_string(&wallet_cfg)?;
         if cfg_text.contains("127.0.0.1:3040") || cfg_text.contains("localhost:3040") {
@@ -191,7 +192,7 @@ pub(crate) fn build_doctor_report() -> DynResult<DoctorReport> {
                 name: "wallet network config".to_string(),
                 detail: "wallet may point to non-local sequencer".to_string(),
                 remediation: Some(
-                    "Set .scaffold/wallet/config.json sequencer_addr=http://127.0.0.1:3040"
+                    "Set .scaffold/wallet/wallet_config.json sequencer_addr=http://127.0.0.1:3040"
                         .to_string(),
                 ),
             });
@@ -200,7 +201,7 @@ pub(crate) fn build_doctor_report() -> DynResult<DoctorReport> {
         rows.push(CheckRow {
             status: CheckStatus::Warn,
             name: "wallet network config".to_string(),
-            detail: "missing .scaffold/wallet/config.json".to_string(),
+            detail: "missing .scaffold/wallet/wallet_config.json".to_string(),
             remediation: Some("Run `logos-scaffold setup`".to_string()),
         });
     }

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -175,6 +175,7 @@ fn ensure_wallet_install(
 
 #[cfg(test)]
 mod tests {
+    use crate::commands::wallet_support::WALLET_CONFIG_PRIMARY;
     use std::fs;
 
     use tempfile::tempdir;
@@ -191,7 +192,7 @@ mod tests {
         let wallet_home = temp.path().join(".scaffold/wallet");
         fs::create_dir_all(&wallet_home).expect("mkdir wallet home");
         fs::write(
-            wallet_home.join("config.json"),
+            wallet_home.join(WALLET_CONFIG_PRIMARY),
             format!(
                 r#"{{
   "initial_accounts": [
@@ -226,7 +227,7 @@ mod tests {
         let wallet_home = temp.path().join(".scaffold/wallet");
         fs::create_dir_all(&wallet_home).expect("mkdir wallet home");
         fs::write(
-            wallet_home.join("config.json"),
+            wallet_home.join(WALLET_CONFIG_PRIMARY),
             format!(
                 r#"{{
   "initial_accounts": [

--- a/src/commands/wallet_support.rs
+++ b/src/commands/wallet_support.rs
@@ -446,7 +446,7 @@ fn one_line(text: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{WALLET_CONFIG_PRIMARY, WALLET_CONFIG_FALLBACK};
+    use super::{WALLET_CONFIG_FALLBACK, WALLET_CONFIG_PRIMARY};
     use std::fs;
 
     use tempfile::tempdir;

--- a/src/commands/wallet_support.rs
+++ b/src/commands/wallet_support.rs
@@ -11,8 +11,8 @@ use crate::model::Project;
 use crate::state::write_text;
 use crate::DynResult;
 
-const WALLET_CONFIG_PRIMARY: &str = "wallet_config.json";
-const WALLET_CONFIG_FALLBACK: &str = "config.json";
+pub(crate) const WALLET_CONFIG_PRIMARY: &str = "wallet_config.json";
+pub(crate) const WALLET_CONFIG_FALLBACK: &str = "config.json";
 
 pub(crate) struct WalletRuntimeContext {
     pub(crate) wallet_home: PathBuf,
@@ -446,6 +446,7 @@ fn one_line(text: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use super::{WALLET_CONFIG_PRIMARY, WALLET_CONFIG_FALLBACK};
     use std::fs;
 
     use tempfile::tempdir;
@@ -531,7 +532,7 @@ mod tests {
         let wallet_home = temp.path().join(".scaffold/wallet");
         fs::create_dir_all(&wallet_home).expect("mkdir wallet home");
         fs::write(
-            wallet_home.join("wallet_config.json"),
+            wallet_home.join(WALLET_CONFIG_PRIMARY),
             r#"{
   "initial_accounts": [
     { "Private": { "account_id": "2ECgkFTaXzwjJBXR7ZKmXYQtpHbvTTHK9Auma4NL9AUo" } },
@@ -552,7 +553,7 @@ mod tests {
         let wallet_home = temp.path().join(".scaffold/wallet");
         fs::create_dir_all(&wallet_home).expect("mkdir wallet home");
         fs::write(
-            wallet_home.join("wallet_config.json"),
+            wallet_home.join(WALLET_CONFIG_PRIMARY),
             r#"{
   "initial_accounts": [
     { "Private": { "account_id": "2ECgkFTaXzwjJBXR7ZKmXYQtpHbvTTHK9Auma4NL9AUo" } }

--- a/src/commands/wallet_support.rs
+++ b/src/commands/wallet_support.rs
@@ -43,23 +43,26 @@ pub(crate) fn load_wallet_runtime(project: &Project) -> DynResult<WalletRuntimeC
 }
 
 fn read_wallet_config(wallet_home: &Path) -> DynResult<(PathBuf, Value)> {
-    let candidates = [
-        wallet_home.join(WALLET_CONFIG_PRIMARY),
-        wallet_home.join(WALLET_CONFIG_FALLBACK),
-    ];
+    let primary = wallet_home.join(WALLET_CONFIG_PRIMARY);
+    let fallback = wallet_home.join(WALLET_CONFIG_FALLBACK);
 
-    let path = candidates
-        .iter()
-        .find(|path| path.exists())
-        .cloned()
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "missing wallet config. Expected `{}` or `{}` under {}. Run `logos-scaffold setup`.",
-                WALLET_CONFIG_PRIMARY,
-                WALLET_CONFIG_FALLBACK,
-                wallet_home.display()
-            )
-        })?;
+    let path = if primary.exists() {
+        primary
+    } else if fallback.exists() {
+        // Legacy: older `setup` runs wrote "config.json" instead of
+        // "wallet_config.json". Re-run `logos-scaffold setup` to migrate.
+        eprintln!(
+            "warning: found legacy wallet config '{}';              re-run `logos-scaffold setup` to migrate to '{}'.",
+            WALLET_CONFIG_FALLBACK,
+            WALLET_CONFIG_PRIMARY,
+        );
+        fallback
+    } else {
+        return Err(anyhow::anyhow!(
+            "missing wallet config at \'{}\'. Run `logos-scaffold setup`.",
+            wallet_home.join(WALLET_CONFIG_PRIMARY).display()
+        ));
+    };
 
     let text = fs::read_to_string(&path)
         .with_context(|| format!("failed to read wallet config at {}", path.display()))?;

--- a/src/state.rs
+++ b/src/state.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use anyhow::{anyhow, bail};
 
 use crate::model::LocalnetState;
+use crate::commands::wallet_support::WALLET_CONFIG_PRIMARY;
 use crate::DynResult;
 
 pub(crate) fn write_text(path: &Path, text: &str) -> DynResult<()> {
@@ -45,7 +46,7 @@ pub(crate) fn read_localnet_state(path: &Path) -> DynResult<LocalnetState> {
 
 pub(crate) fn prepare_wallet_home(lssa_repo: &Path, wallet_home: &Path) -> DynResult<()> {
     fs::create_dir_all(wallet_home)?;
-    let cfg_dst = wallet_home.join("wallet_config.json");
+    let cfg_dst = wallet_home.join(WALLET_CONFIG_PRIMARY);
     if !cfg_dst.exists() {
         let cfg_src = lssa_repo.join("wallet/configs/debug/wallet_config.json");
         if !cfg_src.exists() {

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 
 use anyhow::{anyhow, bail};
 
-use crate::model::LocalnetState;
 use crate::commands::wallet_support::WALLET_CONFIG_PRIMARY;
+use crate::model::LocalnetState;
 use crate::DynResult;
 
 pub(crate) fn write_text(path: &Path, text: &str) -> DynResult<()> {

--- a/src/state.rs
+++ b/src/state.rs
@@ -45,7 +45,7 @@ pub(crate) fn read_localnet_state(path: &Path) -> DynResult<LocalnetState> {
 
 pub(crate) fn prepare_wallet_home(lssa_repo: &Path, wallet_home: &Path) -> DynResult<()> {
     fs::create_dir_all(wallet_home)?;
-    let cfg_dst = wallet_home.join("config.json");
+    let cfg_dst = wallet_home.join("wallet_config.json");
     if !cfg_dst.exists() {
         let cfg_src = lssa_repo.join("wallet/configs/debug/wallet_config.json");
         if !cfg_src.exists() {


### PR DESCRIPTION
## Summary

Fixes #21.

`setup` was writing the wallet config as `config.json`, while
`wallet_support.rs` checked `wallet_config.json` first and silently
fell back to `config.json`. This worked but was confusing for
downstream consumers who had to probe both names.

## Changes

**`src/state.rs`**
- `prepare_wallet_home` now writes `wallet_config.json` instead of `config.json`.

**`src/commands/wallet_support.rs`**
- Removed unused `candidates` array.
- Legacy `config.json` fallback kept for backwards compatibility with
  existing installations, now emits an `eprintln!` warning directing
  users to re-run `setup`.
- Error message when neither file exists now includes the expected path.

## Testing

```bash
cargo check   # ✓
cargo test    # ✓ 52 passed, 0 failed
