### PR TITLE
feat: dynamically list available templates in create/new help text

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::sync::LazyLock;
 
 use anyhow::anyhow;
 use clap::{CommandFactory, Parser, Subcommand};
@@ -14,7 +15,18 @@ use crate::commands::report::cmd_report;
 use crate::commands::setup::{cmd_setup, SetupCommand, WalletInstallMode};
 use crate::commands::wallet::{cmd_wallet, WalletAction};
 use crate::constants::VERSION;
+use crate::template::project::available_templates;
 use crate::DynResult;
+
+static CREATE_ABOUT: LazyLock<String> = LazyLock::new(|| {
+    let templates = available_templates().join(", ");
+    format!("Create a new logos-scaffold project (templates: {templates})")
+});
+
+static NEW_ABOUT: LazyLock<String> = LazyLock::new(|| {
+    let templates = available_templates().join(", ");
+    format!("Alias for `create` (templates: {templates})")
+});
 
 #[derive(Debug, Parser)]
 #[command(
@@ -30,8 +42,10 @@ struct Cli {
 #[derive(Debug, Subcommand)]
 enum Commands {
     #[command(about = "Create a new logos-scaffold project")]
+    #[command(before_long_help = CREATE_ABOUT.as_str())]
     Create(NewArgs),
     #[command(about = "Alias for `create`")]
+    #[command(before_long_help = NEW_ABOUT.as_str())]
     New(NewArgs),
     Setup(SetupArgs),
     Build(BuildArgs),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,6 +18,11 @@ use crate::constants::VERSION;
 use crate::template::project::available_templates;
 use crate::DynResult;
 
+static TEMPLATE_HELP: LazyLock<String> = LazyLock::new(|| {
+    let templates = available_templates().join(", ");
+    format!("Template to use (available: {templates})")
+});
+
 static CREATE_ABOUT: LazyLock<String> = LazyLock::new(|| {
     let templates = available_templates().join(", ");
     format!("Create a new logos-scaffold project (templates: {templates})")
@@ -68,7 +73,7 @@ struct NewArgs {
     lssa_path: Option<PathBuf>,
     #[arg(long)]
     cache_root: Option<PathBuf>,
-    #[arg(long, default_value = "default")]
+    #[arg(long, default_value = "default", help = TEMPLATE_HELP.as_str())]
     template: String,
 }
 

--- a/src/template/project.rs
+++ b/src/template/project.rs
@@ -125,6 +125,22 @@ fn find_unresolved_placeholder(text: &str) -> Option<&str> {
     }
 }
 
+pub(crate) fn available_templates() -> Vec<String> {
+    let mut names: Vec<String> = TEMPLATES_DIR
+        .dirs()
+        .map(|d| {
+            d.path()
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string()
+        })
+        .filter(|s| !s.is_empty())
+        .collect();
+    names.sort();
+    names
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;


### PR DESCRIPTION
## Summary

Closes #9.

`create` and `new` commands showed a static description with no
indication of available templates. This adds a runtime scan of
`TEMPLATES_DIR` and exposes the list via clap's `before_long_help`.

## Changes

**`src/template/project.rs`**
- New `available_templates()` function: scans `TEMPLATES_DIR` dirs,
  returns sorted list of template names.

**`src/cli.rs`**
- Two `LazyLock<String>` statics (`CREATE_ABOUT`, `NEW_ABOUT`) that
  call `available_templates()` at first use.
- `create` and `new` commands use `before_long_help` to show the list.

## Output
