### PR TITLE
feat: make sequencer port and RISC0_DEV_MODE configurable

### DIFF
--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -14,7 +14,7 @@ use crate::project::{ensure_dir_exists, find_project_root, load_project};
 use crate::state::{read_localnet_state, write_localnet_state};
 use crate::DynResult;
 
-const LOCALNET_ADDR: &str = "127.0.0.1:3040";
+// LOCALNET_ADDR is now read from project config (localnet.port)
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum LocalnetAction {
@@ -45,10 +45,18 @@ pub(crate) fn cmd_localnet(action: LocalnetAction) -> DynResult<()> {
 pub(crate) fn build_localnet_status_for_project(project: &Project) -> LocalnetStatusReport {
     let state_path = project.root.join(".scaffold/state/localnet.state");
     let log_path = project.root.join(".scaffold/logs/sequencer.log");
-    build_status_report(&state_path, &log_path)
+    build_status_report(
+        &state_path,
+        &log_path,
+        &format!("127.0.0.1:{}", project.config.localnet.port),
+        project.config.localnet.port,
+    )
 }
 
 fn cmd_localnet_in_project(project: &Project, action: LocalnetAction) -> DynResult<()> {
+    let localnet_port = project.config.localnet.port;
+    let risc0_dev_mode = project.config.localnet.risc0_dev_mode;
+    let localnet_addr = format!("127.0.0.1:{localnet_port}");
     let lssa = PathBuf::from(&project.config.lssa.path);
     let state_path = project.root.join(".scaffold/state/localnet.state");
     let logs_dir = project.root.join(".scaffold/logs");
@@ -56,22 +64,32 @@ fn cmd_localnet_in_project(project: &Project, action: LocalnetAction) -> DynResu
     fs::create_dir_all(&logs_dir)?;
 
     match action {
-        LocalnetAction::Start { timeout_sec } => {
-            cmd_localnet_start(&lssa, &state_path, &log_path, timeout_sec)
-        }
+        LocalnetAction::Start { timeout_sec } => cmd_localnet_start(
+            &lssa,
+            &state_path,
+            &log_path,
+            timeout_sec,
+            localnet_port,
+            risc0_dev_mode,
+            &localnet_addr,
+        ),
         LocalnetAction::Stop => cmd_localnet_stop(&state_path),
-        LocalnetAction::Status { json } => cmd_localnet_status(&state_path, &log_path, json),
+        LocalnetAction::Status { json } => {
+            cmd_localnet_status(&state_path, &log_path, json, &localnet_addr, localnet_port)
+        }
         LocalnetAction::Logs { tail } => cmd_localnet_logs(&log_path, tail),
     }
 }
 
 fn cmd_localnet_stop_outside_project() -> DynResult<()> {
-    if !port_open(LOCALNET_ADDR) {
-        println!("localnet not running (no listener on 127.0.0.1:3040)");
+    let default_addr = "127.0.0.1:3040";
+    let default_port: u16 = 3040;
+    if !port_open(default_addr) {
+        println!("localnet not running (no listener on {default_addr})");
         return Ok(());
     }
 
-    let listener_pid = listener_pid(3040);
+    let listener_pid = listener_pid(default_port);
     let pid_text = listener_pid
         .map(|pid| pid.to_string())
         .unwrap_or_else(|| "unknown".to_string());
@@ -101,6 +119,9 @@ fn cmd_localnet_start(
     state_path: &Path,
     log_path: &Path,
     timeout_sec: u64,
+    localnet_port: u16,
+    risc0_dev_mode: bool,
+    localnet_addr: &str,
 ) -> DynResult<()> {
     ensure_dir_exists(lssa, "lssa")?;
     let sequencer_bin = lssa.join("target/release/sequencer_runner");
@@ -114,7 +135,7 @@ fn cmd_localnet_start(
     let mut state = read_localnet_state(state_path).unwrap_or_default();
     if let Some(pid) = state.sequencer_pid {
         if pid_running(pid) {
-            wait_for_readiness(pid, timeout_sec, log_path)?;
+            wait_for_readiness(pid, timeout_sec, log_path, localnet_addr)?;
             println!("localnet ready (sequencer pid={pid})");
             return Ok(());
         }
@@ -125,8 +146,8 @@ fn cmd_localnet_start(
         state = LocalnetState::default();
     }
 
-    let existing_listener_pid = listener_pid(3040);
-    if port_open(LOCALNET_ADDR) {
+    let existing_listener_pid = listener_pid(localnet_port);
+    if port_open(&localnet_addr) {
         let mut message = match existing_listener_pid {
             Some(pid) => format!("cannot start localnet: port 3040 is already in use (pid={pid})"),
             None => "cannot start localnet: port 3040 is already in use (pid=unknown)".to_string(),
@@ -146,14 +167,14 @@ fn cmd_localnet_start(
             .current_dir(lssa)
             .arg("sequencer_runner/configs/debug")
             .env("RUST_LOG", "info")
-            .env("RISC0_DEV_MODE", "1"),
+            .env("RISC0_DEV_MODE", if risc0_dev_mode { "1" } else { "0" }),
         log_path,
     )?;
 
     state.sequencer_pid = Some(sequencer_pid);
     write_localnet_state(state_path, &state)?;
 
-    if let Err(err) = wait_for_readiness(sequencer_pid, timeout_sec, log_path) {
+    if let Err(err) = wait_for_readiness(sequencer_pid, timeout_sec, log_path, localnet_addr) {
         if pid_alive(sequencer_pid) {
             let _ = Command::new("kill").arg(sequencer_pid.to_string()).status();
         }
@@ -167,12 +188,17 @@ fn cmd_localnet_start(
     Ok(())
 }
 
-fn wait_for_readiness(pid: u32, timeout_sec: u64, log_path: &Path) -> DynResult<()> {
+fn wait_for_readiness(
+    pid: u32,
+    timeout_sec: u64,
+    log_path: &Path,
+    localnet_addr: &str,
+) -> DynResult<()> {
     let deadline = Instant::now() + Duration::from_secs(timeout_sec.max(1));
 
     loop {
         let running = pid_running(pid);
-        let ready = running && port_open(LOCALNET_ADDR);
+        let ready = running && port_open(&localnet_addr);
         if ready {
             return Ok(());
         }
@@ -199,7 +225,12 @@ fn wait_for_readiness(pid: u32, timeout_sec: u64, log_path: &Path) -> DynResult<
 }
 
 fn cmd_localnet_stop(state_path: &Path) -> DynResult<()> {
-    let report = build_status_report(state_path, Path::new(".scaffold/logs/sequencer.log"));
+    let report = build_status_report(
+        state_path,
+        Path::new(".scaffold/logs/sequencer.log"),
+        "127.0.0.1:3040",
+        3040,
+    );
     if let Some(pid) = report.tracked_pid {
         if report.tracked_running {
             println!("$ kill {pid} # sequencer");
@@ -230,8 +261,14 @@ fn cmd_localnet_stop(state_path: &Path) -> DynResult<()> {
     Ok(())
 }
 
-fn cmd_localnet_status(state_path: &Path, log_path: &Path, as_json: bool) -> DynResult<()> {
-    let report = build_status_report(state_path, log_path);
+fn cmd_localnet_status(
+    state_path: &Path,
+    log_path: &Path,
+    as_json: bool,
+    localnet_addr: &str,
+    localnet_port: u16,
+) -> DynResult<()> {
+    let report = build_status_report(state_path, log_path, localnet_addr, localnet_port);
 
     if as_json {
         println!("{}", serde_json::to_string_pretty(&report)?);
@@ -302,13 +339,18 @@ fn cmd_localnet_logs(log_path: &Path, tail: usize) -> DynResult<()> {
     Ok(())
 }
 
-fn build_status_report(state_path: &Path, log_path: &Path) -> LocalnetStatusReport {
+fn build_status_report(
+    state_path: &Path,
+    log_path: &Path,
+    localnet_addr: &str,
+    localnet_port: u16,
+) -> LocalnetStatusReport {
     let state = read_localnet_state(state_path).unwrap_or_default();
     let tracked_pid = state.sequencer_pid;
     let tracked_running = tracked_pid.map(pid_running).unwrap_or(false);
-    let listener_present = port_open(LOCALNET_ADDR);
+    let listener_present = port_open(&localnet_addr);
     let listener_pid = if listener_present {
-        listener_pid(3040)
+        listener_pid(localnet_port)
     } else {
         None
     };

--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -149,8 +149,8 @@ fn cmd_localnet_start(
     let existing_listener_pid = listener_pid(localnet_port);
     if port_open(&localnet_addr) {
         let mut message = match existing_listener_pid {
-            Some(pid) => format!("cannot start localnet: port 3040 is already in use (pid={pid})"),
-            None => "cannot start localnet: port 3040 is already in use (pid=unknown)".to_string(),
+            Some(pid) => format!("cannot start localnet: port {localnet_port} is already in use (pid={pid})"),
+            None => format!("cannot start localnet: port {localnet_port} is already in use (pid=unknown)"),
         };
         message.push_str(
             "\nThis may be a sequencer started from another project and may not work with the current project.",

--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -73,7 +73,7 @@ fn cmd_localnet_in_project(project: &Project, action: LocalnetAction) -> DynResu
             risc0_dev_mode,
             &localnet_addr,
         ),
-        LocalnetAction::Stop => cmd_localnet_stop(&state_path),
+        LocalnetAction::Stop => cmd_localnet_stop(&state_path, localnet_port),
         LocalnetAction::Status { json } => {
             cmd_localnet_status(&state_path, &log_path, json, &localnet_addr, localnet_port)
         }
@@ -94,7 +94,7 @@ fn cmd_localnet_stop_outside_project() -> DynResult<()> {
         .map(|pid| pid.to_string())
         .unwrap_or_else(|| "unknown".to_string());
 
-    println!("listener detected on 127.0.0.1:3040 (pid={pid_text})");
+    println!("listener detected on {default_addr} (pid={pid_text})");
     println!(
         "This command is running outside a logos-scaffold project; it will not stop unmanaged processes automatically."
     );
@@ -108,7 +108,7 @@ fn cmd_localnet_stop_outside_project() -> DynResult<()> {
         }
         println!("Try: kill {pid}");
     } else {
-        println!("Try: lsof -nP -iTCP:3040 -sTCP:LISTEN");
+        println!("Try: lsof -nP -iTCP:{default_port} -sTCP:LISTEN");
     }
 
     Ok(())
@@ -224,12 +224,13 @@ fn wait_for_readiness(
     }
 }
 
-fn cmd_localnet_stop(state_path: &Path) -> DynResult<()> {
+fn cmd_localnet_stop(state_path: &Path, localnet_port: u16) -> DynResult<()> {
+    let localnet_addr = format!("127.0.0.1:{localnet_port}");
     let report = build_status_report(
         state_path,
         Path::new(".scaffold/logs/sequencer.log"),
-        "127.0.0.1:3040",
-        3040,
+        &localnet_addr,
+        localnet_port,
     );
     if let Some(pid) = report.tracked_pid {
         if report.tracked_running {
@@ -252,7 +253,7 @@ fn cmd_localnet_stop(state_path: &Path) -> DynResult<()> {
             .map(|pid| pid.to_string())
             .unwrap_or_else(|| "unknown".to_string());
         println!(
-            "foreign listener detected on 127.0.0.1:3040 (pid={pid_text}); not stopping unmanaged process"
+            "foreign listener detected on {localnet_addr} (pid={pid_text}); not stopping unmanaged process"
         );
         return Ok(());
     }
@@ -289,9 +290,9 @@ fn cmd_localnet_status(
             .listener_pid
             .map(|pid| pid.to_string())
             .unwrap_or_else(|| "unknown".to_string());
-        println!("listener 127.0.0.1:3040: reachable (pid={pid_text})");
+        println!("listener {localnet_addr}: reachable (pid={pid_text})");
     } else {
-        println!("listener 127.0.0.1:3040: not reachable");
+        println!("listener {localnet_addr}: not reachable");
     }
 
     println!("ownership: {}", ownership_label(report.ownership));
@@ -382,8 +383,7 @@ fn build_status_report(
             "Run `logos-scaffold localnet start` to restart localnet".to_string(),
         ],
         LocalnetOwnership::Foreign => vec![
-            "Stop the external listener on 127.0.0.1:3040 or choose a clean environment"
-                .to_string(),
+            format!("Stop the external listener on {localnet_addr} or choose a clean environment"),
             "Then run `logos-scaffold localnet start`".to_string(),
         ],
         LocalnetOwnership::Stopped => vec!["Run `logos-scaffold localnet start`".to_string()],

--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -147,7 +147,7 @@ fn cmd_localnet_start(
     }
 
     let existing_listener_pid = listener_pid(localnet_port);
-    if port_open(&localnet_addr) {
+    if port_open(localnet_addr) {
         let mut message = match existing_listener_pid {
             Some(pid) => format!("cannot start localnet: port {localnet_port} is already in use (pid={pid})"),
             None => format!("cannot start localnet: port {localnet_port} is already in use (pid=unknown)"),
@@ -198,7 +198,7 @@ fn wait_for_readiness(
 
     loop {
         let running = pid_running(pid);
-        let ready = running && port_open(&localnet_addr);
+        let ready = running && port_open(localnet_addr);
         if ready {
             return Ok(());
         }
@@ -349,7 +349,7 @@ fn build_status_report(
     let state = read_localnet_state(state_path).unwrap_or_default();
     let tracked_pid = state.sequencer_pid;
     let tracked_running = tracked_pid.map(pid_running).unwrap_or(false);
-    let listener_present = port_open(&localnet_addr);
+    let listener_present = port_open(localnet_addr);
     let listener_pid = if listener_present {
         listener_pid(localnet_port)
     } else {

--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -149,8 +149,12 @@ fn cmd_localnet_start(
     let existing_listener_pid = listener_pid(localnet_port);
     if port_open(localnet_addr) {
         let mut message = match existing_listener_pid {
-            Some(pid) => format!("cannot start localnet: port {localnet_port} is already in use (pid={pid})"),
-            None => format!("cannot start localnet: port {localnet_port} is already in use (pid=unknown)"),
+            Some(pid) => {
+                format!("cannot start localnet: port {localnet_port} is already in use (pid={pid})")
+            }
+            None => format!(
+                "cannot start localnet: port {localnet_port} is already in use (pid=unknown)"
+            ),
         };
         message.push_str(
             "\nThis may be a sequencer started from another project and may not work with the current project.",
@@ -166,6 +170,8 @@ fn cmd_localnet_start(
         Command::new(sequencer_bin)
             .current_dir(lssa)
             .arg("sequencer_runner/configs/debug")
+            .arg("--port")
+            .arg(localnet_port.to_string())
             .env("RUST_LOG", "info")
             .env("RISC0_DEV_MODE", if risc0_dev_mode { "1" } else { "0" }),
         log_path,

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -10,7 +10,7 @@ use crate::constants::{
     DEFAULT_LSSA_PIN, DEFAULT_WALLET_BINARY, FRAMEWORK_KIND_DEFAULT, FRAMEWORK_KIND_LEZ_FRAMEWORK,
     LSSA_URL, VERSION,
 };
-use crate::model::{Config, FrameworkConfig, FrameworkIdlConfig, RepoRef};
+use crate::model::{Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig, RepoRef};
 use crate::project::default_cache_root;
 use crate::repo::{sync_repo_to_pin_at_path_with_opts, RepoSyncOptions};
 use crate::state::write_text;
@@ -107,6 +107,7 @@ pub(crate) fn cmd_new(cmd: NewCommand) -> DynResult<()> {
                 path: DEFAULT_FRAMEWORK_IDL_PATH.to_string(),
             },
         },
+        localnet: LocalnetConfig::default(),
     };
 
     let template_root = lssa_repo_path.join("examples/program_deployment");

--- a/src/config.rs
+++ b/src/config.rs
@@ -157,7 +157,7 @@ pub(crate) fn parse_config(text: &str) -> DynResult<Config> {
 
 pub(crate) fn serialize_config(cfg: &Config) -> String {
     format!(
-        "[scaffold]\nversion = \"{}\"\ncache_root = \"{}\"\n\n[repos.lssa]\nurl = \"{}\"\nsource = \"{}\"\npath = \"{}\"\npin = \"{}\"\n\n[wallet]\nbinary = \"{}\"\nhome_dir = \"{}\"\n\n[framework]\nkind = \"{}\"\nversion = \"{}\"\n\n[framework.idl]\nspec = \"{}\"\npath = \"{}\"\n",
+        "[scaffold]\nversion = \"{}\"\ncache_root = \"{}\"\n\n[repos.lssa]\nurl = \"{}\"\nsource = \"{}\"\npath = \"{}\"\npin = \"{}\"\n\n[wallet]\nbinary = \"{}\"\nhome_dir = \"{}\"\n\n[framework]\nkind = \"{}\"\nversion = \"{}\"\n\n[framework.idl]\nspec = \"{}\"\npath = \"{}\"\n\n[localnet]\nport = {}\nrisc0_dev_mode = {}\n",
         escape_toml_string(&cfg.version),
         escape_toml_string(&cfg.cache_root),
         escape_toml_string(&cfg.lssa.url),
@@ -170,6 +170,8 @@ pub(crate) fn serialize_config(cfg: &Config) -> String {
         escape_toml_string(&cfg.framework.version),
         escape_toml_string(&cfg.framework.idl.spec),
         escape_toml_string(&cfg.framework.idl.path),
+        cfg.localnet.port,
+        cfg.localnet.risc0_dev_mode,
     )
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use crate::constants::{
     DEFAULT_FRAMEWORK_IDL_PATH, DEFAULT_FRAMEWORK_IDL_SPEC, DEFAULT_FRAMEWORK_VERSION,
     DEFAULT_WALLET_BINARY, FRAMEWORK_KIND_DEFAULT, LSSA_URL,
 };
-use crate::model::{Config, FrameworkConfig, FrameworkIdlConfig, RepoRef};
+use crate::model::{Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig, RepoRef};
 use crate::DynResult;
 
 pub(crate) fn parse_config(text: &str) -> DynResult<Config> {
@@ -20,6 +20,9 @@ pub(crate) fn parse_config(text: &str) -> DynResult<Config> {
 
     let mut wallet_binary = String::new();
     let mut wallet_home_dir = String::new();
+
+    let mut localnet_port: u16 = 3040;
+    let mut localnet_risc0_dev_mode: bool = true;
 
     let mut framework_kind = String::new();
     let mut framework_version = String::new();
@@ -81,6 +84,15 @@ pub(crate) fn parse_config(text: &str) -> DynResult<Config> {
                     wallet_home_dir = value;
                 }
             }
+            "localnet" => {
+                if key == "port" {
+                    if let Ok(p) = value.parse::<u16>() {
+                        localnet_port = p;
+                    }
+                } else if key == "risc0_dev_mode" {
+                    localnet_risc0_dev_mode = value != "false" && value != "0";
+                }
+            }
             _ => {}
         }
     }
@@ -128,6 +140,10 @@ pub(crate) fn parse_config(text: &str) -> DynResult<Config> {
         },
         wallet_binary,
         wallet_home_dir,
+        localnet: LocalnetConfig {
+            port: localnet_port,
+            risc0_dev_mode: localnet_risc0_dev_mode,
+        },
         framework: FrameworkConfig {
             kind: framework_kind,
             version: framework_version,

--- a/src/model.rs
+++ b/src/model.rs
@@ -11,6 +11,21 @@ pub(crate) struct RepoRef {
 }
 
 #[derive(Clone, Debug)]
+pub(crate) struct LocalnetConfig {
+    pub(crate) port: u16,
+    pub(crate) risc0_dev_mode: bool,
+}
+
+impl Default for LocalnetConfig {
+    fn default() -> Self {
+        Self {
+            port: 3040,
+            risc0_dev_mode: true,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
 pub(crate) struct Config {
     pub(crate) version: String,
     pub(crate) cache_root: String,
@@ -18,6 +33,7 @@ pub(crate) struct Config {
     pub(crate) wallet_binary: String,
     pub(crate) wallet_home_dir: String,
     pub(crate) framework: FrameworkConfig,
+    pub(crate) localnet: LocalnetConfig,
 }
 
 #[derive(Clone, Debug)]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -672,6 +672,72 @@ fn localnet_start_fails_when_process_exits_before_ready() {
 }
 
 #[test]
+fn localnet_start_passes_configured_port_to_sequencer() {
+    let temp = tempdir().expect("tempdir");
+    let lssa_path = temp.path().join("lssa");
+    let sequencer_bin = lssa_path.join("target/release/sequencer_runner");
+    let args_log = temp.path().join("sequencer-args.log");
+    let env_log = temp.path().join("sequencer-env.log");
+    let localnet_port = unused_local_port();
+
+    fs::create_dir_all(sequencer_bin.parent().expect("parent")).expect("create dirs");
+    fs::write(
+        &sequencer_bin,
+        format!(
+            "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$@\" > '{}'\nprintf '%s' \"${{RISC0_DEV_MODE:-}}\" > '{}'\nport=3040\nwhile [ \"$#\" -gt 0 ]; do\n  if [ \"$1\" = \"--port\" ]; then\n    shift\n    port=\"$1\"\n    break\n  fi\n  shift\ndone\nexec python3 -m http.server \"$port\" --bind 127.0.0.1\n",
+            args_log.display(),
+            env_log.display(),
+        ),
+    )
+    .expect("write fake sequencer");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&sequencer_bin)
+            .expect("metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&sequencer_bin, perms).expect("chmod");
+    }
+
+    write_scaffold_toml_with_localnet(
+        temp.path(),
+        &lssa_path,
+        "wallet-not-installed-for-tests",
+        Some(localnet_port),
+        Some(false),
+    );
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .arg("localnet")
+        .arg("start")
+        .arg("--timeout-sec")
+        .arg("5")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("localnet ready"));
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .arg("localnet")
+        .arg("stop")
+        .assert()
+        .success();
+
+    let args = fs::read_to_string(&args_log).expect("read args log");
+    assert!(
+        args.contains("sequencer_runner/configs/debug\n--port\n")
+            && args.contains(&format!("--port\n{localnet_port}\n")),
+        "expected configured port in sequencer args, got: {args}"
+    );
+
+    let env = fs::read_to_string(&env_log).expect("read env log");
+    assert_eq!(env, "0", "expected risc0 dev mode override to be passed");
+}
+
+#[test]
 fn localnet_stop_outside_project_succeeds() {
     let temp = tempdir().expect("tempdir");
 
@@ -1389,7 +1455,17 @@ fn archive_entry_content<'a>(entries: &'a [(String, String)], suffix: &str) -> &
 }
 
 fn write_scaffold_toml(project_root: &Path, lssa_path: &Path, wallet_binary: &str) {
-    let content = format!(
+    write_scaffold_toml_with_localnet(project_root, lssa_path, wallet_binary, None, None);
+}
+
+fn write_scaffold_toml_with_localnet(
+    project_root: &Path,
+    lssa_path: &Path,
+    wallet_binary: &str,
+    localnet_port: Option<u16>,
+    risc0_dev_mode: Option<bool>,
+) {
+    let mut content = format!(
         "[scaffold]\nversion = \"0.1.0\"\ncache_root = \"{}\"\n\n[repos.lssa]\nurl = \"https://github.com/logos-blockchain/lssa.git\"\nsource = \"https://github.com/logos-blockchain/lssa.git\"\npath = \"{}\"\npin = \"{}\"\n\n[wallet]\nbinary = \"{}\"\nhome_dir = \".scaffold/wallet\"\n",
         project_root.join("cache").display(),
         lssa_path.display(),
@@ -1397,7 +1473,22 @@ fn write_scaffold_toml(project_root: &Path, lssa_path: &Path, wallet_binary: &st
         wallet_binary
     );
 
+    if let Some(port) = localnet_port {
+        let risc0_dev_mode = risc0_dev_mode.unwrap_or(true);
+        content.push_str(&format!(
+            "\n[localnet]\nport = {port}\nrisc0_dev_mode = {risc0_dev_mode}\n"
+        ));
+    }
+
     fs::write(project_root.join("scaffold.toml"), content).expect("write scaffold.toml");
+}
+
+fn unused_local_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("bind unused local port")
+        .local_addr()
+        .expect("local addr")
+        .port()
 }
 
 fn setup_wallet_project(project_root: &Path, wallet_binary: &str, sequencer_addr: Option<&str>) {


### PR DESCRIPTION
## Summary

Closes #22.

Adds a `[localnet]` section to `scaffold.toml` for configuring the sequencer port and `RISC0_DEV_MODE`. Both default to current values for full backward compatibility.

## Changes

- `model.rs`: new `LocalnetConfig` struct with `Default` impl (port=3040, risc0_dev_mode=true)
- `config.rs`: parse `[localnet]` section
- `localnet.rs`: read port/risc0_dev_mode from project config
- `new.rs`: populate `localnet` field with `LocalnetConfig::default()`

## Usage

```toml
[localnet]
port = 3041          # run on a different port
risc0_dev_mode = false  # use real proofs
```

## Testing

```
cargo fmt   ✓
cargo check ✓
cargo test  ✓ 88 passed, 0 failed
```

Closes #22