### PR TITLE
feat: add init command for existing projects

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,6 +9,7 @@ use crate::commands::client::cmd_client;
 use crate::commands::deploy::cmd_deploy;
 use crate::commands::doctor::cmd_doctor;
 use crate::commands::idl::cmd_idl;
+use crate::commands::init::{cmd_init, InitCommand};
 use crate::commands::localnet::{cmd_localnet, LocalnetAction};
 use crate::commands::new::{cmd_new, NewCommand};
 use crate::commands::report::cmd_report;
@@ -46,6 +47,8 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Commands {
+    #[command(about = "Initialise logos-scaffold in an existing project")]
+    Init(InitArgs),
     #[command(about = "Create a new logos-scaffold project")]
     #[command(before_long_help = CREATE_ABOUT.as_str())]
     Create(NewArgs),
@@ -75,6 +78,16 @@ struct NewArgs {
     cache_root: Option<PathBuf>,
     #[arg(long, default_value = "default", help = TEMPLATE_HELP.as_str())]
     template: String,
+}
+
+#[derive(Debug, clap::Args)]
+struct InitArgs {
+    #[arg(long)]
+    vendor_deps: bool,
+    #[arg(long)]
+    lssa_path: Option<PathBuf>,
+    #[arg(long)]
+    cache_root: Option<PathBuf>,
 }
 
 #[derive(Debug, clap::Args)]
@@ -228,6 +241,11 @@ pub(crate) fn run(args: Vec<String>) -> DynResult<()> {
     };
 
     match cli.command {
+        Some(Commands::Init(args)) => cmd_init(InitCommand {
+            lssa_path: args.lssa_path,
+            cache_root: args.cache_root,
+            vendor_deps: args.vendor_deps,
+        }),
         Some(Commands::Create(args)) | Some(Commands::New(args)) => cmd_new(NewCommand {
             name: args.name,
             vendor_deps: args.vendor_deps,

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,0 +1,114 @@
+use std::env;
+use std::fs;
+
+use anyhow::{bail, Context};
+
+use crate::config::serialize_config;
+use crate::constants::{
+    DEFAULT_FRAMEWORK_IDL_PATH, DEFAULT_FRAMEWORK_IDL_SPEC, DEFAULT_FRAMEWORK_VERSION,
+    DEFAULT_LSSA_PIN, DEFAULT_WALLET_BINARY, FRAMEWORK_KIND_DEFAULT, LSSA_URL, VERSION,
+};
+use crate::model::{Config, FrameworkConfig, FrameworkIdlConfig, RepoRef};
+use crate::repo::{sync_repo_to_pin_at_path_with_opts, RepoSyncOptions};
+use crate::state::write_text;
+use crate::DynResult;
+
+use crate::project::default_cache_root;
+
+pub(crate) struct InitCommand {
+    pub(crate) lssa_path: Option<std::path::PathBuf>,
+    pub(crate) cache_root: Option<std::path::PathBuf>,
+    pub(crate) vendor_deps: bool,
+}
+
+pub(crate) fn cmd_init(cmd: InitCommand) -> DynResult<()> {
+    let project_root = env::current_dir()?;
+
+    // scaffold.toml zaten varsa dur
+    let scaffold_toml = project_root.join("scaffold.toml");
+    if scaffold_toml.exists() {
+        bail!(
+            "scaffold.toml already exists at {}. \
+             This project is already initialised.\n\
+             Next step: run `logos-scaffold setup` to sync dependencies.",
+            scaffold_toml.display()
+        );
+    }
+
+    // .scaffold dizin yapısını oluştur
+    fs::create_dir_all(project_root.join(".scaffold/state"))
+        .context("failed to create .scaffold/state")?;
+    fs::create_dir_all(project_root.join(".scaffold/logs"))
+        .context("failed to create .scaffold/logs")?;
+
+    let cache_root = cmd.cache_root.unwrap_or(default_cache_root()?);
+    fs::create_dir_all(cache_root.join("repos"))?;
+    fs::create_dir_all(cache_root.join("state"))?;
+    fs::create_dir_all(cache_root.join("logs"))?;
+    fs::create_dir_all(cache_root.join("builds"))?;
+
+    let lssa_source = cmd
+        .lssa_path
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| LSSA_URL.to_string());
+
+    let lssa_repo_path = if cmd.vendor_deps {
+        let root = project_root.join(".scaffold/repos");
+        fs::create_dir_all(&root)?;
+        let lssa_vendor = root.join("lssa");
+        sync_repo_to_pin_at_path_with_opts(
+            &lssa_vendor,
+            &lssa_source,
+            DEFAULT_LSSA_PIN,
+            "lssa",
+            RepoSyncOptions::fail_on_source_mismatch(),
+        )?;
+        lssa_vendor
+    } else {
+        let lssa_cached = cache_root.join("repos/lssa");
+        sync_repo_to_pin_at_path_with_opts(
+            &lssa_cached,
+            &lssa_source,
+            DEFAULT_LSSA_PIN,
+            "lssa",
+            RepoSyncOptions::auto_reclone_cache_repo(),
+        )?;
+        lssa_cached
+    };
+
+    let cfg = Config {
+        version: VERSION.to_string(),
+        cache_root: cache_root.display().to_string(),
+        lssa: RepoRef {
+            url: LSSA_URL.to_string(),
+            source: lssa_source,
+            path: lssa_repo_path.display().to_string(),
+            pin: DEFAULT_LSSA_PIN.to_string(),
+        },
+        wallet_binary: DEFAULT_WALLET_BINARY.to_string(),
+        wallet_home_dir: ".scaffold/wallet".to_string(),
+        framework: FrameworkConfig {
+            kind: FRAMEWORK_KIND_DEFAULT.to_string(),
+            version: DEFAULT_FRAMEWORK_VERSION.to_string(),
+            idl: FrameworkIdlConfig {
+                spec: DEFAULT_FRAMEWORK_IDL_SPEC.to_string(),
+                path: DEFAULT_FRAMEWORK_IDL_PATH.to_string(),
+            },
+        },
+    };
+
+    write_text(&scaffold_toml, &serialize_config(&cfg)).context("failed to write scaffold.toml")?;
+
+    println!("Initialised logos-scaffold in {}", project_root.display());
+    println!("  scaffold.toml written");
+    println!("  .scaffold/state/ created");
+    println!("  .scaffold/logs/  created");
+    println!("  Cache root: {}", cfg.cache_root);
+    println!("  Pinned lssa: {}", cfg.lssa.pin);
+    println!();
+    println!("Next steps:");
+    println!("  logos-scaffold setup");
+    println!("  logos-scaffold localnet start");
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod client;
 pub(crate) mod deploy;
 pub(crate) mod doctor;
 pub(crate) mod idl;
+pub(crate) mod init;
 pub(crate) mod localnet;
 pub(crate) mod new;
 pub(crate) mod report;


### PR DESCRIPTION
## Summary

Closes #24.

`create`/`new` only scaffold fresh projects from templates. Existing projects had to manually write `scaffold.toml` and create directory structures.

## Changes

**`src/commands/init.rs`** (new file)
- `cmd_init`: initialises scaffold in the current directory
- Checks for existing `scaffold.toml` and bails if found
- Creates `.scaffold/state/` and `.scaffold/logs/`
- Syncs lssa dependency (same as `create`)
- Skips template copying — project keeps its own code

**`src/commands/mod.rs`**
- Registers `init` module

**`src/cli.rs`**
- New `Init` command with `--vendor-deps`, `--lssa-path`, `--cache-root` flags

## Usage

```bash
cd my-existing-lssa-project
logos-scaffold init
logos-scaffold setup
logos-scaffold localnet start
```

## Testing

```
cargo fmt   ✓
cargo check ✓
cargo test  ✓ 88 passed, 0 failed
```

Closes #24