### PR TITLE
feat(localnet): configure sequencer binary and config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,29 @@ logos-scaffold localnet status
 logos-scaffold doctor
 ```
 
+### Pointing localnet at a custom sequencer
+
+`[localnet].sequencer_binary` and `[localnet].sequencer_config_path` let you
+build and run a sequencer that isn't upstream LEZ's `sequencer_service`
+without forking scaffold. `sequencer_binary` is treated as the cargo
+package name (`cargo build -p <sequencer_binary>`); the produced binary
+must land at `<lez>/target/release/<sequencer_binary>`.
+`sequencer_config_path` is resolved relative to the LEZ checkout when not
+absolute.
+
+```toml
+[localnet]
+port = 3040
+risc0_dev_mode = true
+sequencer_binary = "my_custom_seq"
+sequencer_config_path = "sequencer/service/configs/dev/sequencer_config.json"
+```
+
+Defaults match upstream LEZ at the pinned version; override at your own
+risk. Overriding opts out of the scaffold ↔ LEZ pin alignment guarantee —
+make sure your fork stays compatible with the `[repos.lez].pin` your
+project uses, or `setup` and `doctor` will surface the mismatch.
+
 ## LEZ Framework
 
 To use the [LEZ Framework](https://github.com/jimmy-claw/lez-framework) for an

--- a/README.md
+++ b/README.md
@@ -229,8 +229,9 @@ build and run a sequencer that isn't upstream LEZ's `sequencer_service`
 without forking scaffold. `sequencer_binary` is treated as the cargo
 package name (`cargo build -p <sequencer_binary>`); the produced binary
 must land at `<lez>/target/release/<sequencer_binary>`.
-`sequencer_config_path` is resolved relative to the LEZ checkout when not
-absolute.
+`sequencer_config_path` must be a relative path inside the LEZ checkout.
+`localnet start` patches this file in place to apply `[localnet].port`, so
+absolute paths and `..` parent components are rejected.
 
 ```toml
 [localnet]

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -5,9 +5,7 @@ use anyhow::bail;
 
 use super::wallet_support::wallet_password;
 use crate::commands::wallet_support::WALLET_CONFIG_PRIMARY;
-use crate::constants::{
-    DEFAULT_LEZ, DEFAULT_SPEL, SEQUENCER_BIN_REL_PATH, SPEL_BIN_REL_PATH, WALLET_BIN_REL_PATH,
-};
+use crate::constants::{DEFAULT_LEZ, DEFAULT_SPEL, SPEL_BIN_REL_PATH, WALLET_BIN_REL_PATH};
 use crate::doctor_checks::{
     check_binary, check_container_runtime, check_path, check_port_warn, check_repo,
     check_standalone_support, one_line, print_rows,
@@ -157,10 +155,18 @@ pub(crate) fn build_doctor_report() -> DynResult<DoctorReport> {
         remediation: None,
     });
 
+    let sequencer_bin = project.config.localnet.sequencer_bin_path(&lez);
     rows.push(check_path(
         "sequencer binary",
-        &lez.join(SEQUENCER_BIN_REL_PATH),
+        &sequencer_bin,
         "Run `logos-scaffold setup`",
+    ));
+
+    let sequencer_config = project.config.localnet.sequencer_config_resolved_path(&lez);
+    rows.push(check_path(
+        "sequencer config",
+        &sequencer_config,
+        "Fix [localnet].sequencer_config_path in scaffold.toml or run `logos-scaffold setup`",
     ));
 
     let wallet_binary_path = lez.join(WALLET_BIN_REL_PATH);

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -7,7 +7,7 @@ use super::wallet_support::wallet_password;
 use crate::commands::wallet_support::WALLET_CONFIG_PRIMARY;
 use crate::constants::{DEFAULT_LEZ, DEFAULT_SPEL, SPEL_BIN_REL_PATH, WALLET_BIN_REL_PATH};
 use crate::doctor_checks::{
-    check_binary, check_container_runtime, check_path, check_port_warn, check_repo,
+    check_binary, check_container_runtime, check_file, check_path, check_port_warn, check_repo,
     check_standalone_support, one_line, print_rows,
 };
 use crate::model::{CheckRow, CheckStatus, DoctorReport, DoctorSummary};
@@ -156,14 +156,14 @@ pub(crate) fn build_doctor_report() -> DynResult<DoctorReport> {
     });
 
     let sequencer_bin = project.config.localnet.sequencer_bin_path(&lez);
-    rows.push(check_path(
+    rows.push(check_file(
         "sequencer binary",
         &sequencer_bin,
         "Run `logos-scaffold setup`",
     ));
 
     let sequencer_config = project.config.localnet.sequencer_config_resolved_path(&lez);
-    rows.push(check_path(
+    rows.push(check_file(
         "sequencer config",
         &sequencer_config,
         "Fix [localnet].sequencer_config_path in scaffold.toml or run `logos-scaffold setup`",

--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -8,9 +8,10 @@ use std::time::{Duration, Instant};
 use anyhow::{bail, Context};
 use serde_json::Value;
 
-use crate::constants::{SEQUENCER_BIN_REL_PATH, SEQUENCER_CONFIG_REL_PATH};
 use crate::error::{LocalnetError, ResetError};
-use crate::model::{LocalnetOwnership, LocalnetState, LocalnetStatusReport, Project};
+use crate::model::{
+    LocalnetConfig, LocalnetOwnership, LocalnetState, LocalnetStatusReport, Project,
+};
 use crate::process::{listener_pid, pid_alive, pid_command, pid_running, port_open, spawn_to_log};
 use crate::project::{ensure_dir_exists, find_project_root, load_project, resolve_repo_path};
 use crate::state::{read_localnet_state, write_localnet_state};
@@ -68,8 +69,8 @@ pub(crate) fn build_localnet_status_for_project(project: &Project) -> LocalnetSt
 }
 
 fn cmd_localnet_in_project(project: &Project, action: LocalnetAction) -> DynResult<()> {
-    let localnet_port = project.config.localnet.port;
-    let risc0_dev_mode = project.config.localnet.risc0_dev_mode;
+    let localnet_cfg = &project.config.localnet;
+    let localnet_port = localnet_cfg.port;
     let localnet_addr = format!("127.0.0.1:{localnet_port}");
     let lez = resolve_repo_path(project, &project.config.lez, "lez")?;
     let state_path = project.root.join(".scaffold/state/localnet.state");
@@ -83,8 +84,7 @@ fn cmd_localnet_in_project(project: &Project, action: LocalnetAction) -> DynResu
             &state_path,
             &log_path,
             timeout_sec,
-            localnet_port,
-            risc0_dev_mode,
+            localnet_cfg,
             &localnet_addr,
         ),
         LocalnetAction::Stop => cmd_localnet_stop(&state_path, localnet_port),
@@ -145,17 +145,30 @@ fn cmd_localnet_start(
     state_path: &Path,
     log_path: &Path,
     timeout_sec: u64,
-    localnet_port: u16,
-    risc0_dev_mode: bool,
+    localnet_cfg: &LocalnetConfig,
     localnet_addr: &str,
 ) -> DynResult<()> {
     ensure_dir_exists(lez, "lez")?;
-    let sequencer_bin = lez.join(SEQUENCER_BIN_REL_PATH);
+    let localnet_port = localnet_cfg.port;
+    let risc0_dev_mode = localnet_cfg.risc0_dev_mode;
+    let sequencer_bin = localnet_cfg.sequencer_bin_path(lez);
     if !sequencer_bin.exists() {
         return Err(LocalnetError::MissingSequencerBinary {
             path: sequencer_bin.display().to_string(),
         }
         .into());
+    }
+    // Validate the configured config path *before* we call into
+    // `patch_sequencer_port` so a misconfigured value surfaces with a
+    // targeted message rather than a generic "Is a directory" /
+    // serde_json parse error from inside the JSON-mutation helper.
+    let sequencer_config = localnet_cfg.sequencer_config_resolved_path(lez);
+    if !sequencer_config.is_file() {
+        bail!(
+            "sequencer config not found or not a regular file at {}; \
+             fix [localnet].sequencer_config_path in scaffold.toml or run `logos-scaffold setup`",
+            sequencer_config.display()
+        );
     }
 
     let mut state = read_localnet_state(state_path).unwrap_or_default();
@@ -192,16 +205,18 @@ fn cmd_localnet_start(
         bail!("{message}");
     }
 
-    patch_sequencer_port(lez, localnet_port)?;
+    patch_sequencer_port(&sequencer_config, localnet_port)?;
 
-    // Use a path relative to lez (the child's cwd), not relative to the
-    // parent's cwd.  `current_dir(lez)` applies before exec, so a parent-
-    // relative path like `.scaffold/cache/repos/lez/target/release/…`
-    // would be resolved inside lez and fail with ENOENT.
+    // Spawn from the absolute binary path; `current_dir(lez)` is preserved
+    // so the sequencer's own relative paths (rocksdb, logs) still resolve
+    // against the LEZ checkout. The config path is passed as the single
+    // positional arg — the pinned sequencer reads its port from this file
+    // (already patched above), so we deliberately do NOT pass a `--port`
+    // CLI flag (the pinned binary refuses unknown flags).
     let sequencer_pid = spawn_to_log(
-        Command::new(format!("./{SEQUENCER_BIN_REL_PATH}"))
+        Command::new(&sequencer_bin)
             .current_dir(lez)
-            .arg(SEQUENCER_CONFIG_REL_PATH)
+            .arg(&sequencer_config)
             .env("RUST_LOG", "info")
             .env("RISC0_DEV_MODE", if risc0_dev_mode { "1" } else { "0" }),
         log_path,
@@ -437,27 +452,29 @@ fn build_status_report(
     }
 }
 
-/// Update the port in `sequencer_config.json` so the sequencer listens on the
-/// configured port.  The pinned LEZ version does not accept `--port` as a CLI
-/// flag — it reads the port from this file.
-fn patch_sequencer_port(lez: &Path, port: u16) -> DynResult<()> {
-    let config_path = lez.join(SEQUENCER_CONFIG_REL_PATH);
-    let text = fs::read_to_string(&config_path)
+/// Update the port in the sequencer's JSON config so the sequencer listens
+/// on the configured port. The pinned LEZ version does not accept `--port`
+/// as a CLI flag — it reads the port from this file.
+///
+/// `config_path` is the already-resolved absolute path; the caller has
+/// verified it points at a regular file.
+fn patch_sequencer_port(config_path: &Path, port: u16) -> DynResult<()> {
+    let text = fs::read_to_string(config_path)
         .with_context(|| format!("failed to read {}", config_path.display()))?;
-    let mut doc: Value =
-        serde_json::from_str(&text).context("failed to parse sequencer_config.json")?;
+    let mut doc: Value = serde_json::from_str(&text)
+        .with_context(|| format!("failed to parse {} as JSON", config_path.display()))?;
 
     if let Some(obj) = doc.as_object_mut() {
         obj.insert("port".to_string(), Value::Number(port.into()));
     } else {
         bail!(
-            "sequencer_config.json is not a JSON object: {}",
+            "sequencer config is not a JSON object: {}",
             config_path.display()
         );
     }
 
     let updated = serde_json::to_string_pretty(&doc).context("failed to serialize config")?;
-    fs::write(&config_path, format!("{updated}\n"))
+    fs::write(config_path, format!("{updated}\n"))
         .with_context(|| format!("failed to write {}", config_path.display()))?;
     Ok(())
 }
@@ -487,11 +504,12 @@ pub(crate) fn cmd_localnet_reset(
     reset_wallet: bool,
     verify_timeout_sec: u64,
 ) -> DynResult<()> {
-    let localnet_port = project.config.localnet.port;
+    let localnet_cfg = &project.config.localnet;
+    let localnet_port = localnet_cfg.port;
 
     // Prerequisite: the sequencer binary must already be built. If not, setup
     // would fail later and we'd have already deleted data with no way to start.
-    let sequencer_bin = lez.join(SEQUENCER_BIN_REL_PATH);
+    let sequencer_bin = localnet_cfg.sequencer_bin_path(lez);
     if !sequencer_bin.exists() {
         return Err(LocalnetError::MissingSequencerBinary {
             path: sequencer_bin.display().to_string(),
@@ -516,15 +534,7 @@ pub(crate) fn cmd_localnet_reset(
     reset_cleanup(project, lez, state_path, reset_wallet)?;
 
     println!("starting sequencer…");
-    cmd_localnet_start(
-        lez,
-        state_path,
-        log_path,
-        20,
-        localnet_port,
-        project.config.localnet.risc0_dev_mode,
-        localnet_addr,
-    )?;
+    cmd_localnet_start(lez, state_path, log_path, 20, localnet_cfg, localnet_addr)?;
 
     println!("waiting for block production…");
     verify_block_production(localnet_addr, verify_timeout_sec)
@@ -667,8 +677,8 @@ mod tests {
                 },
             },
             localnet: LocalnetConfig {
-                port: 3040,
                 risc0_dev_mode: false,
+                ..LocalnetConfig::default()
             },
             modules: std::collections::BTreeMap::new(),
             basecamp: None,

--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -162,14 +162,7 @@ fn cmd_localnet_start(
     // `patch_sequencer_port` so a misconfigured value surfaces with a
     // targeted message rather than a generic "Is a directory" /
     // serde_json parse error from inside the JSON-mutation helper.
-    let sequencer_config = localnet_cfg.sequencer_config_resolved_path(lez);
-    if !sequencer_config.is_file() {
-        bail!(
-            "sequencer config not found or not a regular file at {}; \
-             fix [localnet].sequencer_config_path in scaffold.toml or run `logos-scaffold setup`",
-            sequencer_config.display()
-        );
-    }
+    let sequencer_config = resolve_sequencer_config_file(lez, localnet_cfg)?;
 
     let mut state = read_localnet_state(state_path).unwrap_or_default();
     if let Some(pid) = state.sequencer_pid {
@@ -516,6 +509,7 @@ pub(crate) fn cmd_localnet_reset(
         }
         .into());
     }
+    let _sequencer_config = resolve_sequencer_config_file(lez, localnet_cfg)?;
 
     println!("stopping sequencer…");
     cmd_localnet_stop(state_path, localnet_port)?;
@@ -538,6 +532,35 @@ pub(crate) fn cmd_localnet_reset(
 
     println!("waiting for block production…");
     verify_block_production(localnet_addr, verify_timeout_sec)
+}
+
+fn resolve_sequencer_config_file(lez: &Path, localnet_cfg: &LocalnetConfig) -> DynResult<PathBuf> {
+    let sequencer_config = localnet_cfg.sequencer_config_resolved_path(lez);
+    if !sequencer_config.is_file() {
+        bail!(
+            "sequencer config not found or not a regular file at {}; \
+             fix [localnet].sequencer_config_path in scaffold.toml or run `logos-scaffold setup`",
+            sequencer_config.display()
+        );
+    }
+
+    let lez = fs::canonicalize(lez)
+        .with_context(|| format!("failed to resolve LEZ checkout at {}", lez.display()))?;
+    let sequencer_config = fs::canonicalize(&sequencer_config).with_context(|| {
+        format!(
+            "failed to resolve sequencer config at {}",
+            sequencer_config.display()
+        )
+    })?;
+    if !sequencer_config.starts_with(&lez) {
+        bail!(
+            "sequencer config must resolve inside the LEZ checkout {}; got {}",
+            lez.display(),
+            sequencer_config.display()
+        );
+    }
+
+    Ok(sequencer_config)
 }
 
 /// Deletes on-disk state so the next start begins with a fresh chain.

--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -152,7 +152,7 @@ fn cmd_localnet_start(
     let localnet_port = localnet_cfg.port;
     let risc0_dev_mode = localnet_cfg.risc0_dev_mode;
     let sequencer_bin = localnet_cfg.sequencer_bin_path(lez);
-    if !sequencer_bin.exists() {
+    if !sequencer_bin.is_file() {
         return Err(LocalnetError::MissingSequencerBinary {
             path: sequencer_bin.display().to_string(),
         }
@@ -510,7 +510,7 @@ pub(crate) fn cmd_localnet_reset(
     // Prerequisite: the sequencer binary must already be built. If not, setup
     // would fail later and we'd have already deleted data with no way to start.
     let sequencer_bin = localnet_cfg.sequencer_bin_path(lez);
-    if !sequencer_bin.exists() {
+    if !sequencer_bin.is_file() {
         return Err(LocalnetError::MissingSequencerBinary {
             path: sequencer_bin.display().to_string(),
         }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -332,6 +332,7 @@ mod tests {
                 localnet: LocalnetConfig {
                     port: 3040,
                     risc0_dev_mode: true,
+                    ..LocalnetConfig::default()
                 },
                 modules: std::collections::BTreeMap::new(),
                 run: RunConfig::default(),

--- a/src/commands/run_state.rs
+++ b/src/commands/run_state.rs
@@ -386,6 +386,7 @@ mod tests {
                 localnet: LocalnetConfig {
                     port: 3040,
                     risc0_dev_mode: true,
+                    ..LocalnetConfig::default()
                 },
                 modules: BTreeMap::new(),
                 run: RunConfig::default(),

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -21,6 +21,11 @@ pub(crate) fn cmd_setup() -> DynResult<()> {
     sync_pinned_repo(&project.config.lez, &lez, "lez")?;
     ensure_dir_exists(&lez, "lez")?;
 
+    // The binary name in [localnet].sequencer_binary doubles as the cargo
+    // package name (`-p`) and the produced binary's filename under
+    // `target/release/` — see `model::LocalnetConfig::sequencer_binary`.
+    let sequencer_binary = &project.config.localnet.sequencer_binary;
+    let build_label = format!("build {sequencer_binary} (standalone)");
     run_checked(
         Command::new("cargo")
             .current_dir(&lez)
@@ -29,8 +34,8 @@ pub(crate) fn cmd_setup() -> DynResult<()> {
             .arg("--features")
             .arg("standalone")
             .arg("-p")
-            .arg("sequencer_service"),
-        "build sequencer_service (standalone)",
+            .arg(sequencer_binary),
+        &build_label,
     )?;
 
     run_checked(

--- a/src/config.rs
+++ b/src/config.rs
@@ -299,7 +299,57 @@ fn parse_localnet(doc: &DocumentMut) -> DynResult<LocalnetConfig> {
     if let Some(v) = table.get("risc0_dev_mode").and_then(Item::as_value) {
         cfg.risc0_dev_mode = v.as_bool().unwrap_or(true);
     }
+    if let Some(s) = read_string(table, "sequencer_binary") {
+        validate_sequencer_binary_name(&s)?;
+        cfg.sequencer_binary = s;
+    }
+    if let Some(s) = read_string(table, "sequencer_config_path") {
+        validate_sequencer_config_path(&s)?;
+        cfg.sequencer_config_path = s;
+    }
     Ok(cfg)
+}
+
+/// `[localnet].sequencer_binary` is consumed both as a `cargo build -p`
+/// argument and as a filename joined under `<lez>/target/release/`.
+/// Reject anything that is not a plain cargo package / binary name so
+/// neither use can be subverted (option injection, path traversal, or
+/// silent `Path::join` short-circuit on absolute values).
+fn validate_sequencer_binary_name(name: &str) -> DynResult<()> {
+    let path = std::path::Path::new(name);
+    let invalid = name.is_empty()
+        || name.starts_with('-')
+        || name == "."
+        || name == ".."
+        || name.contains('/')
+        || name.contains('\\')
+        || path.is_absolute();
+    if invalid {
+        bail!(
+            "invalid scaffold.toml: [localnet].sequencer_binary must be a cargo package name \
+             (no path separators, leading `-`, `.`, `..`, or absolute paths); got {name:?}"
+        );
+    }
+    check_toml_value("localnet.sequencer_binary", name)
+}
+
+/// `[localnet].sequencer_config_path` is mutated in place by
+/// `patch_sequencer_port`, so it has to be a real filesystem path the
+/// operator owns. We deliberately do *not* reject path separators here —
+/// the file naturally lives a few directories deep inside LEZ — but we
+/// still fail on values that look like CLI flags so they can't sneak into
+/// the spawned sequencer's argv.
+fn validate_sequencer_config_path(path: &str) -> DynResult<()> {
+    if path.is_empty() {
+        bail!("invalid scaffold.toml: [localnet].sequencer_config_path must not be empty");
+    }
+    if path.starts_with('-') {
+        bail!(
+            "invalid scaffold.toml: [localnet].sequencer_config_path must not start with `-` \
+             (would be parsed as a sequencer CLI flag); got {path:?}"
+        );
+    }
+    check_toml_value("localnet.sequencer_config_path", path)
 }
 
 fn read_string(table: &Table, key: &str) -> Option<String> {
@@ -374,10 +424,17 @@ pub(crate) fn serialize_config(cfg: &Config) -> DynResult<String> {
     idl_table["path"] = value(&cfg.framework.idl.path);
 
     // [localnet]
+    check_toml_value("localnet.sequencer_binary", &cfg.localnet.sequencer_binary)?;
+    check_toml_value(
+        "localnet.sequencer_config_path",
+        &cfg.localnet.sequencer_config_path,
+    )?;
     let localnet = doc.entry("localnet").or_insert(Item::Table(Table::new()));
     let localnet_table = localnet.as_table_mut().expect("localnet table");
     localnet_table["port"] = value(i64::from(cfg.localnet.port));
     localnet_table["risc0_dev_mode"] = value(cfg.localnet.risc0_dev_mode);
+    localnet_table["sequencer_binary"] = value(&cfg.localnet.sequencer_binary);
+    localnet_table["sequencer_config_path"] = value(&cfg.localnet.sequencer_config_path);
 
     // [basecamp]
     if let Some(bc) = &cfg.basecamp {
@@ -732,5 +789,99 @@ role = "project"
         );
         let cfg = parse_config(&toml).expect("parse");
         assert_eq!(cfg.lez.path, "/abs/lez");
+    }
+
+    #[test]
+    fn localnet_sequencer_keys_default_when_absent() {
+        let cfg = parse_config(&minimal_v0_2_0()).expect("parse");
+        let dflt = LocalnetConfig::default();
+        assert_eq!(cfg.localnet.sequencer_binary, dflt.sequencer_binary);
+        assert_eq!(
+            cfg.localnet.sequencer_config_path,
+            dflt.sequencer_config_path
+        );
+    }
+
+    #[test]
+    fn localnet_sequencer_keys_round_trip_explicit_values() {
+        let toml = minimal_v0_2_0().replace(
+            "[localnet]\nport = 3040\nrisc0_dev_mode = true\n",
+            "[localnet]\nport = 3040\nrisc0_dev_mode = true\n\
+             sequencer_binary = \"my_sequencer\"\n\
+             sequencer_config_path = \"sequencer/service/configs/dev/sequencer_config.json\"\n",
+        );
+        let cfg = parse_config(&toml).expect("parse");
+        assert_eq!(cfg.localnet.sequencer_binary, "my_sequencer");
+        assert_eq!(
+            cfg.localnet.sequencer_config_path,
+            "sequencer/service/configs/dev/sequencer_config.json"
+        );
+        let serialized = serialize_config(&cfg).expect("serialize");
+        let cfg2 = parse_config(&serialized).expect("re-parse");
+        assert_eq!(cfg2.localnet.sequencer_binary, "my_sequencer");
+        assert_eq!(
+            cfg2.localnet.sequencer_config_path,
+            "sequencer/service/configs/dev/sequencer_config.json"
+        );
+    }
+
+    #[test]
+    fn validate_sequencer_binary_name_rejects_bad_inputs() {
+        for bad in [
+            "",
+            "-help",
+            ".",
+            "..",
+            "../escape",
+            "sub/dir",
+            "sub\\dir",
+            "/abs/path",
+        ] {
+            assert!(
+                validate_sequencer_binary_name(bad).is_err(),
+                "expected rejection for {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_sequencer_binary_name_accepts_real_names() {
+        for ok in ["sequencer_service", "sequencer_runner", "my-sequencer"] {
+            validate_sequencer_binary_name(ok).expect("accept");
+        }
+    }
+
+    #[test]
+    fn validate_sequencer_config_path_rejects_bad_inputs() {
+        for bad in ["", "-flag-like-value"] {
+            assert!(
+                validate_sequencer_config_path(bad).is_err(),
+                "expected rejection for {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_rejects_invalid_sequencer_binary() {
+        let toml = minimal_v0_2_0().replace(
+            "[localnet]\nport = 3040\nrisc0_dev_mode = true\n",
+            "[localnet]\nport = 3040\nrisc0_dev_mode = true\nsequencer_binary = \"../escape\"\n",
+        );
+        let err = parse_config(&toml).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("sequencer_binary"), "{msg}");
+        assert!(msg.contains("../escape"), "{msg}");
+    }
+
+    #[test]
+    fn parse_rejects_invalid_sequencer_config_path() {
+        let toml = minimal_v0_2_0().replace(
+            "[localnet]\nport = 3040\nrisc0_dev_mode = true\n",
+            "[localnet]\nport = 3040\nrisc0_dev_mode = true\nsequencer_config_path = \"--port=80\"\n",
+        );
+        let err = parse_config(&toml).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("sequencer_config_path"), "{msg}");
+        assert!(msg.contains("--port=80"), "{msg}");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -323,11 +323,15 @@ fn validate_sequencer_binary_name(name: &str) -> DynResult<()> {
         || name == ".."
         || name.contains('/')
         || name.contains('\\')
-        || path.is_absolute();
+        || path.is_absolute()
+        || !name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_');
     if invalid {
         bail!(
             "invalid scaffold.toml: [localnet].sequencer_binary must be a cargo package name \
-             (no path separators, leading `-`, `.`, `..`, or absolute paths); got {name:?}"
+             (ASCII letters, digits, `_`, or `-`; no path separators, leading `-`, `.`, `..`, \
+             or absolute paths); got {name:?}"
         );
     }
     check_toml_value("localnet.sequencer_binary", name)
@@ -832,6 +836,10 @@ role = "project"
             "-help",
             ".",
             "..",
+            "foo bar",
+            "foo.bar",
+            "foo:bar",
+            "séquencer",
             "../escape",
             "sub/dir",
             "sub\\dir",

--- a/src/config.rs
+++ b/src/config.rs
@@ -383,11 +383,16 @@ fn parse_localnet(doc: &DocumentMut) -> DynResult<LocalnetConfig> {
     if let Some(v) = table.get("risc0_dev_mode").and_then(Item::as_value) {
         cfg.risc0_dev_mode = v.as_bool().unwrap_or(true);
     }
-    if let Some(s) = read_string(table, "sequencer_binary") {
+    if let Some(s) = read_present_string(table, "sequencer_binary", "[localnet].sequencer_binary")?
+    {
         validate_sequencer_binary_name(&s)?;
         cfg.sequencer_binary = s;
     }
-    if let Some(s) = read_string(table, "sequencer_config_path") {
+    if let Some(s) = read_present_string(
+        table,
+        "sequencer_config_path",
+        "[localnet].sequencer_config_path",
+    )? {
         validate_sequencer_config_path(&s)?;
         cfg.sequencer_config_path = s;
     }
@@ -422,22 +427,41 @@ fn validate_sequencer_binary_name(name: &str) -> DynResult<()> {
 }
 
 /// `[localnet].sequencer_config_path` is mutated in place by
-/// `patch_sequencer_port`, so it has to be a real filesystem path the
-/// operator owns. We deliberately do *not* reject path separators here —
-/// the file naturally lives a few directories deep inside LEZ — but we
-/// still fail on values that look like CLI flags so they can't sneak into
-/// the spawned sequencer's argv.
+/// `patch_sequencer_port`, so keep it constrained to a path inside the
+/// configured LEZ checkout. Forward-slash separators are allowed because
+/// the file naturally lives a few directories deep inside LEZ.
 fn validate_sequencer_config_path(path: &str) -> DynResult<()> {
-    if path.is_empty() {
-        bail!("invalid scaffold.toml: [localnet].sequencer_config_path must not be empty");
-    }
-    if path.starts_with('-') {
+    let parsed = std::path::Path::new(path);
+    let invalid = path.is_empty()
+        || path.starts_with('-')
+        || path.contains('\\')
+        || parsed.is_absolute()
+        || parsed.components().any(|component| {
+            matches!(
+                component,
+                std::path::Component::ParentDir
+                    | std::path::Component::Prefix(_)
+                    | std::path::Component::RootDir
+            )
+        });
+    if invalid {
         bail!(
-            "invalid scaffold.toml: [localnet].sequencer_config_path must not start with `-` \
-             (would be parsed as a sequencer CLI flag); got {path:?}"
+            "invalid scaffold.toml: [localnet].sequencer_config_path must be a LEZ-relative \
+             config file path (non-empty, no leading `-`, absolute paths, parent components, \
+             or backslash separators); got {path:?}"
         );
     }
     check_toml_value("localnet.sequencer_config_path", path)
+}
+
+fn read_present_string(table: &Table, key: &str, label: &str) -> DynResult<Option<String>> {
+    let Some(item) = table.get(key) else {
+        return Ok(None);
+    };
+    let Some(value) = item.as_str() else {
+        bail!("invalid scaffold.toml: {label} must be a string");
+    };
+    Ok(Some(value.to_string()))
 }
 
 fn read_string(table: &Table, key: &str) -> Option<String> {
@@ -1046,7 +1070,14 @@ role = "project"
 
     #[test]
     fn validate_sequencer_config_path_rejects_bad_inputs() {
-        for bad in ["", "-flag-like-value"] {
+        for bad in [
+            "",
+            "-flag-like-value",
+            "../escape.json",
+            "sequencer/../escape.json",
+            "/abs/path/config.json",
+            "sub\\dir\\config.json",
+        ] {
             assert!(
                 validate_sequencer_config_path(bad).is_err(),
                 "expected rejection for {bad:?}"
@@ -1056,25 +1087,33 @@ role = "project"
 
     #[test]
     fn parse_rejects_invalid_sequencer_binary() {
-        let toml = minimal_v0_2_0().replace(
-            "[localnet]\nport = 3040\nrisc0_dev_mode = true\n",
-            "[localnet]\nport = 3040\nrisc0_dev_mode = true\nsequencer_binary = \"../escape\"\n",
-        );
-        let err = parse_config(&toml).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("sequencer_binary"), "{msg}");
-        assert!(msg.contains("../escape"), "{msg}");
+        for bad in ["../escape", ""] {
+            let toml = minimal_v0_2_0().replace(
+                "[localnet]\nport = 3040\nrisc0_dev_mode = true\n",
+                &format!(
+                    "[localnet]\nport = 3040\nrisc0_dev_mode = true\nsequencer_binary = {bad:?}\n"
+                ),
+            );
+            let err = parse_config(&toml).unwrap_err();
+            let msg = err.to_string();
+            assert!(msg.contains("sequencer_binary"), "{msg}");
+            assert!(msg.contains(bad), "{msg}");
+        }
     }
 
     #[test]
     fn parse_rejects_invalid_sequencer_config_path() {
-        let toml = minimal_v0_2_0().replace(
-            "[localnet]\nport = 3040\nrisc0_dev_mode = true\n",
-            "[localnet]\nport = 3040\nrisc0_dev_mode = true\nsequencer_config_path = \"--port=80\"\n",
-        );
-        let err = parse_config(&toml).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("sequencer_config_path"), "{msg}");
-        assert!(msg.contains("--port=80"), "{msg}");
+        for bad in ["--port=80", "", "../escape.json", "/abs/path/config.json"] {
+            let toml = minimal_v0_2_0().replace(
+                "[localnet]\nport = 3040\nrisc0_dev_mode = true\n",
+                &format!(
+                    "[localnet]\nport = 3040\nrisc0_dev_mode = true\nsequencer_config_path = {bad:?}\n"
+                ),
+            );
+            let err = parse_config(&toml).unwrap_err();
+            let msg = err.to_string();
+            assert!(msg.contains("sequencer_config_path"), "{msg}");
+            assert!(msg.contains(bad), "{msg}");
+        }
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -46,13 +46,25 @@ pub(crate) const FRAMEWORK_KIND_LEZ_FRAMEWORK: &str = "lez-framework";
 pub(crate) const DEFAULT_FRAMEWORK_VERSION: &str = "0.1.0";
 pub(crate) const DEFAULT_FRAMEWORK_IDL_SPEC: &str = "lssa-idl/0.1.0";
 pub(crate) const DEFAULT_FRAMEWORK_IDL_PATH: &str = "idl";
-pub(crate) const SEQUENCER_BIN_REL_PATH: &str = "target/release/sequencer_service";
+/// Cargo build profile directory under the LEZ checkout that holds release
+/// binaries. The binary *file name* is data-driven via
+/// `[localnet].sequencer_binary` in `scaffold.toml`; this constant is the
+/// dirname half of that join, shared by setup, localnet, and doctor.
+pub(crate) const SEQUENCER_TARGET_REL_DIR: &str = "target/release";
+/// Default for `[localnet].sequencer_binary`. Doubles as the cargo *package*
+/// name passed to `cargo build -p` and the output binary file name under
+/// `target/release/` — upstream LEZ keeps the two in sync. Projects pointing
+/// at a fork must preserve this coupling (cargo `-p <name>` produces
+/// `target/release/<name>`).
+pub(crate) const DEFAULT_SEQUENCER_BIN_NAME: &str = "sequencer_service";
 /// Project-relative directory holding the Risc0 guest crate (`methods/Cargo.toml`,
 /// `methods/guest/...`). Shared between the build side (`build_methods_guests`),
 /// which compiles the manifest, and the deploy side, which discovers the resulting
 /// `.bin` artefacts under `methods/target/...`.
 pub(crate) const METHODS_DIR: &str = "methods";
-pub(crate) const SEQUENCER_CONFIG_REL_PATH: &str =
+/// Default for `[localnet].sequencer_config_path`. Resolved relative to the
+/// LEZ checkout root unless an absolute path is configured.
+pub(crate) const DEFAULT_SEQUENCER_CONFIG_REL_PATH: &str =
     "sequencer/service/configs/debug/sequencer_config.json";
 pub(crate) const SPEL_BIN_REL_PATH: &str = "target/release/spel";
 /// Default `source` for `[repos.basecamp]`. Built via `nix build .#app`,

--- a/src/doctor_checks.rs
+++ b/src/doctor_checks.rs
@@ -128,6 +128,24 @@ pub(crate) fn check_path(name: &str, path: &Path, remediation: &str) -> CheckRow
     }
 }
 
+pub(crate) fn check_file(name: &str, path: &Path, remediation: &str) -> CheckRow {
+    if path.is_file() {
+        CheckRow {
+            status: CheckStatus::Pass,
+            name: name.to_string(),
+            detail: format!("found {}", path.display()),
+            remediation: None,
+        }
+    } else {
+        CheckRow {
+            status: CheckStatus::Fail,
+            name: name.to_string(),
+            detail: format!("missing or not a regular file {}", path.display()),
+            remediation: Some(remediation.to_string()),
+        }
+    }
+}
+
 pub(crate) fn check_port_warn(name: &str, addr: &str, remediation: &str) -> CheckRow {
     if port_open(addr) {
         CheckRow {

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub(crate) enum LocalnetError {
-    #[error("missing sequencer binary at {path}; run `logos-scaffold setup`")]
+    #[error("missing or invalid sequencer binary at {path}; run `logos-scaffold setup`")]
     MissingSequencerBinary { path: String },
 
     #[error("sequencer process exited before becoming ready (pid={pid})\nlast logs:\n{log_tail}")]

--- a/src/model.rs
+++ b/src/model.rs
@@ -2,6 +2,10 @@ use std::path::PathBuf;
 
 use serde::Serialize;
 
+use crate::constants::{
+    DEFAULT_SEQUENCER_BIN_NAME, DEFAULT_SEQUENCER_CONFIG_REL_PATH, SEQUENCER_TARGET_REL_DIR,
+};
+
 /// A pinned external git dependency.
 ///
 /// `source` is a clone URL or, for `RepoBuild::NixFlake`, a flake-style ref
@@ -52,6 +56,41 @@ impl RepoBuild {
 pub(crate) struct LocalnetConfig {
     pub(crate) port: u16,
     pub(crate) risc0_dev_mode: bool,
+    /// Cargo package name for the LEZ sequencer. Used both at build time
+    /// (`cargo build -p <sequencer_binary>`) and at runtime
+    /// (`<lez>/target/release/<sequencer_binary>`). See
+    /// `DEFAULT_SEQUENCER_BIN_NAME`.
+    pub(crate) sequencer_binary: String,
+    /// Path to the sequencer's JSON config file. Resolved relative to the
+    /// LEZ checkout root if not absolute. Mutated in place by
+    /// `patch_sequencer_port` in `commands::localnet` to honour
+    /// `[localnet].port`, so it must point at a regular file the scaffold
+    /// has write access to.
+    pub(crate) sequencer_config_path: String,
+}
+
+impl LocalnetConfig {
+    /// Resolved on-disk path to the sequencer binary inside the LEZ
+    /// checkout. Mirrors `Path::join`'s semantics: an absolute
+    /// `sequencer_binary` replaces `<lez>/target/release/`, but the
+    /// validator in `config.rs` rejects absolute / path-separator values
+    /// so we never reach that branch in normal flow.
+    pub(crate) fn sequencer_bin_path(&self, lez: &std::path::Path) -> PathBuf {
+        lez.join(SEQUENCER_TARGET_REL_DIR)
+            .join(&self.sequencer_binary)
+    }
+
+    /// Resolved on-disk path to the sequencer config file. Absolute paths
+    /// are taken as-is; relative paths are resolved against the LEZ
+    /// checkout root so the same value works on every machine.
+    pub(crate) fn sequencer_config_resolved_path(&self, lez: &std::path::Path) -> PathBuf {
+        let p = PathBuf::from(&self.sequencer_config_path);
+        if p.is_absolute() {
+            p
+        } else {
+            lez.join(p)
+        }
+    }
 }
 
 impl Default for LocalnetConfig {
@@ -59,6 +98,8 @@ impl Default for LocalnetConfig {
         Self {
             port: 3040,
             risc0_dev_mode: true,
+            sequencer_binary: DEFAULT_SEQUENCER_BIN_NAME.to_string(),
+            sequencer_config_path: DEFAULT_SEQUENCER_CONFIG_REL_PATH.to_string(),
         }
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -61,8 +61,7 @@ pub(crate) struct LocalnetConfig {
     /// (`<lez>/target/release/<sequencer_binary>`). See
     /// `DEFAULT_SEQUENCER_BIN_NAME`.
     pub(crate) sequencer_binary: String,
-    /// Path to the sequencer's JSON config file. Resolved relative to the
-    /// LEZ checkout root if not absolute. Mutated in place by
+    /// LEZ-relative path to the sequencer's JSON config file. Mutated in place by
     /// `patch_sequencer_port` in `commands::localnet` to honour
     /// `[localnet].port`, so it must point at a regular file the scaffold
     /// has write access to.
@@ -80,16 +79,11 @@ impl LocalnetConfig {
             .join(&self.sequencer_binary)
     }
 
-    /// Resolved on-disk path to the sequencer config file. Absolute paths
-    /// are taken as-is; relative paths are resolved against the LEZ
-    /// checkout root so the same value works on every machine.
+    /// Resolved on-disk path to the sequencer config file. Config parsing
+    /// rejects absolute paths and parent components, so this stays inside
+    /// the LEZ checkout root.
     pub(crate) fn sequencer_config_resolved_path(&self, lez: &std::path::Path) -> PathBuf {
-        let p = PathBuf::from(&self.sequencer_config_path);
-        if p.is_absolute() {
-            p
-        } else {
-            lez.join(p)
-        }
+        lez.join(&self.sequencer_config_path)
     }
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -614,6 +614,76 @@ fn doctor_json_outputs_machine_readable_report() {
 }
 
 #[test]
+fn doctor_reports_configured_sequencer_binary_and_config_path() {
+    // When [localnet].sequencer_binary / sequencer_config_path are set,
+    // doctor's `sequencer binary` and `sequencer config` rows must report
+    // the *configured* paths, not the upstream defaults. Drives the
+    // setup/localnet/doctor wiring without spawning a real sequencer.
+    let temp = tempdir().expect("tempdir");
+    let lez_path = temp.path().join("lez");
+    fs::create_dir_all(&lez_path).expect("create lez path");
+    let spel_path = temp.path().join("spel");
+    let custom_config_rel = "sequencer/service/configs/dev/sequencer_config.json";
+
+    let toml = format!(
+        "[scaffold]\nversion = \"0.2.0\"\ncache_root = \"{}\"\n\n\
+         [repos.lez]\nsource = \"https://github.com/logos-blockchain/logos-execution-zone.git\"\n\
+         pin = \"{}\"\npath = \"{}\"\n\n\
+         [repos.spel]\nsource = \"https://github.com/logos-co/spel.git\"\n\
+         pin = \"{}\"\npath = \"{}\"\n\n\
+         [wallet]\nhome_dir = \".scaffold/wallet\"\n\n\
+         [localnet]\nport = 3040\nrisc0_dev_mode = true\n\
+         sequencer_binary = \"my_custom_seq\"\n\
+         sequencer_config_path = \"{}\"\n",
+        temp.path().join("cache").display(),
+        TEST_PIN,
+        lez_path.display(),
+        TEST_PIN,
+        spel_path.display(),
+        custom_config_rel,
+    );
+    fs::write(temp.path().join("scaffold.toml"), toml).expect("write scaffold.toml");
+
+    let assert = Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .arg("doctor")
+        .arg("--json")
+        .assert();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8 stdout");
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+    let checks = value
+        .get("checks")
+        .and_then(serde_json::Value::as_array)
+        .expect("checks array");
+
+    let bin_row = checks
+        .iter()
+        .find(|c| c.get("name").and_then(serde_json::Value::as_str) == Some("sequencer binary"))
+        .expect("sequencer binary check present");
+    let bin_detail = bin_row
+        .get("detail")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        bin_detail.contains("target/release/my_custom_seq"),
+        "expected detail to mention configured binary path, got {bin_detail:?}"
+    );
+
+    let cfg_row = checks
+        .iter()
+        .find(|c| c.get("name").and_then(serde_json::Value::as_str) == Some("sequencer config"))
+        .expect("sequencer config check present");
+    let cfg_detail = cfg_row
+        .get("detail")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        cfg_detail.contains(custom_config_rel),
+        "expected detail to mention configured config path, got {cfg_detail:?}"
+    );
+}
+
+#[test]
 fn doctor_uses_password_env_override_for_wallet_health() {
     let temp = tempdir().expect("tempdir");
     setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -885,6 +885,44 @@ fn localnet_start_rejects_sequencer_binary_directory() {
         ));
 }
 
+#[cfg(unix)]
+#[test]
+fn localnet_reset_rejects_config_symlink_outside_lez_before_cleanup() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempdir().expect("tempdir");
+    let lez_path = temp.path().join("lez");
+    let sequencer_bin = lez_path.join("target/release/sequencer_service");
+    let config_path = lez_path.join("sequencer/service/configs/debug/sequencer_config.json");
+    let outside_config = temp.path().join("outside_config.json");
+    let rocksdb_path = lez_path.join("rocksdb");
+
+    fs::create_dir_all(sequencer_bin.parent().expect("parent")).expect("create binary dir");
+    fs::write(&sequencer_bin, "#!/bin/sh\nexit 1\n").expect("write fake sequencer");
+    fs::create_dir_all(config_path.parent().expect("parent")).expect("create config dir");
+    fs::write(&outside_config, r#"{"port": 3040}"#).expect("write outside config");
+    symlink(&outside_config, &config_path).expect("symlink config outside lez");
+    fs::create_dir_all(&rocksdb_path).expect("create rocksdb");
+    write_scaffold_toml(temp.path(), &lez_path);
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .arg("localnet")
+        .arg("reset")
+        .arg("--verify-timeout-sec")
+        .arg("1")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "sequencer config must resolve inside the LEZ checkout",
+        ));
+
+    assert!(
+        rocksdb_path.exists(),
+        "reset must not delete chain data before config preflight passes"
+    );
+}
+
 #[test]
 fn localnet_stop_outside_project_succeeds() {
     let temp = tempdir().expect("tempdir");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -624,6 +624,9 @@ fn doctor_reports_configured_sequencer_binary_and_config_path() {
     fs::create_dir_all(&lez_path).expect("create lez path");
     let spel_path = temp.path().join("spel");
     let custom_config_rel = "sequencer/service/configs/dev/sequencer_config.json";
+    fs::create_dir_all(lez_path.join("target/release/my_custom_seq"))
+        .expect("create binary directory");
+    fs::create_dir_all(lez_path.join(custom_config_rel)).expect("create config directory");
 
     let toml = format!(
         "[scaffold]\nversion = \"0.2.0\"\ncache_root = \"{}\"\n\n\
@@ -668,6 +671,15 @@ fn doctor_reports_configured_sequencer_binary_and_config_path() {
         bin_detail.contains("target/release/my_custom_seq"),
         "expected detail to mention configured binary path, got {bin_detail:?}"
     );
+    assert_eq!(
+        bin_row.get("status").and_then(serde_json::Value::as_str),
+        Some("fail"),
+        "directory at configured binary path should fail doctor"
+    );
+    assert!(
+        bin_detail.contains("not a regular file"),
+        "expected directory binary path to fail as non-file, got {bin_detail:?}"
+    );
 
     let cfg_row = checks
         .iter()
@@ -680,6 +692,15 @@ fn doctor_reports_configured_sequencer_binary_and_config_path() {
     assert!(
         cfg_detail.contains(custom_config_rel),
         "expected detail to mention configured config path, got {cfg_detail:?}"
+    );
+    assert_eq!(
+        cfg_row.get("status").and_then(serde_json::Value::as_str),
+        Some("fail"),
+        "directory at configured config path should fail doctor"
+    );
+    assert!(
+        cfg_detail.contains("not a regular file"),
+        "expected directory config path to fail as non-file, got {cfg_detail:?}"
     );
 }
 
@@ -837,6 +858,31 @@ fn localnet_start_patches_config_and_uses_configured_port() {
 
     let env = fs::read_to_string(&env_log).expect("read env log");
     assert_eq!(env, "0", "expected risc0 dev mode override to be passed");
+}
+
+#[test]
+fn localnet_start_rejects_sequencer_binary_directory() {
+    let temp = tempdir().expect("tempdir");
+    let lez_path = temp.path().join("lez");
+    let sequencer_bin = lez_path.join("target/release/sequencer_service");
+    let config_path = lez_path.join("sequencer/service/configs/debug/sequencer_config.json");
+
+    fs::create_dir_all(&sequencer_bin).expect("create binary directory");
+    fs::create_dir_all(config_path.parent().expect("parent")).expect("create config dir");
+    fs::write(&config_path, r#"{"port": 3040}"#).expect("write sequencer config");
+    write_scaffold_toml(temp.path(), &lez_path);
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .arg("localnet")
+        .arg("start")
+        .arg("--timeout-sec")
+        .arg("1")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "missing or invalid sequencer binary",
+        ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Follow-up to #30, rebased onto the v0.2.0 schema (#95). Adds `[localnet].sequencer_binary` and `[localnet].sequencer_config_path` so projects can point scaffold at a non-upstream sequencer (custom fork, alternate LEZ layout) without forking scaffold itself. Defaults match upstream LEZ at the pinned version, so existing `scaffold.toml` files pick up the new keys with no behaviour change and no schema bump.

## What changed

- `LocalnetConfig` (`src/model.rs`) gains the two `String` fields and two helpers — `sequencer_bin_path(lez)` and `sequencer_config_resolved_path(lez)` — so the absolute/relative resolution lives in one place.
- `setup` (`src/commands/setup.rs`) builds via `cargo build -p <sequencer_binary>`. The binary file name and the cargo package name share a value upstream and must continue to match in any fork — documented inline.
- `localnet start` (`src/commands/localnet.rs`) resolves the binary via the helper, verifies the resolved config path is a regular file *before* calling `patch_sequencer_port`, and keeps master's JSON-mutation flow (the pinned LEZ rejects unknown CLI flags, so no `--port` arg).
- `doctor` (`src/commands/doctor.rs`) surfaces both the binary and the config as `check_path` rows resolved through the same helpers, so absolute and LEZ-relative values render symmetrically.
- README gets a "Pointing localnet at a custom sequencer" section with the example and a scaffold↔LEZ pin alignment caveat.

## Validation

- `sequencer_binary` is constrained to a cargo package name: rejects empty, leading `-`, `.`, `..`, path separators, and absolute paths. Both the `cargo -p` arg and the `target/release/<name>` join become impossible to subvert.
- `sequencer_config_path` allows path separators (the file lives a few directories deep in LEZ) but rejects empty values and leading `-` so flag-shaped values can't sneak into the spawned sequencer's argv.
- Both validators include the offending value in the error.

## Tested

- `cargo fmt --all`
- `cargo check`
- `cargo test --lib` — 8 new unit tests in `config.rs` (defaults, round-trip, each forbidden form for both keys)
- `cargo test --test cli` — new `doctor --json` integration test asserts the configured paths surface end-to-end (replaces the old `localnet start` smoke test, which had a port-binding race)

## Non-changes

- No schema bump — additive within `[scaffold].version = "0.2.0"`, defaults make existing configs work unchanged.
- No re-introduction of a `--port` CLI flag for the spawned sequencer; master's `patch_sequencer_port` flow is preserved.

## Out of scope

- Prebuilt binary support (the binary still has to live at `<lez>/target/release/<name>`).
- A separate `sequencer_package` knob if a fork ever needs the cargo package and runtime binary names to diverge — easy to add later, not needed today.