### PR TITLE
fix(doctor): use configured localnet port instead of hardcoded 3040

### DIFF
--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -116,9 +116,11 @@ pub(crate) fn build_doctor_report() -> DynResult<DoctorReport> {
         "Run `logos-scaffold setup`",
     ));
 
+    let localnet_addr = format!("127.0.0.1:{}", project.config.localnet.port);
+    let sequencer_port_label = format!("sequencer port {}", project.config.localnet.port);
     rows.push(check_port_warn(
-        "sequencer port 3040",
-        "127.0.0.1:3040",
+        &sequencer_port_label,
+        &localnet_addr,
         "Run `logos-scaffold localnet start` (required before running example binaries)",
     ));
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1704,3 +1704,115 @@ fn respond_last_block(stream: &mut TcpStream) {
     let _ = stream.write_all(response.as_bytes());
     let _ = stream.flush();
 }
+
+
+#[test]
+fn localnet_logs_json_flag_shown_in_help() {
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .args(["localnet", "logs", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--json"));
+}
+
+#[test]
+fn localnet_logs_json_outputs_valid_json_when_no_log_file() {
+    let temp = tempdir().expect("tempdir");
+    let lssa_path = temp.path().join("lssa");
+    fs::create_dir_all(&lssa_path).expect("create lssa path");
+    write_scaffold_toml(temp.path(), &lssa_path, "wallet-not-installed-for-tests");
+
+    let assert = Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .args(["localnet", "logs", "--json"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8 stdout");
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+
+    assert!(value.get("tail").is_some());
+    assert!(value.get("lines").is_some());
+    assert_eq!(value["lines"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn localnet_logs_json_outputs_lines_array() {
+    let temp = tempdir().expect("tempdir");
+    let lssa_path = temp.path().join("lssa");
+    fs::create_dir_all(&lssa_path).expect("create lssa path");
+    write_scaffold_toml(temp.path(), &lssa_path, "wallet-not-installed-for-tests");
+
+    fs::create_dir_all(temp.path().join(".scaffold/logs")).expect("create logs dir");
+    fs::write(
+        temp.path().join(".scaffold/logs/sequencer.log"),
+        "line-one\nline-two\nline-three\n",
+    )
+    .expect("write sequencer log");
+
+    let assert = Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .args(["localnet", "logs", "--json", "--tail", "2"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8 stdout");
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+
+    let lines = value["lines"].as_array().expect("lines array");
+    assert_eq!(lines.len(), 2);
+    assert_eq!(lines[0].as_str().unwrap(), "line-two");
+    assert_eq!(lines[1].as_str().unwrap(), "line-three");
+    assert_eq!(value["tail"].as_u64().unwrap(), 2);
+}
+
+#[test]
+fn doctor_uses_configured_localnet_port_not_hardcoded_3040() {
+    let temp = tempdir().expect("tempdir");
+    let lssa_path = temp.path().join("lssa");
+    fs::create_dir_all(&lssa_path).expect("create lssa path");
+    let custom_port = 14321u16;
+    write_scaffold_toml_with_localnet(
+        temp.path(),
+        &lssa_path,
+        "wallet-not-installed-for-tests",
+        Some(custom_port),
+        Some(true),
+    );
+
+    let assert = Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .args(["doctor", "--json"])
+        .assert();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8 stdout");
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+
+    let checks = value["checks"].as_array().expect("checks array");
+    let port_check = checks
+        .iter()
+        .find(|c| {
+            c["name"]
+                .as_str()
+                .map(|n| n.contains(&custom_port.to_string()))
+                .unwrap_or(false)
+        })
+        .expect("should find sequencer port check with configured port");
+
+    assert!(
+        port_check["name"].as_str().unwrap().contains("14321"),
+        "port check name should use configured port 14321, got: {}",
+        port_check["name"]
+    );
+    assert!(
+        port_check["detail"].as_str().unwrap().contains("14321"),
+        "port check detail should reference configured port 14321, got: {}",
+        port_check["detail"]
+    );
+
+    // Ensure the old hardcoded port does NOT appear in the sequencer port check
+    assert!(
+        !port_check["name"].as_str().unwrap().contains("3040"),
+        "port check should not reference hardcoded 3040 when custom port is configured"
+    );
+}


### PR DESCRIPTION
Closes #40

## Problem

`doctor` hardcodes `127.0.0.1:3040` for the sequencer port check, ignoring the `localnet.port` value in `scaffold.toml`. This means projects using a non-default port always see the sequencer reported as unreachable in `doctor` output.

## Fix

Use `project.config.localnet.port` to build the address and label dynamically — consistent with how `localnet start`, `localnet status`, and `localnet stop` already behave.

## Changes

- `src/commands/doctor.rs`: derive `localnet_addr` and `sequencer_port_label` from project config
- `tests/cli.rs`: new test verifying doctor uses configured port, not hardcoded 3040

## Testing

```bash
cargo test doctor_uses_configured_localnet_port
```