### PR TITLE
test(new): add unit tests for to_cargo_crate_name

### DIFF
--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -202,3 +202,51 @@ pub(crate) fn to_cargo_crate_name(input: &str) -> String {
         out
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::to_cargo_crate_name;
+
+    #[test]
+    fn simple_name_is_lowercased() {
+        assert_eq!(to_cargo_crate_name("MyApp"), "myapp");
+    }
+
+    #[test]
+    fn spaces_become_dashes() {
+        assert_eq!(to_cargo_crate_name("my app"), "my-app");
+    }
+
+    #[test]
+    fn special_chars_become_single_dash() {
+        assert_eq!(to_cargo_crate_name("my--app"), "my-app");
+        assert_eq!(to_cargo_crate_name("my___app"), "my-app");
+    }
+
+    #[test]
+    fn leading_and_trailing_dashes_are_trimmed() {
+        assert_eq!(to_cargo_crate_name("--myapp--"), "myapp");
+        assert_eq!(to_cargo_crate_name("_myapp_"), "myapp");
+    }
+
+    #[test]
+    fn empty_string_returns_default() {
+        assert_eq!(to_cargo_crate_name(""), "program_deployment");
+    }
+
+    #[test]
+    fn only_special_chars_returns_default() {
+        assert_eq!(to_cargo_crate_name("---"), "program_deployment");
+        assert_eq!(to_cargo_crate_name("!!!"), "program_deployment");
+    }
+
+    #[test]
+    fn alphanumeric_preserved() {
+        assert_eq!(to_cargo_crate_name("my-app-123"), "my-app-123");
+    }
+
+    #[test]
+    fn unicode_becomes_dash() {
+        assert_eq!(to_cargo_crate_name("héllo"), "h-llo");
+    }
+}


### PR DESCRIPTION
Closes #42

## Summary

`to_cargo_crate_name` had no tests despite handling several edge cases. This PR adds 8 unit tests directly in `src/commands/new.rs`.

## Tests added

- `simple_name_is_lowercased`
- `spaces_become_dashes`
- `special_chars_become_single_dash`
- `leading_and_trailing_dashes_are_trimmed`
- `empty_string_returns_default`
- `only_special_chars_returns_default`
- `alphanumeric_preserved`
- `unicode_becomes_dash`

## Testing

```bash
cargo test --lib -- new::tests
```