### PR TITLE
fix: use configured localnet port in doctor command

### DIFF
--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -116,9 +116,11 @@ pub(crate) fn build_doctor_report() -> DynResult<DoctorReport> {
         "Run `logos-scaffold setup`",
     ));
 
+    let localnet_port = project.config.localnet.port;
+    let localnet_addr = format!("127.0.0.1:{localnet_port}");
     rows.push(check_port_warn(
-        "sequencer port 3040",
-        "127.0.0.1:3040",
+        &format!("sequencer port {localnet_port}"),
+        &localnet_addr,
         "Run `logos-scaffold localnet start` (required before running example binaries)",
     ));
 


### PR DESCRIPTION
Fixes #40.

Replace hardcoded port 3040 with `project.config.localnet.port` in `build_doctor_report()`.

```rust
// Before
rows.push(check_port_warn(
    "sequencer port 3040",
    "127.0.0.1:3040",
    ...
));

// After
let localnet_port = project.config.localnet.port;
let localnet_addr = format!("127.0.0.1:{localnet_port}");
rows.push(check_port_warn(
    &format!("sequencer port {localnet_port}"),
    &localnet_addr,
    ...
));
```