### PR TITLE
refactor: move GUEST_BIN_REL_PATH to constants.rs

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -4,6 +4,7 @@ use std::process::Command;
 
 use anyhow::{bail, Context};
 
+use crate::constants::GUEST_BIN_REL_PATH;
 use crate::process::run_with_stdin;
 use crate::project::load_project;
 use crate::DynResult;
@@ -13,8 +14,6 @@ use super::wallet_support::{
     sequencer_unreachable_hint, summarize_command_failure, wallet_password, RpcReachabilityError,
 };
 
-const GUEST_BIN_REL_PATH: &str =
-    "target/riscv-guest/example_program_deployment_methods/example_program_deployment_programs/riscv32im-risc0-zkvm-elf/release";
 const DEFAULT_SEQUENCER_ADDR: &str = "http://127.0.0.1:3040";
 
 pub(crate) fn cmd_deploy(

--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -1,3 +1,4 @@
+use crate::constants::GUEST_BIN_REL_PATH;
 use std::collections::VecDeque;
 use std::env;
 use std::fs::{self, File};
@@ -23,7 +24,6 @@ use crate::state::write_text;
 use crate::DynResult;
 
 const REPORT_WARNING: &str = "WARNING: This diagnostics bundle is sanitized on a best-effort basis and may still contain sensitive data. Inspect every file before sharing it publicly.";
-const GUEST_BIN_REL_PATH: &str = "target/riscv-guest/example_program_deployment_methods/example_program_deployment_programs/riscv32im-risc0-zkvm-elf/release";
 
 pub(crate) fn cmd_report(out: Option<PathBuf>, tail: usize) -> DynResult<()> {
     let project = load_project().context(

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -10,3 +10,5 @@ pub(crate) const FRAMEWORK_KIND_LEZ_FRAMEWORK: &str = "lez-framework";
 pub(crate) const DEFAULT_FRAMEWORK_VERSION: &str = "0.1.0";
 pub(crate) const DEFAULT_FRAMEWORK_IDL_SPEC: &str = "lssa-idl/0.1.0";
 pub(crate) const DEFAULT_FRAMEWORK_IDL_PATH: &str = "idl";
+
+pub(crate) const GUEST_BIN_REL_PATH: &str = "target/riscv-guest/example_program_deployment_methods/example_program_deployment_programs/riscv32im-risc0-zkvm-elf/release";


### PR DESCRIPTION
Fixes #44.

`GUEST_BIN_REL_PATH` was defined identically in `deploy.rs` and `report.rs`. Moved to `src/constants.rs` and imported in both files.