### PR TITLE
fix: use serde_json for deploy --json output to prevent malformed JSON

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -274,8 +274,12 @@ fn deploy_single_program(
         let summary = summarize_command_failure(&output.stdout, &output.stderr);
         if json {
             eprintln!(
-                "{{\"status\":\"failed\",\"program\":\"{}\",\"error\":\"{}\"}}",
-                program_name, summary
+                "{}",
+                serde_json::json!({
+                    "status": "failed",
+                    "program": program_name,
+                    "error": summary,
+                })
             );
         } else {
             println!("FAIL {program_name} deployment failed");
@@ -285,13 +289,13 @@ fn deploy_single_program(
     }
 
     if json {
-        let tx_val = tx
-            .as_deref()
-            .map(|t| format!("\"{}\"", t))
-            .unwrap_or_else(|| "null".to_string());
         println!(
-            "{{\"status\":\"submitted\",\"program\":\"{}\",\"tx\":{}}}",
-            program_name, tx_val
+            "{}",
+            serde_json::json!({
+                "status": "submitted",
+                "program": program_name,
+                "tx": tx,
+            })
         );
     } else {
         println!("OK  {program_name} submitted");


### PR DESCRIPTION
## Summary

`deploy_single_program()` in `deploy.rs` constructs JSON output via manual
`format!()` interpolation when `--json` is passed. If `program_name` or an
error summary contains characters like `"`, `\`, or newlines, the output
is malformed JSON.

This replaces the two manual formatting sites with `serde_json::json!()`
which is already a project dependency. The `tx` field also benefits:
`Option<String>` serializes directly to the value or `null`, removing
the hand-rolled `tx_val` logic.

## Test plan

- [x] `cargo check` — compiles cleanly
- [x] `cargo fmt --check` — no formatting issues
- [x] `cargo test` — all 89 existing tests pass
