### PR TITLE
fix: detect IDL name collisions after sanitization to prevent silent overwrites

### DIFF
--- a/src/commands/idl.rs
+++ b/src/commands/idl.rs
@@ -60,9 +60,16 @@ pub(crate) fn build_idl_for_current_project() -> DynResult<()> {
     }
 
     blocks.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut seen_stems: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
     for (name, json_text) in blocks {
         let canonical = canonical_json(&json_text)?;
-        let file_name = format!("{}.json", sanitize_file_stem(&name));
+        let stem = sanitize_file_stem(&name);
+        if let Some(prev_name) = seen_stems.get(&stem) {
+            bail!("IDL name collision: `{name}` and `{prev_name}` both sanitize to `{stem}.json`");
+        }
+        seen_stems.insert(stem.clone(), name.clone());
+        let file_name = format!("{stem}.json");
         let path = idl_dir.join(file_name);
         write_text(&path, &canonical)?;
         println!("Wrote IDL {}", path.display());


### PR DESCRIPTION
## Summary

`sanitize_file_stem()` normalizes IDL block names by lowercasing and replacing
non-alphanumeric characters with `_`. This means different names can map to the
same output filename (e.g. `foo-bar` and `foo_bar` both become `foo_bar.json`),
and the later block silently overwrites the earlier one.

This adds a `HashMap` to track seen stems and bails with a clear error message
when a collision is detected.

## Test plan

- [x] `cargo check` — compiles cleanly
- [x] `cargo fmt --check` — no formatting issues
- [x] `cargo test` — all 89 existing tests pass
