### PR TITLE
fix: localnet start with relative LSSA paths and config-based port

### DIFF
--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -6,7 +6,7 @@ use anyhow::bail;
 
 use super::wallet_support::wallet_password;
 use crate::commands::wallet_support::WALLET_CONFIG_PRIMARY;
-use crate::constants::DEFAULT_LSSA_PIN;
+use crate::constants::{DEFAULT_LSSA_PIN, SEQUENCER_BIN_REL_PATH};
 use crate::doctor_checks::{
     check_binary, check_container_runtime, check_path, check_port_warn, check_repo,
     check_standalone_support, one_line, print_rows,
@@ -112,7 +112,7 @@ pub(crate) fn build_doctor_report() -> DynResult<DoctorReport> {
 
     rows.push(check_path(
         "sequencer binary",
-        &lssa.join("target/release/sequencer_runner"),
+        &lssa.join(SEQUENCER_BIN_REL_PATH),
         "Run `logos-scaffold setup`",
     ));
 

--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -6,6 +6,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context};
+use serde_json::Value;
 
 use crate::error::LocalnetError;
 use crate::model::{LocalnetOwnership, LocalnetState, LocalnetStatusReport, Project};
@@ -166,12 +167,12 @@ fn cmd_localnet_start(
         bail!("{message}");
     }
 
+    patch_sequencer_port(lssa, localnet_port)?;
+
     let sequencer_pid = spawn_to_log(
         Command::new(sequencer_bin)
             .current_dir(lssa)
             .arg("sequencer_runner/configs/debug")
-            .arg("--port")
-            .arg(localnet_port.to_string())
             .env("RUST_LOG", "info")
             .env("RISC0_DEV_MODE", if risc0_dev_mode { "1" } else { "0" }),
         log_path,
@@ -405,6 +406,31 @@ fn build_status_report(
         log_path: log_path.display().to_string(),
         remediation,
     }
+}
+
+/// Update the port in `sequencer_runner/configs/debug/sequencer_config.json`
+/// so the sequencer listens on the configured port.  The pinned LSSA version
+/// does not accept `--port` as a CLI flag — it reads the port from this file.
+fn patch_sequencer_port(lssa: &Path, port: u16) -> DynResult<()> {
+    let config_path = lssa.join("sequencer_runner/configs/debug/sequencer_config.json");
+    let text = fs::read_to_string(&config_path)
+        .with_context(|| format!("failed to read {}", config_path.display()))?;
+    let mut doc: Value =
+        serde_json::from_str(&text).context("failed to parse sequencer_config.json")?;
+
+    if let Some(obj) = doc.as_object_mut() {
+        obj.insert("port".to_string(), Value::Number(port.into()));
+    } else {
+        bail!(
+            "sequencer_config.json is not a JSON object: {}",
+            config_path.display()
+        );
+    }
+
+    let updated = serde_json::to_string_pretty(&doc).context("failed to serialize config")?;
+    fs::write(&config_path, format!("{updated}\n"))
+        .with_context(|| format!("failed to write {}", config_path.display()))?;
+    Ok(())
 }
 
 fn read_log_tail(log_path: &Path, tail: usize) -> String {

--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant};
 use anyhow::{bail, Context};
 use serde_json::Value;
 
+use crate::constants::{SEQUENCER_BIN_REL_PATH, SEQUENCER_CONFIG_DIR_REL_PATH};
 use crate::error::LocalnetError;
 use crate::model::{LocalnetOwnership, LocalnetState, LocalnetStatusReport, Project};
 use crate::process::{listener_pid, pid_alive, pid_command, pid_running, port_open, spawn_to_log};
@@ -125,7 +126,7 @@ fn cmd_localnet_start(
     localnet_addr: &str,
 ) -> DynResult<()> {
     ensure_dir_exists(lssa, "lssa")?;
-    let sequencer_bin = lssa.join("target/release/sequencer_runner");
+    let sequencer_bin = lssa.join(SEQUENCER_BIN_REL_PATH);
     if !sequencer_bin.exists() {
         return Err(LocalnetError::MissingSequencerBinary {
             path: sequencer_bin.display().to_string(),
@@ -169,10 +170,14 @@ fn cmd_localnet_start(
 
     patch_sequencer_port(lssa, localnet_port)?;
 
+    // Use a path relative to lssa (the child's cwd), not relative to the
+    // parent's cwd.  `current_dir(lssa)` applies before exec, so a parent-
+    // relative path like `.scaffold/cache/repos/lssa/target/release/…`
+    // would be resolved inside lssa and fail with ENOENT.
     let sequencer_pid = spawn_to_log(
-        Command::new(sequencer_bin)
+        Command::new(format!("./{SEQUENCER_BIN_REL_PATH}"))
             .current_dir(lssa)
-            .arg("sequencer_runner/configs/debug")
+            .arg(SEQUENCER_CONFIG_DIR_REL_PATH)
             .env("RUST_LOG", "info")
             .env("RISC0_DEV_MODE", if risc0_dev_mode { "1" } else { "0" }),
         log_path,
@@ -408,11 +413,13 @@ fn build_status_report(
     }
 }
 
-/// Update the port in `sequencer_runner/configs/debug/sequencer_config.json`
-/// so the sequencer listens on the configured port.  The pinned LSSA version
-/// does not accept `--port` as a CLI flag — it reads the port from this file.
+/// Update the port in `sequencer_config.json` so the sequencer listens on the
+/// configured port.  The pinned LSSA version does not accept `--port` as a CLI
+/// flag — it reads the port from this file.
 fn patch_sequencer_port(lssa: &Path, port: u16) -> DynResult<()> {
-    let config_path = lssa.join("sequencer_runner/configs/debug/sequencer_config.json");
+    let config_path = lssa
+        .join(SEQUENCER_CONFIG_DIR_REL_PATH)
+        .join("sequencer_config.json");
     let text = fs::read_to_string(&config_path)
         .with_context(|| format!("failed to read {}", config_path.display()))?;
     let mut doc: Value =

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -10,3 +10,5 @@ pub(crate) const FRAMEWORK_KIND_LEZ_FRAMEWORK: &str = "lez-framework";
 pub(crate) const DEFAULT_FRAMEWORK_VERSION: &str = "0.1.0";
 pub(crate) const DEFAULT_FRAMEWORK_IDL_SPEC: &str = "lssa-idl/0.1.0";
 pub(crate) const DEFAULT_FRAMEWORK_IDL_PATH: &str = "idl";
+pub(crate) const SEQUENCER_BIN_REL_PATH: &str = "target/release/sequencer_runner";
+pub(crate) const SEQUENCER_CONFIG_DIR_REL_PATH: &str = "sequencer_runner/configs/debug";

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -634,7 +634,14 @@ fn localnet_start_fails_when_process_exits_before_ready() {
     let temp = tempdir().expect("tempdir");
     let lssa_path = temp.path().join("lssa");
     let sequencer_bin = lssa_path.join("target/release/sequencer_runner");
+    let config_dir = lssa_path.join("sequencer_runner/configs/debug");
     fs::create_dir_all(sequencer_bin.parent().expect("parent")).expect("create dirs");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("sequencer_config.json"),
+        r#"{"port": 3040}"#,
+    )
+    .expect("write sequencer config");
     fs::write(&sequencer_bin, "#!/bin/sh\nexit 1\n").expect("write fake sequencer");
 
     #[cfg(unix)]
@@ -672,19 +679,26 @@ fn localnet_start_fails_when_process_exits_before_ready() {
 }
 
 #[test]
-fn localnet_start_passes_configured_port_to_sequencer() {
+fn localnet_start_patches_config_and_uses_configured_port() {
     let temp = tempdir().expect("tempdir");
     let lssa_path = temp.path().join("lssa");
     let sequencer_bin = lssa_path.join("target/release/sequencer_runner");
+    let config_dir = lssa_path.join("sequencer_runner/configs/debug");
+    let config_path = config_dir.join("sequencer_config.json");
     let args_log = temp.path().join("sequencer-args.log");
     let env_log = temp.path().join("sequencer-env.log");
     let localnet_port = unused_local_port();
 
     fs::create_dir_all(sequencer_bin.parent().expect("parent")).expect("create dirs");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(&config_path, r#"{"port": 3040}"#).expect("write sequencer config");
+
+    // Fake sequencer: reads port from sequencer_config.json (like the real one),
+    // logs args and env for assertions.
     fs::write(
         &sequencer_bin,
         format!(
-            "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$@\" > '{}'\nprintf '%s' \"${{RISC0_DEV_MODE:-}}\" > '{}'\nport=3040\nwhile [ \"$#\" -gt 0 ]; do\n  if [ \"$1\" = \"--port\" ]; then\n    shift\n    port=\"$1\"\n    break\n  fi\n  shift\ndone\nexec python3 -m http.server \"$port\" --bind 127.0.0.1\n",
+            "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$@\" > '{}'\nprintf '%s' \"${{RISC0_DEV_MODE:-}}\" > '{}'\nconfig=\"$1/sequencer_config.json\"\nport=$(python3 -c \"import json,sys; print(json.load(open(sys.argv[1]))['port'])\" \"$config\")\nexec python3 -m http.server \"$port\" --bind 127.0.0.1\n",
             args_log.display(),
             env_log.display(),
         ),
@@ -726,11 +740,21 @@ fn localnet_start_passes_configured_port_to_sequencer() {
         .assert()
         .success();
 
+    // Verify sequencer_config.json was patched with the configured port
+    let patched_config = fs::read_to_string(&config_path).expect("read patched config");
+    let config_json: serde_json::Value =
+        serde_json::from_str(&patched_config).expect("parse patched config");
+    assert_eq!(
+        config_json["port"],
+        serde_json::Value::Number(localnet_port.into()),
+        "expected port in sequencer_config.json to be patched to {localnet_port}, got: {patched_config}"
+    );
+
+    // Verify --port was NOT passed as a CLI arg
     let args = fs::read_to_string(&args_log).expect("read args log");
     assert!(
-        args.contains("sequencer_runner/configs/debug\n--port\n")
-            && args.contains(&format!("--port\n{localnet_port}\n")),
-        "expected configured port in sequencer args, got: {args}"
+        !args.contains("--port"),
+        "expected --port NOT to appear in sequencer args, got: {args}"
     );
 
     let env = fs::read_to_string(&env_log).expect("read env log");


### PR DESCRIPTION
## Summary

- Patch `sequencer_config.json` port instead of passing `--port` CLI flag (unsupported by pinned LSSA)
- Fix ENOENT when spawning sequencer with relative `scaffold.toml` paths
- Extract `SEQUENCER_BIN_REL_PATH` and `SEQUENCER_CONFIG_DIR_REL_PATH` to constants

## Details

`logos-scaffold localnet start` had two bugs:

### 1. `--port` CLI flag not supported by pinned LSSA

The `sequencer_runner` at the default LSSA pin (`767b5afd`) doesn't accept `--port` as a CLI argument — it reads the port from `sequencer_config.json`. Instead of passing `--port`, we now patch the JSON config file before starting.

### 2. Binary path resolved from wrong directory

`Command::new(relative_path).current_dir(lssa)` resolves the binary path after `chdir(lssa)` in the child process. With a relative `[repos.lssa].path` like `.scaffold/cache/repos/lssa`, the binary path becomes:

```
.scaffold/cache/repos/lssa/.scaffold/cache/repos/lssa/target/release/sequencer_runner
                           ^--- resolved from child cwd, not parent
```

This fails with `No such file or directory (os error 2)`. Fixed by using `./target/release/sequencer_runner` which is relative to the child's cwd (`lssa`).

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt --check` passes
- [x] All 53 integration tests pass
- [ ] Manual validation: `logos-scaffold new`, `setup`, `localnet start` with default and custom port values
- [ ] Manual validation: works with both relative and absolute `[repos.lssa].path` in `scaffold.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)