### PR TITLE
feat: create basecamp qml template

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "logos-scaffold"
 version = "0.1.0"
-description = "Rust CLI for bootstrapping LSSA program_deployment projects in standalone mode"
+description = "Rust CLI for bootstrapping LEZ and Basecamp projects in local development mode"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # logos-scaffold
 
-`logos-scaffold` is a Rust CLI for bootstrapping LEZ (Logos Execution Zone) `program_deployment` projects in standalone mode.
+`logos-scaffold` is a Rust CLI for bootstrapping:
+
+- LEZ (Logos Execution Zone) `program_deployment` projects in standalone mode
+- Basecamp pure QML (`ui_qml`) plugins for local development
 
 ## Platform
 
@@ -37,7 +40,8 @@ Keep that runbook updated whenever first-class commands, templates, or supported
 logos-scaffold create <name> [--vendor-deps] [--lez-path PATH] [--cache-root PATH]
 logos-scaffold new <name> [--vendor-deps] [--lez-path PATH] [--cache-root PATH]
 logos-scaffold setup
-logos-scaffold build [project-path]
+logos-scaffold build [project-path] [--artifact raw|all]
+logos-scaffold install [project-path]
 logos-scaffold deploy [program-name]
 logos-scaffold localnet start [--timeout-sec N]
 logos-scaffold localnet stop
@@ -107,6 +111,28 @@ logos-scaffold new <name> --template lez-framework
 ```
 
 See [LEZ Framework Template](./templates/lez-framework/README.md) for details.
+
+## Basecamp QML
+
+To scaffold a pure QML Basecamp plugin:
+
+```bash
+logos-scaffold new <name> --template basecamp-qml
+cd <name>
+logos-scaffold setup
+logos-scaffold build
+logos-scaffold install
+```
+
+`build` stages a raw plugin bundle under `.scaffold/build/raw/plugins/<plugin-name>/`.
+`install` syncs that bundle into the scaffold-managed Basecamp data directory and prints the
+exact `LOGOS_DATA_DIR` value to use when launching Basecamp locally.
+
+If Nix is available and you also want packaging outputs:
+
+```bash
+logos-scaffold build --artifact all
+```
 
 ## Troubleshooting
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,6 +9,7 @@ use crate::commands::client::cmd_client;
 use crate::commands::deploy::cmd_deploy;
 use crate::commands::doctor::cmd_doctor;
 use crate::commands::idl::cmd_idl;
+use crate::commands::install::cmd_install;
 use crate::commands::localnet::{cmd_localnet, LocalnetAction};
 use crate::commands::new::{cmd_new, NewCommand};
 use crate::commands::report::cmd_report;
@@ -55,6 +56,7 @@ enum Commands {
     Setup(SetupArgs),
     Build(BuildArgs),
     Deploy(DeployArgs),
+    Install(InstallArgs),
     Localnet(LocalnetArgs),
     Wallet(WalletArgs),
     Doctor(DoctorArgs),
@@ -72,7 +74,13 @@ struct NewArgs {
     #[arg(long, alias = "lssa-path")]
     lez_path: Option<PathBuf>,
     #[arg(long)]
+    module_builder_path: Option<PathBuf>,
+    #[arg(long)]
     cache_root: Option<PathBuf>,
+    #[arg(long)]
+    basecamp_data_root: Option<PathBuf>,
+    #[arg(long, default_value = "dev")]
+    basecamp_runtime: String,
     #[arg(long, default_value = "default", help = TEMPLATE_HELP.as_str())]
     template: String,
 }
@@ -85,6 +93,8 @@ struct BuildArgs {
     #[command(subcommand)]
     subcommand: Option<BuildSubcommand>,
     project_path: Option<PathBuf>,
+    #[arg(long, default_value = "raw")]
+    artifact: String,
 }
 
 #[derive(Debug, Subcommand)]
@@ -123,6 +133,11 @@ struct ReportArgs {
     out: Option<PathBuf>,
     #[arg(long, default_value_t = 500)]
     tail: usize,
+}
+
+#[derive(Debug, clap::Args)]
+struct InstallArgs {
+    project_path: Option<PathBuf>,
 }
 
 #[derive(Debug, clap::Args)]
@@ -229,7 +244,10 @@ pub(crate) fn run(args: Vec<String>) -> DynResult<()> {
             name: args.name,
             vendor_deps: args.vendor_deps,
             lez_path: args.lez_path,
+            module_builder_path: args.module_builder_path,
             cache_root: args.cache_root,
+            basecamp_data_root: args.basecamp_data_root,
+            basecamp_runtime: args.basecamp_runtime,
             template: args.template,
         }),
         Some(Commands::Setup(_)) => cmd_setup(),
@@ -244,9 +262,10 @@ pub(crate) fn run(args: Vec<String>) -> DynResult<()> {
                     .map(|p| vec!["build".to_string(), p.to_string_lossy().to_string()])
                     .unwrap_or_else(|| vec!["build".to_string()]),
             ),
-            None => cmd_build_shortcut(args.project_path),
+            None => cmd_build_shortcut(args.project_path, args.artifact),
         },
         Some(Commands::Deploy(args)) => cmd_deploy(args.program_name, args.program_path, args.json),
+        Some(Commands::Install(args)) => cmd_install(args.project_path),
         Some(Commands::Localnet(localnet)) => {
             let action = match localnet.command {
                 LocalnetSubcommand::Start(args) => LocalnetAction::Start {

--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -1,0 +1,353 @@
+use std::env;
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{anyhow, bail};
+use serde::Deserialize;
+
+use crate::constants::BASECAMP_RUNTIME_PORTABLE;
+use crate::process::{run_checked, which};
+use crate::project::ensure_basecamp_qml_project;
+use crate::repo::{sync_repo_to_pin, RepoSyncOptions};
+use crate::DynResult;
+
+const RAW_STAGE_REL_PATH: &str = ".scaffold/build/raw/plugins";
+const IGNORED_ENTRY_NAMES: &[&str] = &[
+    ".git",
+    ".scaffold",
+    "build",
+    "node_modules",
+    "result",
+    "target",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BasecampBuildArtifact {
+    Raw,
+    All,
+}
+
+#[derive(Debug)]
+pub(crate) struct StagedPlugin {
+    pub(crate) plugin_name: String,
+    pub(crate) stage_dir: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+struct BasecampPluginMetadata {
+    name: String,
+    #[serde(rename = "type")]
+    plugin_type: String,
+    view: String,
+    #[serde(default)]
+    icon: String,
+    #[serde(default)]
+    main: String,
+}
+
+pub(crate) fn parse_basecamp_build_artifact(value: &str) -> DynResult<BasecampBuildArtifact> {
+    match value {
+        "raw" => Ok(BasecampBuildArtifact::Raw),
+        "all" => Ok(BasecampBuildArtifact::All),
+        other => bail!("unsupported build artifact `{other}`. Expected `raw` or `all`."),
+    }
+}
+
+pub(crate) fn cmd_setup_basecamp(project: &mut crate::model::Project) -> DynResult<()> {
+    ensure_basecamp_qml_project(project, "logos-scaffold setup")?;
+    let repo = project
+        .config
+        .logos_module_builder
+        .as_mut()
+        .ok_or_else(|| anyhow!("invalid scaffold.toml: missing [repos.logos_module_builder]"))?;
+
+    fs::create_dir_all(project.root.join(".scaffold/state"))?;
+    fs::create_dir_all(project.root.join(".scaffold/logs"))?;
+    fs::create_dir_all(project.root.join(".scaffold/build"))?;
+    fs::create_dir_all(project.root.join(".scaffold/runtime"))?;
+    let cache_root = PathBuf::from(&project.config.cache_root);
+    let repo_path = PathBuf::from(&repo.path);
+    let sync_opts = if is_cache_managed_repo_path(&cache_root, &repo_path) {
+        RepoSyncOptions::auto_reclone_cache_repo()
+    } else {
+        RepoSyncOptions::fail_on_source_mismatch()
+    };
+    sync_repo_to_pin(
+        repo,
+        "logos-module-builder",
+        sync_opts,
+    )?;
+
+    println!("setup complete");
+    println!("  logos-module-builder: {}", repo.path);
+    println!("  pin: {}", repo.pin);
+    Ok(())
+}
+
+pub(crate) fn build_basecamp_qml_project(
+    project: &crate::model::Project,
+    artifact: BasecampBuildArtifact,
+) -> DynResult<()> {
+    ensure_basecamp_qml_project(project, "logos-scaffold build")?;
+    let staged = stage_raw_plugin_bundle(project)?;
+
+    println!(
+        "Raw plugin staged for {} at {}",
+        staged.plugin_name,
+        staged.stage_dir.display()
+    );
+
+    if artifact == BasecampBuildArtifact::All {
+        if which("nix").is_none() {
+            bail!(
+                "Nix is required for `logos-scaffold build --artifact all`.\nNext step: install `nix`, or rerun `logos-scaffold build --artifact raw`."
+            );
+        }
+
+        run_checked(
+            Command::new("nix")
+                .current_dir(&project.root)
+                .arg("build")
+                .arg(".#lgx"),
+            "nix build .#lgx",
+        )?;
+        run_checked(
+            Command::new("nix")
+                .current_dir(&project.root)
+                .arg("build")
+                .arg(".#lgx-portable"),
+            "nix build .#lgx-portable",
+        )?;
+    }
+
+    Ok(())
+}
+
+pub(crate) fn install_basecamp_qml_project(project: &crate::model::Project) -> DynResult<()> {
+    ensure_basecamp_qml_project(project, "logos-scaffold install")?;
+    let metadata = load_plugin_metadata(project)?;
+    let staged_dir = raw_stage_root(project).join(&metadata.name);
+    if !staged_dir.exists() {
+        bail!(
+            "missing staged raw plugin at {}\nNext step: run `logos-scaffold build` first.",
+            staged_dir.display()
+        );
+    }
+
+    let target_dir = resolve_runtime_plugin_dir(project, &metadata.name);
+    if target_dir.exists() {
+        fs::remove_dir_all(&target_dir)?;
+    }
+    copy_dir_recursive(&staged_dir, &target_dir)?;
+
+    println!("Installed Basecamp plugin");
+    println!("  Plugin: {}", metadata.name);
+    println!("  Target: {}", target_dir.display());
+    println!("  LOGOS_DATA_DIR={}", resolve_data_root(project).display());
+    println!("  Launch Basecamp with that `LOGOS_DATA_DIR` to load the plugin.");
+    Ok(())
+}
+
+pub(crate) fn resolve_runtime_plugin_dir(
+    project: &crate::model::Project,
+    plugin_name: &str,
+) -> PathBuf {
+    runtime_base_dir(project).join("plugins").join(plugin_name)
+}
+
+pub(crate) fn resolve_data_root(project: &crate::model::Project) -> PathBuf {
+    let configured = PathBuf::from(&project.config.basecamp.data_root);
+    if configured.is_absolute() {
+        configured
+    } else {
+        project.root.join(configured)
+    }
+}
+
+pub(crate) fn runtime_base_dir(project: &crate::model::Project) -> PathBuf {
+    let data_root = resolve_data_root(project);
+    if project.config.basecamp.runtime_variant == BASECAMP_RUNTIME_PORTABLE {
+        return data_root;
+    }
+
+    PathBuf::from(format!("{}Dev", data_root.to_string_lossy()))
+}
+
+pub(crate) fn raw_stage_root(project: &crate::model::Project) -> PathBuf {
+    project.root.join(RAW_STAGE_REL_PATH)
+}
+
+fn stage_raw_plugin_bundle(project: &crate::model::Project) -> DynResult<StagedPlugin> {
+    let metadata = load_plugin_metadata(project)?;
+    validate_metadata_files(project, &metadata)?;
+    maybe_run_qmllint(project, &metadata.view)?;
+
+    let stage_root = raw_stage_root(project);
+    fs::create_dir_all(&stage_root)?;
+
+    let stage_dir = stage_root.join(&metadata.name);
+    if stage_dir.exists() {
+        fs::remove_dir_all(&stage_dir)?;
+    }
+    copy_project_tree(&project.root, &stage_dir, Path::new(""))?;
+
+    Ok(StagedPlugin {
+        plugin_name: metadata.name,
+        stage_dir,
+    })
+}
+
+fn load_plugin_metadata(project: &crate::model::Project) -> DynResult<BasecampPluginMetadata> {
+    let path = project.root.join("metadata.json");
+    let text = fs::read_to_string(&path)?;
+    let metadata: BasecampPluginMetadata = serde_json::from_str(&text)
+        .map_err(|err| anyhow!("invalid metadata.json at {}: {err}", path.display()))?;
+
+    if metadata.name.trim().is_empty() {
+        bail!("metadata.json must contain a non-empty `name`");
+    }
+    if metadata.plugin_type != "ui_qml" {
+        bail!(
+            "basecamp-qml v1 only supports `type: \"ui_qml\"`; found `{}`",
+            metadata.plugin_type
+        );
+    }
+    if metadata.view.trim().is_empty() {
+        bail!("metadata.json must contain a non-empty `view`");
+    }
+    if !metadata.main.trim().is_empty() {
+        bail!(
+            "basecamp-qml v1 only supports QML-only plugins. Remove `main` from metadata.json before building."
+        );
+    }
+
+    Ok(metadata)
+}
+
+fn validate_metadata_files(
+    project: &crate::model::Project,
+    metadata: &BasecampPluginMetadata,
+) -> DynResult<()> {
+    let view_path = project.root.join(&metadata.view);
+    if !view_path.exists() {
+        bail!("QML entry file not found at {}", view_path.display());
+    }
+
+    if !metadata.icon.trim().is_empty() {
+        let icon_path = project.root.join(&metadata.icon);
+        if !icon_path.exists() {
+            bail!("plugin icon not found at {}", icon_path.display());
+        }
+    }
+
+    Ok(())
+}
+
+fn maybe_run_qmllint(project: &crate::model::Project, view: &str) -> DynResult<()> {
+    let Some(qmllint) = which("qmllint") else {
+        println!("warning: `qmllint` not found in PATH; skipping QML lint");
+        return Ok(());
+    };
+
+    let output = Command::new(qmllint)
+        .current_dir(&project.root)
+        .arg(view)
+        .output()?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    println!("warning: `qmllint {view}` reported issues");
+    if !stdout.is_empty() {
+        println!("{stdout}");
+    }
+    if !stderr.is_empty() {
+        println!("{stderr}");
+    }
+    Ok(())
+}
+
+fn copy_project_tree(src_root: &Path, dst_root: &Path, relative: &Path) -> DynResult<()> {
+    let src_dir = src_root.join(relative);
+    fs::create_dir_all(dst_root)?;
+
+    for entry in fs::read_dir(&src_dir)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let rel_path = relative.join(&name);
+        let src_path = src_root.join(&rel_path);
+        let dst_path = dst_root.join(&name);
+
+        if should_skip_entry(&name) {
+            continue;
+        }
+
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            copy_project_tree(src_root, &dst_path, &rel_path)?;
+        } else if file_type.is_file() {
+            if let Some(parent) = dst_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::copy(src_path, dst_path)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) -> DynResult<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            copy_dir_recursive(&src_path, &dst_path)?;
+        } else if file_type.is_file() {
+            if let Some(parent) = dst_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::copy(src_path, dst_path)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn should_skip_entry(name: &OsStr) -> bool {
+    let value = name.to_string_lossy();
+    if IGNORED_ENTRY_NAMES.contains(&value.as_ref()) {
+        return true;
+    }
+    value.starts_with("result-")
+}
+
+fn is_cache_managed_repo_path(cache_root: &Path, repo_path: &Path) -> bool {
+    let cache_repos = normalize_path(cache_root).join("repos");
+    let repo = normalize_path(repo_path);
+    repo.starts_with(cache_repos)
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    if let Ok(canonical) = path.canonicalize() {
+        return canonical;
+    }
+
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        env::current_dir()
+            .map(|cwd| cwd.join(path))
+            .unwrap_or_else(|_| path.to_path_buf())
+    }
+}

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -3,36 +3,47 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
+use crate::commands::basecamp::{build_basecamp_qml_project, parse_basecamp_build_artifact};
 use crate::commands::client::generate_clients_from_current_idl;
 use crate::commands::idl::build_idl_for_current_project;
 use crate::commands::setup::cmd_setup;
-use crate::constants::{FRAMEWORK_KIND_DEFAULT, FRAMEWORK_KIND_LEZ_FRAMEWORK};
+use crate::constants::{
+    FRAMEWORK_KIND_DEFAULT, FRAMEWORK_KIND_LEZ_FRAMEWORK, PROJECT_KIND_BASECAMP_QML,
+    PROJECT_KIND_LEZ,
+};
 use crate::process::run_checked;
 use crate::project::{load_project, run_in_project_dir};
 use crate::DynResult;
 
-pub(crate) fn cmd_build_shortcut(project_dir: Option<PathBuf>) -> DynResult<()> {
+pub(crate) fn cmd_build_shortcut(project_dir: Option<PathBuf>, artifact: String) -> DynResult<()> {
     run_in_project_dir(project_dir.as_deref(), || {
         cmd_setup()?;
         let cwd = env::current_dir()?;
 
         let project = load_project()?;
-        match project.config.framework.kind.as_str() {
-            FRAMEWORK_KIND_DEFAULT => {
-                build_workspace_for_current_project(&cwd)?;
+        match project.config.project.kind.as_str() {
+            PROJECT_KIND_LEZ => match project.config.framework.kind.as_str() {
+                FRAMEWORK_KIND_DEFAULT => {
+                    build_workspace_for_current_project(&cwd)?;
+                }
+                FRAMEWORK_KIND_LEZ_FRAMEWORK => {
+                    build_workspace_for_current_project(&cwd)?;
+                    build_idl_for_current_project()?;
+                    generate_clients_from_current_idl()?;
+                }
+                other => {
+                    build_workspace_for_current_project(&cwd)?;
+                    println!(
+                        "Skipping framework-specific build steps for framework kind `{}`",
+                        other
+                    );
+                }
+            },
+            PROJECT_KIND_BASECAMP_QML => {
+                let artifact = parse_basecamp_build_artifact(&artifact)?;
+                build_basecamp_qml_project(&project, artifact)?;
             }
-            FRAMEWORK_KIND_LEZ_FRAMEWORK => {
-                build_workspace_for_current_project(&cwd)?;
-                build_idl_for_current_project()?;
-                generate_clients_from_current_idl()?;
-            }
-            other => {
-                build_workspace_for_current_project(&cwd)?;
-                println!(
-                    "Skipping framework-specific build steps for framework kind `{}`",
-                    other
-                );
-            }
+            other => anyhow::bail!("unsupported project kind `{other}` for `logos-scaffold build`"),
         }
 
         Ok(())

--- a/src/commands/client.rs
+++ b/src/commands/client.rs
@@ -8,7 +8,7 @@ use crate::commands::idl::build_idl_for_current_project;
 use crate::constants::FRAMEWORK_KIND_LEZ_FRAMEWORK;
 use crate::model::Project;
 use crate::process::run_checked;
-use crate::project::{load_project, run_in_project_dir};
+use crate::project::{ensure_lez_project, load_project, run_in_project_dir};
 use crate::DynResult;
 
 pub(crate) fn cmd_client(args: &[String]) -> DynResult<()> {
@@ -48,6 +48,7 @@ pub(crate) fn generate_clients_from_current_idl() -> DynResult<()> {
 
 fn load_lez_framework_project_for_client_build() -> DynResult<Option<Project>> {
     let project = load_project()?;
+    ensure_lez_project(&project, "logos-scaffold build client")?;
     if project.config.framework.kind == FRAMEWORK_KIND_LEZ_FRAMEWORK {
         return Ok(Some(project));
     }

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -5,7 +5,7 @@ use std::process::Command;
 use anyhow::{bail, Context};
 
 use crate::process::run_with_stdin;
-use crate::project::load_project;
+use crate::project::{ensure_lez_project, load_project};
 use crate::DynResult;
 
 use super::wallet_support::{
@@ -25,6 +25,7 @@ pub(crate) fn cmd_deploy(
     let project = load_project().context(
         "This command must be run inside a logos-scaffold project.\nNext step: cd into your scaffolded project directory and retry.",
     )?;
+    ensure_lez_project(&project, "logos-scaffold deploy")?;
     let wallet = load_wallet_runtime(&project)?;
 
     let sequencer_addr = wallet

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -13,7 +13,7 @@ use crate::doctor_checks::{
 };
 use crate::model::{CheckRow, CheckStatus, DoctorReport, DoctorSummary};
 use crate::process::{pid_running, run_capture, run_with_stdin, set_command_echo};
-use crate::project::load_project;
+use crate::project::{ensure_lez_project, load_project, require_lez_repo};
 use crate::state::read_localnet_state;
 use crate::DynResult;
 
@@ -70,7 +70,9 @@ fn cmd_doctor_inner(as_json: bool) -> DynResult<()> {
 
 pub(crate) fn build_doctor_report() -> DynResult<DoctorReport> {
     let project = load_project()?;
-    let lez = PathBuf::from(&project.config.lez.path);
+    ensure_lez_project(&project, "logos-scaffold doctor")?;
+    let lez_repo = require_lez_repo(&project, "logos-scaffold doctor")?;
+    let lez = PathBuf::from(&lez_repo.path);
     let wallet_home = project.root.join(&project.config.wallet_home_dir);
     let localnet_state_path = project.root.join(".scaffold/state/localnet.state");
 
@@ -84,10 +86,10 @@ pub(crate) fn build_doctor_report() -> DynResult<DoctorReport> {
     rows.push(check_binary("kill", true));
     rows.push(check_container_runtime());
 
-    rows.push(check_repo("lez", &lez, &project.config.lez.pin));
+    rows.push(check_repo("lez", &lez, &lez_repo.pin));
 
     rows.push(CheckRow {
-        status: if project.config.lez.pin == DEFAULT_LEZ_PIN {
+        status: if lez_repo.pin == DEFAULT_LEZ_PIN {
             CheckStatus::Pass
         } else {
             CheckStatus::Warn
@@ -95,9 +97,9 @@ pub(crate) fn build_doctor_report() -> DynResult<DoctorReport> {
         name: "lez standalone pin".to_string(),
         detail: format!(
             "configured pin={} expected={}",
-            project.config.lez.pin, DEFAULT_LEZ_PIN
+            lez_repo.pin, DEFAULT_LEZ_PIN
         ),
-        remediation: if project.config.lez.pin == DEFAULT_LEZ_PIN {
+        remediation: if lez_repo.pin == DEFAULT_LEZ_PIN {
             None
         } else {
             Some(format!(

--- a/src/commands/idl.rs
+++ b/src/commands/idl.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, bail};
 
 use crate::constants::FRAMEWORK_KIND_LEZ_FRAMEWORK;
 use crate::process::run_capture;
-use crate::project::{load_project, run_in_project_dir};
+use crate::project::{ensure_lez_project, load_project, run_in_project_dir};
 use crate::state::write_text;
 use crate::DynResult;
 
@@ -30,6 +30,7 @@ pub(crate) fn cmd_idl(args: &[String]) -> DynResult<()> {
 
 pub(crate) fn build_idl_for_current_project() -> DynResult<()> {
     let project = load_project()?;
+    ensure_lez_project(&project, "logos-scaffold build idl")?;
     if project.config.framework.kind != FRAMEWORK_KIND_LEZ_FRAMEWORK {
         println!(
             "Skipping IDL build for framework kind `{}`",

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -1,0 +1,13 @@
+use std::path::PathBuf;
+
+use crate::commands::basecamp::install_basecamp_qml_project;
+use crate::project::{ensure_basecamp_qml_project, load_project, run_in_project_dir};
+use crate::DynResult;
+
+pub(crate) fn cmd_install(project_dir: Option<PathBuf>) -> DynResult<()> {
+    run_in_project_dir(project_dir.as_deref(), || {
+        let project = load_project()?;
+        ensure_basecamp_qml_project(&project, "logos-scaffold install")?;
+        install_basecamp_qml_project(&project)
+    })
+}

--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -12,7 +12,7 @@ use crate::constants::{SEQUENCER_BIN_REL_PATH, SEQUENCER_CONFIG_REL_PATH};
 use crate::error::LocalnetError;
 use crate::model::{LocalnetOwnership, LocalnetState, LocalnetStatusReport, Project};
 use crate::process::{listener_pid, pid_alive, pid_command, pid_running, port_open, spawn_to_log};
-use crate::project::{ensure_dir_exists, find_project_root, load_project};
+use crate::project::{ensure_dir_exists, ensure_lez_project, find_project_root, load_project};
 use crate::state::{read_localnet_state, write_localnet_state};
 use crate::DynResult;
 
@@ -56,10 +56,18 @@ pub(crate) fn build_localnet_status_for_project(project: &Project) -> LocalnetSt
 }
 
 fn cmd_localnet_in_project(project: &Project, action: LocalnetAction) -> DynResult<()> {
+    ensure_lez_project(project, "logos-scaffold localnet")?;
     let localnet_port = project.config.localnet.port;
     let risc0_dev_mode = project.config.localnet.risc0_dev_mode;
     let localnet_addr = format!("127.0.0.1:{localnet_port}");
-    let lez = PathBuf::from(&project.config.lez.path);
+    let lez = PathBuf::from(
+        &project
+            .config
+            .lez
+            .as_ref()
+            .expect("LEZ project should have repo")
+            .path,
+    );
     let state_path = project.root.join(".scaffold/state/localnet.state");
     let logs_dir = project.root.join(".scaffold/logs");
     let log_path = logs_dir.join("sequencer.log");

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,8 +1,10 @@
+pub(crate) mod basecamp;
 pub(crate) mod build;
 pub(crate) mod client;
 pub(crate) mod deploy;
 pub(crate) mod doctor;
 pub(crate) mod idl;
+pub(crate) mod install;
 pub(crate) mod localnet;
 pub(crate) mod new;
 pub(crate) mod report;

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -6,10 +6,15 @@ use anyhow::{bail, Context};
 
 use crate::config::serialize_config;
 use crate::constants::{
-    DEFAULT_FRAMEWORK_IDL_PATH, DEFAULT_FRAMEWORK_IDL_SPEC, DEFAULT_FRAMEWORK_VERSION,
-    DEFAULT_LEZ_PIN, FRAMEWORK_KIND_DEFAULT, FRAMEWORK_KIND_LEZ_FRAMEWORK, LEZ_URL, VERSION,
+    BASECAMP_RUNTIME_DEV, BASECAMP_RUNTIME_PORTABLE, DEFAULT_BASECAMP_DATA_ROOT, DEFAULT_FRAMEWORK_IDL_PATH,
+    DEFAULT_FRAMEWORK_IDL_SPEC, DEFAULT_FRAMEWORK_VERSION, DEFAULT_LEZ_PIN,
+    DEFAULT_LOGOS_MODULE_BUILDER_PIN, FRAMEWORK_KIND_DEFAULT, FRAMEWORK_KIND_LEZ_FRAMEWORK,
+    LEZ_URL, LOGOS_MODULE_BUILDER_URL, PROJECT_KIND_BASECAMP_QML, PROJECT_KIND_LEZ, VERSION,
 };
-use crate::model::{Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig, RepoRef};
+use crate::model::{
+    BasecampConfig, Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig, ProjectConfig,
+    RepoRef,
+};
 use crate::project::default_cache_root;
 use crate::repo::{sync_repo_to_pin_at_path_with_opts, RepoSyncOptions};
 use crate::state::write_text;
@@ -23,79 +28,63 @@ pub(crate) struct NewCommand {
     pub(crate) template: String,
     pub(crate) vendor_deps: bool,
     pub(crate) lez_path: Option<PathBuf>,
+    pub(crate) module_builder_path: Option<PathBuf>,
     pub(crate) cache_root: Option<PathBuf>,
+    pub(crate) basecamp_data_root: Option<PathBuf>,
+    pub(crate) basecamp_runtime: String,
 }
 
 pub(crate) fn cmd_new(cmd: NewCommand) -> DynResult<()> {
-    let template_variant = match cmd.template.as_str() {
-        FRAMEWORK_KIND_DEFAULT | FRAMEWORK_KIND_LEZ_FRAMEWORK => cmd.template.clone(),
-        other => {
-            bail!("unsupported template `{other}`. Expected `default` or `lez-framework`.")
-        }
-    };
+    match cmd.template.as_str() {
+        FRAMEWORK_KIND_DEFAULT | FRAMEWORK_KIND_LEZ_FRAMEWORK => create_lez_project(cmd),
+        PROJECT_KIND_BASECAMP_QML => create_basecamp_qml_project(cmd),
+        other => bail!(
+            "unsupported template `{other}`. Expected `default`, `lez-framework`, or `basecamp-qml`."
+        ),
+    }
+}
 
+fn create_lez_project(cmd: NewCommand) -> DynResult<()> {
+    let template_variant = cmd.template;
     let cwd = env::current_dir()?;
     let target = cwd.join(&cmd.name);
-    let crate_name = {
-        let fallback = "app";
-        let file_name = target
-            .file_name()
-            .and_then(|s| s.to_str())
-            .unwrap_or(fallback);
-        to_cargo_crate_name(file_name)
-    };
+    let crate_name = to_cargo_crate_name(target_file_name_or(&target, "app"));
 
     if target.exists() {
         bail!("target exists: {}", target.display());
     }
 
-    fs::create_dir_all(target.join(".scaffold/state"))?;
-    fs::create_dir_all(target.join(".scaffold/logs"))?;
+    create_common_scaffold_dirs(&target)?;
 
-    let cache_root = cmd.cache_root.unwrap_or(default_cache_root()?);
-    fs::create_dir_all(cache_root.join("repos"))?;
-    fs::create_dir_all(cache_root.join("state"))?;
-    fs::create_dir_all(cache_root.join("logs"))?;
-    fs::create_dir_all(cache_root.join("builds"))?;
-
+    let cache_root = ensure_cache_root(cmd.cache_root)?;
     let lez_source = cmd
         .lez_path
-        .map(|p| p.display().to_string())
+        .map(|path| path.display().to_string())
         .unwrap_or_else(|| LEZ_URL.to_string());
 
-    let lez_repo_path = if cmd.vendor_deps {
-        let root = target.join(".scaffold/repos");
-        fs::create_dir_all(&root)?;
-        let lez_vendor = root.join("lez");
-        sync_repo_to_pin_at_path_with_opts(
-            &lez_vendor,
-            &lez_source,
-            DEFAULT_LEZ_PIN,
-            "lez",
-            RepoSyncOptions::fail_on_source_mismatch(),
-        )?;
-        lez_vendor
-    } else {
-        let lez_cached = cache_root.join("repos/lez").join(DEFAULT_LEZ_PIN);
-        sync_repo_to_pin_at_path_with_opts(
-            &lez_cached,
-            &lez_source,
-            DEFAULT_LEZ_PIN,
-            "lez",
-            RepoSyncOptions::auto_reclone_cache_repo(),
-        )?;
-        lez_cached
-    };
+    let lez_repo_path = prepare_repo_path(
+        &target,
+        &cache_root,
+        cmd.vendor_deps,
+        "lez",
+        DEFAULT_LEZ_PIN,
+        &lez_source,
+        RepoSyncOptions::auto_reclone_cache_repo(),
+    )?;
 
     let cfg = Config {
         version: VERSION.to_string(),
         cache_root: cache_root.display().to_string(),
-        lez: RepoRef {
+        project: ProjectConfig {
+            kind: PROJECT_KIND_LEZ.to_string(),
+        },
+        lez: Some(RepoRef {
             url: LEZ_URL.to_string(),
             source: lez_source,
             path: lez_repo_path.display().to_string(),
             pin: DEFAULT_LEZ_PIN.to_string(),
-        },
+        }),
+        logos_module_builder: None,
         wallet_home_dir: ".scaffold/wallet".to_string(),
         framework: FrameworkConfig {
             kind: template_variant.clone(),
@@ -106,6 +95,10 @@ pub(crate) fn cmd_new(cmd: NewCommand) -> DynResult<()> {
             },
         },
         localnet: LocalnetConfig::default(),
+        basecamp: BasecampConfig {
+            data_root: DEFAULT_BASECAMP_DATA_ROOT.to_string(),
+            runtime_variant: BASECAMP_RUNTIME_DEV.to_string(),
+        },
     };
 
     let template_root = lez_repo_path.join("examples/program_deployment");
@@ -117,10 +110,13 @@ pub(crate) fn cmd_new(cmd: NewCommand) -> DynResult<()> {
     if template_variant == FRAMEWORK_KIND_DEFAULT {
         patch_simple_tail_call_program_id(&target)?;
     }
-    let overlay_ctx = OverlayRenderContext {
-        crate_name: &crate_name,
-        lez_pin: &cfg.lez.pin,
-    };
+
+    let overlay_ctx = build_overlay_context(
+        &cmd.name,
+        &cfg,
+        &crate_name,
+        "",
+    );
     apply_overlay(&target, &template_variant, &overlay_ctx)?;
     if template_variant == FRAMEWORK_KIND_LEZ_FRAMEWORK {
         cleanup_lez_hello_artifacts(&target)?;
@@ -138,10 +134,178 @@ pub(crate) fn cmd_new(cmd: NewCommand) -> DynResult<()> {
         target.display()
     );
     println!("Cache root: {}", cfg.cache_root);
-    println!("Pinned lez: {}", cfg.lez.pin);
+    if let Some(lez) = &cfg.lez {
+        println!("Pinned lez: {}", lez.pin);
+    }
     println!("Template variant: {}", cfg.framework.kind);
 
     Ok(())
+}
+
+fn create_basecamp_qml_project(cmd: NewCommand) -> DynResult<()> {
+    validate_basecamp_runtime(&cmd.basecamp_runtime)?;
+    let cwd = env::current_dir()?;
+    let target = cwd.join(&cmd.name);
+    let crate_name = to_cargo_crate_name(target_file_name_or(&target, "app"));
+    let plugin_name = to_plugin_name(&cmd.name);
+
+    if target.exists() {
+        bail!("target exists: {}", target.display());
+    }
+
+    create_common_scaffold_dirs(&target)?;
+    fs::create_dir_all(target.join(".scaffold/build"))?;
+    fs::create_dir_all(target.join(".scaffold/runtime"))?;
+
+    let cache_root = ensure_cache_root(cmd.cache_root)?;
+    let module_builder_source = cmd
+        .module_builder_path
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| LOGOS_MODULE_BUILDER_URL.to_string());
+    let module_builder_repo_path = prepare_repo_path(
+        &target,
+        &cache_root,
+        cmd.vendor_deps,
+        "logos-module-builder",
+        DEFAULT_LOGOS_MODULE_BUILDER_PIN,
+        &module_builder_source,
+        RepoSyncOptions::auto_reclone_cache_repo(),
+    )?;
+
+    let basecamp_data_root = cmd
+        .basecamp_data_root
+        .unwrap_or_else(|| target.join(DEFAULT_BASECAMP_DATA_ROOT));
+
+    let cfg = Config {
+        version: VERSION.to_string(),
+        cache_root: cache_root.display().to_string(),
+        project: ProjectConfig {
+            kind: PROJECT_KIND_BASECAMP_QML.to_string(),
+        },
+        lez: None,
+        logos_module_builder: Some(RepoRef {
+            url: LOGOS_MODULE_BUILDER_URL.to_string(),
+            source: module_builder_source,
+            path: module_builder_repo_path.display().to_string(),
+            pin: DEFAULT_LOGOS_MODULE_BUILDER_PIN.to_string(),
+        }),
+        wallet_home_dir: ".scaffold/wallet".to_string(),
+        framework: FrameworkConfig {
+            kind: FRAMEWORK_KIND_DEFAULT.to_string(),
+            version: DEFAULT_FRAMEWORK_VERSION.to_string(),
+            idl: FrameworkIdlConfig {
+                spec: DEFAULT_FRAMEWORK_IDL_SPEC.to_string(),
+                path: DEFAULT_FRAMEWORK_IDL_PATH.to_string(),
+            },
+        },
+        localnet: LocalnetConfig::default(),
+        basecamp: BasecampConfig {
+            data_root: basecamp_data_root.display().to_string(),
+            runtime_variant: cmd.basecamp_runtime.clone(),
+        },
+    };
+
+    let module_builder_flake_url = format!("path:{}", module_builder_repo_path.display());
+    let overlay_ctx = build_overlay_context(
+        &cmd.name,
+        &cfg,
+        &crate_name,
+        &module_builder_flake_url,
+    );
+    apply_overlay(&target, PROJECT_KIND_BASECAMP_QML, &overlay_ctx)?;
+    write_text(&target.join("scaffold.toml"), &serialize_config(&cfg))?;
+
+    println!("Created Basecamp QML project at {}", target.display());
+    println!("Cache root: {}", cfg.cache_root);
+    if let Some(module_builder) = &cfg.logos_module_builder {
+        println!("Pinned logos-module-builder: {}", module_builder.pin);
+        println!("Module builder path: {}", module_builder.path);
+    }
+    println!("Plugin name: {plugin_name}");
+    println!("Basecamp data root: {}", cfg.basecamp.data_root);
+    println!("Basecamp runtime: {}", cfg.basecamp.runtime_variant);
+
+    Ok(())
+}
+
+fn validate_basecamp_runtime(value: &str) -> DynResult<()> {
+    match value {
+        BASECAMP_RUNTIME_DEV | BASECAMP_RUNTIME_PORTABLE => Ok(()),
+        other => bail!("unsupported Basecamp runtime `{other}`. Expected `dev` or `portable`."),
+    }
+}
+
+fn build_overlay_context(
+    raw_name: &str,
+    cfg: &Config,
+    crate_name: &str,
+    module_builder_flake_url: &str,
+) -> OverlayRenderContext {
+    let lez_pin = cfg
+        .lez
+        .as_ref()
+        .map(|repo| repo.pin.clone())
+        .unwrap_or_default();
+
+    OverlayRenderContext {
+        crate_name: crate_name.to_string(),
+        lez_pin,
+        plugin_name: to_plugin_name(raw_name),
+        project_title: to_project_title(raw_name),
+        module_builder_flake_url: module_builder_flake_url.to_string(),
+        basecamp_data_root: cfg.basecamp.data_root.clone(),
+        basecamp_runtime_variant: cfg.basecamp.runtime_variant.clone(),
+    }
+}
+
+fn prepare_repo_path(
+    project_root: &Path,
+    cache_root: &Path,
+    vendor_deps: bool,
+    repo_name: &str,
+    pin: &str,
+    source: &str,
+    cache_opts: RepoSyncOptions,
+) -> DynResult<PathBuf> {
+    if vendor_deps {
+        let root = project_root.join(".scaffold/repos");
+        fs::create_dir_all(&root)?;
+        let vendored = root.join(repo_name);
+        sync_repo_to_pin_at_path_with_opts(
+            &vendored,
+            source,
+            pin,
+            repo_name,
+            RepoSyncOptions::fail_on_source_mismatch(),
+        )?;
+        return Ok(vendored);
+    }
+
+    let cached = cache_root.join("repos").join(repo_name).join(pin);
+    sync_repo_to_pin_at_path_with_opts(&cached, source, pin, repo_name, cache_opts)?;
+    Ok(cached)
+}
+
+fn ensure_cache_root(cache_root: Option<PathBuf>) -> DynResult<PathBuf> {
+    let cache_root = cache_root.unwrap_or(default_cache_root()?);
+    fs::create_dir_all(cache_root.join("repos"))?;
+    fs::create_dir_all(cache_root.join("state"))?;
+    fs::create_dir_all(cache_root.join("logs"))?;
+    fs::create_dir_all(cache_root.join("builds"))?;
+    Ok(cache_root)
+}
+
+fn create_common_scaffold_dirs(target: &Path) -> DynResult<()> {
+    fs::create_dir_all(target.join(".scaffold/state"))?;
+    fs::create_dir_all(target.join(".scaffold/logs"))?;
+    Ok(())
+}
+
+fn target_file_name_or<'a>(target: &'a Path, fallback: &'a str) -> &'a str {
+    target
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or(fallback)
 }
 
 fn cleanup_lez_hello_artifacts(project_root: &Path) -> DynResult<()> {
@@ -201,9 +365,59 @@ pub(crate) fn to_cargo_crate_name(input: &str) -> String {
     }
 }
 
+pub(crate) fn to_plugin_name(input: &str) -> String {
+    let mut out = String::new();
+    let mut prev_sep = false;
+    for ch in input.chars() {
+        let mapped = if ch.is_ascii_alphanumeric() {
+            ch.to_ascii_lowercase()
+        } else {
+            '_'
+        };
+
+        if mapped == '_' {
+            if !prev_sep {
+                out.push('_');
+                prev_sep = true;
+            }
+        } else {
+            out.push(mapped);
+            prev_sep = false;
+        }
+    }
+
+    let out = out.trim_matches('_').to_string();
+    if out.is_empty() {
+        "basecamp_app".to_string()
+    } else {
+        out
+    }
+}
+
+fn to_project_title(input: &str) -> String {
+    let mut words = Vec::new();
+    for chunk in input.split(|ch: char| !ch.is_ascii_alphanumeric()) {
+        if chunk.is_empty() {
+            continue;
+        }
+        let mut chars = chunk.chars();
+        if let Some(first) = chars.next() {
+            let mut word = first.to_ascii_uppercase().to_string();
+            word.push_str(&chars.as_str().to_ascii_lowercase());
+            words.push(word);
+        }
+    }
+
+    if words.is_empty() {
+        "Basecamp App".to_string()
+    } else {
+        words.join(" ")
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::to_cargo_crate_name;
+    use super::{to_cargo_crate_name, to_plugin_name};
 
     #[test]
     fn simple_name_is_lowercased() {
@@ -246,5 +460,10 @@ mod tests {
     #[test]
     fn unicode_becomes_dash() {
         assert_eq!(to_cargo_crate_name("héllo"), "h-llo");
+    }
+
+    #[test]
+    fn plugin_name_uses_underscores() {
+        assert_eq!(to_plugin_name("Hello World"), "hello_world");
     }
 }

--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -18,7 +18,7 @@ use crate::model::{
     CollectedItem, RedactionSummary, ReportManifest, SkippedItem, ToolCommandResult,
 };
 use crate::process::{set_command_echo, which};
-use crate::project::load_project;
+use crate::project::{ensure_lez_project, load_project, require_lez_repo};
 use crate::state::write_text;
 use crate::DynResult;
 
@@ -29,6 +29,7 @@ pub(crate) fn cmd_report(out: Option<PathBuf>, tail: usize) -> DynResult<()> {
     let project = load_project().context(
         "This command must be run inside a logos-scaffold project.\nNext step: cd into your scaffolded project directory and retry.",
     )?;
+    ensure_lez_project(&project, "logos-scaffold report")?;
 
     let now = unix_timestamp_now()?;
     let output_path = resolve_output_path(&project.root, out, now)?;
@@ -752,7 +753,11 @@ fn collect_tool_versions(
         results.push(result);
     }
 
-    let lez = PathBuf::from(&project.config.lez.path);
+    let lez = PathBuf::from(
+        &require_lez_repo(project, "logos-scaffold report")
+            .expect("LEZ report should have repo")
+            .path,
+    );
     let wallet_binary = lez.join(crate::constants::WALLET_BIN_REL_PATH);
     let wallet_binary_str = wallet_binary.display().to_string();
     let (wallet_result, wallet_replacements) = collect_tool_command(

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -3,11 +3,13 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::process::run_checked;
-use crate::project::{ensure_dir_exists, load_project, save_project_config};
+use crate::constants::PROJECT_KIND_BASECAMP_QML;
+use crate::project::{ensure_dir_exists, load_project, require_lez_repo, save_project_config};
 use crate::repo::{sync_repo_to_pin, RepoSyncOptions};
 use crate::state::prepare_wallet_home;
 use crate::DynResult;
 
+use super::basecamp::cmd_setup_basecamp;
 use super::wallet_support::{
     first_public_wallet_address, read_default_wallet_address, wallet_state_path,
     write_default_wallet_address,
@@ -15,7 +17,14 @@ use super::wallet_support::{
 
 pub(crate) fn cmd_setup() -> DynResult<()> {
     let mut project = load_project()?;
-    let lez = PathBuf::from(&project.config.lez.path);
+    if project.config.project.kind == PROJECT_KIND_BASECAMP_QML {
+        let result = cmd_setup_basecamp(&mut project);
+        save_project_config(&project)?;
+        return result;
+    }
+
+    let lez_repo = require_lez_repo(&project, "logos-scaffold setup")?.clone();
+    let lez = PathBuf::from(&lez_repo.path);
     let cache_root = PathBuf::from(&project.config.cache_root);
     let sync_opts = if is_cache_managed_repo_path(&cache_root, &lez) {
         RepoSyncOptions::auto_reclone_cache_repo()
@@ -23,7 +32,9 @@ pub(crate) fn cmd_setup() -> DynResult<()> {
         RepoSyncOptions::fail_on_source_mismatch()
     };
 
-    sync_repo_to_pin(&mut project.config.lez, "lez", sync_opts)?;
+    if let Some(lez_repo) = project.config.lez.as_mut() {
+        sync_repo_to_pin(lez_repo, "lez", sync_opts)?;
+    }
 
     ensure_dir_exists(&lez, "lez")?;
 

--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 use anyhow::{bail, Context};
 
 use crate::process::{render_command, run_forwarded, run_with_stdin};
-use crate::project::load_project;
+use crate::project::{ensure_lez_project, load_project};
 use crate::DynResult;
 
 use super::wallet_support::{
@@ -34,6 +34,7 @@ pub(crate) fn cmd_wallet(action: WalletAction) -> DynResult<()> {
     let project = load_project().context(
         "This command must be run inside a logos-scaffold project.\nNext step: cd into your scaffolded project directory and retry.",
     )?;
+    ensure_lez_project(&project, "logos-scaffold wallet")?;
 
     match action {
         WalletAction::List { long } => cmd_wallet_list(&project, long),

--- a/src/commands/wallet_support.rs
+++ b/src/commands/wallet_support.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 
 use crate::constants::{DEFAULT_WALLET_PASSWORD, WALLET_BIN_REL_PATH};
 use crate::model::Project;
+use crate::project::require_lez_repo;
 use crate::state::write_text;
 use crate::DynResult;
 
@@ -21,7 +22,8 @@ pub(crate) struct WalletRuntimeContext {
 }
 
 pub(crate) fn load_wallet_runtime(project: &Project) -> DynResult<WalletRuntimeContext> {
-    let lez = PathBuf::from(&project.config.lez.path);
+    let lez_repo = require_lez_repo(project, "logos-scaffold wallet")?;
+    let lez = PathBuf::from(&lez_repo.path);
     let wallet_binary = lez.join(WALLET_BIN_REL_PATH);
     if !wallet_binary.exists() {
         bail!(
@@ -455,7 +457,7 @@ fn one_line(text: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{WALLET_CONFIG_FALLBACK, WALLET_CONFIG_PRIMARY};
+    use super::WALLET_CONFIG_PRIMARY;
     use std::fs;
 
     use tempfile::tempdir;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,14 @@
 use anyhow::bail;
 
 use crate::constants::{
-    DEFAULT_FRAMEWORK_IDL_PATH, DEFAULT_FRAMEWORK_IDL_SPEC, DEFAULT_FRAMEWORK_VERSION,
-    FRAMEWORK_KIND_DEFAULT, LEZ_URL,
+    BASECAMP_RUNTIME_DEV, DEFAULT_BASECAMP_DATA_ROOT, DEFAULT_FRAMEWORK_IDL_PATH,
+    DEFAULT_FRAMEWORK_IDL_SPEC, DEFAULT_FRAMEWORK_VERSION, FRAMEWORK_KIND_DEFAULT, LEZ_URL,
+    PROJECT_KIND_LEZ,
 };
-use crate::model::{Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig, RepoRef};
+use crate::model::{
+    BasecampConfig, Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig, ProjectConfig,
+    RepoRef,
+};
 use crate::DynResult;
 
 pub(crate) fn parse_config(text: &str) -> DynResult<Config> {
@@ -12,11 +16,17 @@ pub(crate) fn parse_config(text: &str) -> DynResult<Config> {
 
     let mut version = String::new();
     let mut cache_root = String::new();
+    let mut project_kind = String::new();
 
     let mut lez_url = String::new();
     let mut lez_source = String::new();
     let mut lez_path = String::new();
     let mut lez_pin = String::new();
+
+    let mut module_builder_url = String::new();
+    let mut module_builder_source = String::new();
+    let mut module_builder_path = String::new();
+    let mut module_builder_pin = String::new();
 
     let mut wallet_home_dir = String::new();
 
@@ -27,6 +37,9 @@ pub(crate) fn parse_config(text: &str) -> DynResult<Config> {
     let mut framework_version = String::new();
     let mut framework_idl_spec = String::new();
     let mut framework_idl_path = String::new();
+
+    let mut basecamp_data_root = String::new();
+    let mut basecamp_runtime_variant = String::new();
 
     for raw in text.lines() {
         let line = raw.trim();
@@ -51,6 +64,11 @@ pub(crate) fn parse_config(text: &str) -> DynResult<Config> {
                     cache_root = value;
                 }
             }
+            "project" => {
+                if key == "kind" {
+                    project_kind = value;
+                }
+            }
             "repos.lez" | "repos.lssa" => {
                 if key == "url" {
                     lez_url = value;
@@ -60,6 +78,17 @@ pub(crate) fn parse_config(text: &str) -> DynResult<Config> {
                     lez_path = value;
                 } else if key == "pin" {
                     lez_pin = value;
+                }
+            }
+            "repos.logos_module_builder" => {
+                if key == "url" {
+                    module_builder_url = value;
+                } else if key == "source" {
+                    module_builder_source = value;
+                } else if key == "path" {
+                    module_builder_path = value;
+                } else if key == "pin" {
+                    module_builder_pin = value;
                 }
             }
             "framework" => {
@@ -90,6 +119,13 @@ pub(crate) fn parse_config(text: &str) -> DynResult<Config> {
                     localnet_risc0_dev_mode = value != "false" && value != "0";
                 }
             }
+            "basecamp" => {
+                if key == "data_root" {
+                    basecamp_data_root = value;
+                } else if key == "runtime_variant" {
+                    basecamp_runtime_variant = value;
+                }
+            }
             _ => {}
         }
     }
@@ -98,13 +134,49 @@ pub(crate) fn parse_config(text: &str) -> DynResult<Config> {
         bail!("invalid scaffold.toml: missing [scaffold] keys");
     }
 
+    if project_kind.is_empty() {
+        project_kind = PROJECT_KIND_LEZ.to_string();
+    }
+
     if lez_url.is_empty() {
         lez_url = LEZ_URL.to_string();
     }
 
-    if lez_source.is_empty() || lez_path.is_empty() || lez_pin.is_empty() {
+    let lez = if lez_source.is_empty() && lez_path.is_empty() && lez_pin.is_empty() {
+        None
+    } else {
+        if lez_source.is_empty() || lez_path.is_empty() || lez_pin.is_empty() {
+            bail!("invalid scaffold.toml: missing required repos.lez keys (also accepts legacy repos.lssa)");
+        }
+        Some(RepoRef {
+            url: lez_url,
+            source: lez_source,
+            path: lez_path,
+            pin: lez_pin,
+        })
+    };
+
+    if project_kind == PROJECT_KIND_LEZ && lez.is_none() {
         bail!("invalid scaffold.toml: missing required repos.lez keys (also accepts legacy repos.lssa)");
     }
+
+    let logos_module_builder =
+        if module_builder_source.is_empty() && module_builder_path.is_empty() && module_builder_pin.is_empty() {
+            None
+        } else {
+            if module_builder_source.is_empty()
+                || module_builder_path.is_empty()
+                || module_builder_pin.is_empty()
+            {
+                bail!("invalid scaffold.toml: missing required repos.logos_module_builder keys");
+            }
+            Some(RepoRef {
+                url: module_builder_url,
+                source: module_builder_source,
+                path: module_builder_path,
+                pin: module_builder_pin,
+            })
+        };
 
     if wallet_home_dir.is_empty() {
         wallet_home_dir = ".scaffold/wallet".to_string();
@@ -123,15 +195,19 @@ pub(crate) fn parse_config(text: &str) -> DynResult<Config> {
         framework_idl_path = DEFAULT_FRAMEWORK_IDL_PATH.to_string();
     }
 
+    if basecamp_data_root.is_empty() {
+        basecamp_data_root = DEFAULT_BASECAMP_DATA_ROOT.to_string();
+    }
+    if basecamp_runtime_variant.is_empty() {
+        basecamp_runtime_variant = BASECAMP_RUNTIME_DEV.to_string();
+    }
+
     Ok(Config {
         version,
         cache_root,
-        lez: RepoRef {
-            url: lez_url,
-            source: lez_source,
-            path: lez_path,
-            pin: lez_pin,
-        },
+        project: ProjectConfig { kind: project_kind },
+        lez,
+        logos_module_builder,
         wallet_home_dir,
         localnet: LocalnetConfig {
             port: localnet_port,
@@ -145,18 +221,43 @@ pub(crate) fn parse_config(text: &str) -> DynResult<Config> {
                 path: framework_idl_path,
             },
         },
+        basecamp: BasecampConfig {
+            data_root: basecamp_data_root,
+            runtime_variant: basecamp_runtime_variant,
+        },
     })
 }
 
 pub(crate) fn serialize_config(cfg: &Config) -> String {
-    format!(
-        "[scaffold]\nversion = \"{}\"\ncache_root = \"{}\"\n\n[repos.lez]\nurl = \"{}\"\nsource = \"{}\"\npath = \"{}\"\npin = \"{}\"\n\n[wallet]\nhome_dir = \"{}\"\n\n[framework]\nkind = \"{}\"\nversion = \"{}\"\n\n[framework.idl]\nspec = \"{}\"\npath = \"{}\"\n\n[localnet]\nport = {}\nrisc0_dev_mode = {}\n",
+    let mut out = format!(
+        "[scaffold]\nversion = \"{}\"\ncache_root = \"{}\"\n\n[project]\nkind = \"{}\"\n",
         escape_toml_string(&cfg.version),
         escape_toml_string(&cfg.cache_root),
-        escape_toml_string(&cfg.lez.url),
-        escape_toml_string(&cfg.lez.source),
-        escape_toml_string(&cfg.lez.path),
-        escape_toml_string(&cfg.lez.pin),
+        escape_toml_string(&cfg.project.kind),
+    );
+
+    if let Some(lez) = &cfg.lez {
+        out.push_str(&format!(
+            "\n[repos.lez]\nurl = \"{}\"\nsource = \"{}\"\npath = \"{}\"\npin = \"{}\"\n",
+            escape_toml_string(&lez.url),
+            escape_toml_string(&lez.source),
+            escape_toml_string(&lez.path),
+            escape_toml_string(&lez.pin),
+        ));
+    }
+
+    if let Some(module_builder) = &cfg.logos_module_builder {
+        out.push_str(&format!(
+            "\n[repos.logos_module_builder]\nurl = \"{}\"\nsource = \"{}\"\npath = \"{}\"\npin = \"{}\"\n",
+            escape_toml_string(&module_builder.url),
+            escape_toml_string(&module_builder.source),
+            escape_toml_string(&module_builder.path),
+            escape_toml_string(&module_builder.pin),
+        ));
+    }
+
+    out.push_str(&format!(
+        "\n[wallet]\nhome_dir = \"{}\"\n\n[framework]\nkind = \"{}\"\nversion = \"{}\"\n\n[framework.idl]\nspec = \"{}\"\npath = \"{}\"\n\n[localnet]\nport = {}\nrisc0_dev_mode = {}\n\n[basecamp]\ndata_root = \"{}\"\nruntime_variant = \"{}\"\n",
         escape_toml_string(&cfg.wallet_home_dir),
         escape_toml_string(&cfg.framework.kind),
         escape_toml_string(&cfg.framework.version),
@@ -164,7 +265,11 @@ pub(crate) fn serialize_config(cfg: &Config) -> String {
         escape_toml_string(&cfg.framework.idl.path),
         cfg.localnet.port,
         cfg.localnet.risc0_dev_mode,
-    )
+        escape_toml_string(&cfg.basecamp.data_root),
+        escape_toml_string(&cfg.basecamp.runtime_variant),
+    ));
+
+    out
 }
 
 pub(crate) fn unquote(value: &str) -> String {
@@ -177,4 +282,70 @@ pub(crate) fn unquote(value: &str) -> String {
 
 pub(crate) fn escape_toml_string(s: &str) -> String {
     s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_config, serialize_config};
+    use crate::constants::{BASECAMP_RUNTIME_DEV, PROJECT_KIND_BASECAMP_QML, PROJECT_KIND_LEZ};
+
+    #[test]
+    fn legacy_lez_config_defaults_project_kind() {
+        let text = r#"
+[scaffold]
+version = "0.1.0"
+cache_root = "/tmp/cache"
+
+[repos.lez]
+url = "https://example.com/lez.git"
+source = "https://example.com/lez.git"
+path = "/tmp/lez"
+pin = "abc123"
+"#;
+
+        let cfg = parse_config(text).expect("parse legacy lez config");
+        assert_eq!(cfg.project.kind, PROJECT_KIND_LEZ);
+        assert!(cfg.lez.is_some());
+        assert!(cfg.logos_module_builder.is_none());
+    }
+
+    #[test]
+    fn basecamp_config_parses_and_round_trips() {
+        let text = r#"
+[scaffold]
+version = "0.1.0"
+cache_root = "/tmp/cache"
+
+[project]
+kind = "basecamp-qml"
+
+[repos.logos_module_builder]
+url = "https://github.com/logos-co/logos-module-builder.git"
+source = "/tmp/module-builder"
+path = "/tmp/cache/repos/logos-module-builder/pin"
+pin = "deadbeef"
+
+[basecamp]
+data_root = "/tmp/runtime/LogosBasecamp"
+runtime_variant = "dev"
+"#;
+
+        let cfg = parse_config(text).expect("parse basecamp config");
+        assert_eq!(cfg.project.kind, PROJECT_KIND_BASECAMP_QML);
+        assert!(cfg.lez.is_none());
+        assert_eq!(
+            cfg.logos_module_builder
+                .as_ref()
+                .expect("module builder")
+                .pin,
+            "deadbeef"
+        );
+        assert_eq!(cfg.basecamp.runtime_variant, BASECAMP_RUNTIME_DEV);
+
+        let serialized = serialize_config(&cfg);
+        let reparsed = parse_config(&serialized).expect("reparse serialized config");
+        assert_eq!(reparsed.project.kind, PROJECT_KIND_BASECAMP_QML);
+        assert_eq!(reparsed.basecamp.data_root, "/tmp/runtime/LogosBasecamp");
+        assert_eq!(reparsed.basecamp.runtime_variant, BASECAMP_RUNTIME_DEV);
+    }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,12 +1,21 @@
 pub(crate) const VERSION: &str = "0.1.0";
+pub(crate) const PROJECT_KIND_LEZ: &str = "lez";
+pub(crate) const PROJECT_KIND_BASECAMP_QML: &str = "basecamp-qml";
 pub(crate) const LEZ_URL: &str = "https://github.com/logos-blockchain/logos-execution-zone.git";
 pub(crate) const DEFAULT_LEZ_PIN: &str = "35d8df0d031315219f94d1546ceb862b0e5b208f";
+pub(crate) const LOGOS_MODULE_BUILDER_URL: &str =
+    "https://github.com/logos-co/logos-module-builder.git";
+pub(crate) const DEFAULT_LOGOS_MODULE_BUILDER_PIN: &str =
+    "9b97f6b05987ea4145d7632ada644a2ee8357c26";
 pub(crate) const DEFAULT_HELLO_WORLD_IMAGE_ID_HEX: &str =
     "4880b298f59699c1e4263c5c2245c80123632d608b9116f4b253c63e6c340771";
 pub(crate) const DEFAULT_WALLET_PASSWORD: &str = "logos-scaffold-v0";
 pub(crate) const WALLET_BIN_REL_PATH: &str = "target/release/wallet";
 pub(crate) const FRAMEWORK_KIND_DEFAULT: &str = "default";
 pub(crate) const FRAMEWORK_KIND_LEZ_FRAMEWORK: &str = "lez-framework";
+pub(crate) const BASECAMP_RUNTIME_DEV: &str = "dev";
+pub(crate) const BASECAMP_RUNTIME_PORTABLE: &str = "portable";
+pub(crate) const DEFAULT_BASECAMP_DATA_ROOT: &str = ".scaffold/runtime/LogosBasecamp";
 pub(crate) const DEFAULT_FRAMEWORK_VERSION: &str = "0.1.0";
 pub(crate) const DEFAULT_FRAMEWORK_IDL_SPEC: &str = "lssa-idl/0.1.0";
 pub(crate) const DEFAULT_FRAMEWORK_IDL_PATH: &str = "idl";

--- a/src/model.rs
+++ b/src/model.rs
@@ -11,6 +11,11 @@ pub(crate) struct RepoRef {
 }
 
 #[derive(Clone, Debug)]
+pub(crate) struct ProjectConfig {
+    pub(crate) kind: String,
+}
+
+#[derive(Clone, Debug)]
 pub(crate) struct LocalnetConfig {
     pub(crate) port: u16,
     pub(crate) risc0_dev_mode: bool,
@@ -26,13 +31,22 @@ impl Default for LocalnetConfig {
 }
 
 #[derive(Clone, Debug)]
+pub(crate) struct BasecampConfig {
+    pub(crate) data_root: String,
+    pub(crate) runtime_variant: String,
+}
+
+#[derive(Clone, Debug)]
 pub(crate) struct Config {
     pub(crate) version: String,
     pub(crate) cache_root: String,
-    pub(crate) lez: RepoRef,
+    pub(crate) project: ProjectConfig,
+    pub(crate) lez: Option<RepoRef>,
+    pub(crate) logos_module_builder: Option<RepoRef>,
     pub(crate) wallet_home_dir: String,
     pub(crate) framework: FrameworkConfig,
     pub(crate) localnet: LocalnetConfig,
+    pub(crate) basecamp: BasecampConfig,
 }
 
 #[derive(Clone, Debug)]

--- a/src/project.rs
+++ b/src/project.rs
@@ -4,8 +4,9 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail};
 
+use crate::constants::{PROJECT_KIND_BASECAMP_QML, PROJECT_KIND_LEZ};
 use crate::config::{parse_config, serialize_config};
-use crate::model::Project;
+use crate::model::{Project, RepoRef};
 use crate::state::write_text;
 use crate::DynResult;
 
@@ -43,6 +44,50 @@ pub(crate) fn save_project_config(project: &Project) -> DynResult<()> {
         &serialize_config(&project.config),
     )
 }
+
+pub(crate) fn project_kind(project: &Project) -> &str {
+    &project.config.project.kind
+}
+
+pub(crate) fn is_lez_project(project: &Project) -> bool {
+    project_kind(project) == PROJECT_KIND_LEZ
+}
+
+pub(crate) fn is_basecamp_qml_project(project: &Project) -> bool {
+    project_kind(project) == PROJECT_KIND_BASECAMP_QML
+}
+
+pub(crate) fn ensure_lez_project(project: &Project, command: &str) -> DynResult<()> {
+    if is_lez_project(project) {
+        return Ok(());
+    }
+
+    bail!(
+        "`{command}` is only supported for LEZ projects. This project uses kind `{}`.\nNext step: use `logos-scaffold build` and `logos-scaffold install` for Basecamp QML projects.",
+        project_kind(project),
+    )
+}
+
+pub(crate) fn ensure_basecamp_qml_project(project: &Project, command: &str) -> DynResult<()> {
+    if is_basecamp_qml_project(project) {
+        return Ok(());
+    }
+
+    bail!(
+        "`{command}` is only supported for Basecamp QML projects. This project uses kind `{}`.",
+        project_kind(project),
+    )
+}
+
+pub(crate) fn require_lez_repo<'a>(project: &'a Project, command: &str) -> DynResult<&'a RepoRef> {
+    ensure_lez_project(project, command)?;
+    project
+        .config
+        .lez
+        .as_ref()
+        .ok_or_else(|| anyhow!("invalid scaffold.toml: missing [repos.lez] for LEZ project"))
+}
+
 
 pub(crate) fn find_project_root(mut dir: PathBuf) -> Option<PathBuf> {
     loop {

--- a/src/template/project.rs
+++ b/src/template/project.rs
@@ -9,15 +9,20 @@ use crate::DynResult;
 
 static TEMPLATES_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/templates");
 
-pub(crate) struct OverlayRenderContext<'a> {
-    pub(crate) crate_name: &'a str,
-    pub(crate) lez_pin: &'a str,
+pub(crate) struct OverlayRenderContext {
+    pub(crate) crate_name: String,
+    pub(crate) lez_pin: String,
+    pub(crate) plugin_name: String,
+    pub(crate) project_title: String,
+    pub(crate) module_builder_flake_url: String,
+    pub(crate) basecamp_data_root: String,
+    pub(crate) basecamp_runtime_variant: String,
 }
 
 pub(crate) fn apply_overlay(
     target: &Path,
     variant: &str,
-    ctx: &OverlayRenderContext<'_>,
+    ctx: &OverlayRenderContext,
 ) -> DynResult<()> {
     apply_overlay_variant(target, variant, ctx)?;
     ensure_scaffold_in_gitignore(target)
@@ -45,7 +50,7 @@ fn ensure_scaffold_in_gitignore(target: &Path) -> DynResult<()> {
 fn apply_overlay_variant(
     target: &Path,
     variant: &str,
-    ctx: &OverlayRenderContext<'_>,
+    ctx: &OverlayRenderContext,
 ) -> DynResult<()> {
     let variant_dir = TEMPLATES_DIR
         .get_dir(variant)
@@ -58,7 +63,7 @@ fn apply_dir_recursive(
     dir: &Dir<'_>,
     target_root: &Path,
     relative: &Path,
-    ctx: &OverlayRenderContext<'_>,
+    ctx: &OverlayRenderContext,
 ) -> DynResult<()> {
     for file in dir.files() {
         let file_name = file
@@ -102,10 +107,18 @@ fn normalize_template_file_name(file_name: &std::ffi::OsStr) -> std::ffi::OsStri
     }
 }
 
-fn render_template_text(raw: &str, ctx: &OverlayRenderContext<'_>) -> DynResult<String> {
+fn render_template_text(raw: &str, ctx: &OverlayRenderContext) -> DynResult<String> {
     let rendered = raw
-        .replace("{{crate_name}}", ctx.crate_name)
-        .replace("{{lez_pin}}", ctx.lez_pin);
+        .replace("{{crate_name}}", &ctx.crate_name)
+        .replace("{{lez_pin}}", &ctx.lez_pin)
+        .replace("{{plugin_name}}", &ctx.plugin_name)
+        .replace("{{project_title}}", &ctx.project_title)
+        .replace("{{module_builder_flake_url}}", &ctx.module_builder_flake_url)
+        .replace("{{basecamp_data_root}}", &ctx.basecamp_data_root)
+        .replace(
+            "{{basecamp_runtime_variant}}",
+            &ctx.basecamp_runtime_variant,
+        );
 
     if let Some(token) = find_unresolved_placeholder(&rendered) {
         bail!("unresolved template token `{token}`");
@@ -166,8 +179,13 @@ mod tests {
     fn overlay_writes_expected_files() {
         let target = mk_temp_dir("files");
         let ctx = OverlayRenderContext {
-            crate_name: "my-app",
-            lez_pin: "abc123",
+            crate_name: "my-app".to_string(),
+            lez_pin: "abc123".to_string(),
+            plugin_name: "my_app".to_string(),
+            project_title: "My App".to_string(),
+            module_builder_flake_url: "path:/tmp/logos-module-builder".to_string(),
+            basecamp_data_root: ".scaffold/runtime/LogosBasecamp".to_string(),
+            basecamp_runtime_variant: "dev".to_string(),
         };
 
         apply_overlay(&target, "default", &ctx).expect("failed to apply default overlay");
@@ -203,8 +221,13 @@ mod tests {
     fn lez_framework_overlay_converts_template_manifests_to_cargo_toml() {
         let target = mk_temp_dir("lez-manifests");
         let ctx = OverlayRenderContext {
-            crate_name: "my-app",
-            lez_pin: "abc123",
+            crate_name: "my-app".to_string(),
+            lez_pin: "abc123".to_string(),
+            plugin_name: "my_app".to_string(),
+            project_title: "My App".to_string(),
+            module_builder_flake_url: "path:/tmp/logos-module-builder".to_string(),
+            basecamp_data_root: ".scaffold/runtime/LogosBasecamp".to_string(),
+            basecamp_runtime_variant: "dev".to_string(),
         };
 
         apply_overlay(&target, "lez-framework", &ctx).expect("failed to apply lez-framework");
@@ -238,8 +261,13 @@ mod tests {
     fn overlay_renders_tokens_and_leaves_no_unresolved_placeholders() {
         let target = mk_temp_dir("tokens");
         let ctx = OverlayRenderContext {
-            crate_name: "example-name",
-            lez_pin: "deadbeef",
+            crate_name: "example-name".to_string(),
+            lez_pin: "deadbeef".to_string(),
+            plugin_name: "example_name".to_string(),
+            project_title: "Example Name".to_string(),
+            module_builder_flake_url: "path:/tmp/logos-module-builder".to_string(),
+            basecamp_data_root: ".scaffold/runtime/LogosBasecamp".to_string(),
+            basecamp_runtime_variant: "dev".to_string(),
         };
 
         apply_overlay(&target, "default", &ctx).expect("failed to apply default overlay");
@@ -257,8 +285,13 @@ mod tests {
     fn static_files_match_template_content_after_overlay() {
         let target = mk_temp_dir("parity");
         let ctx = OverlayRenderContext {
-            crate_name: "my-app",
-            lez_pin: "abc123",
+            crate_name: "my-app".to_string(),
+            lez_pin: "abc123".to_string(),
+            plugin_name: "my_app".to_string(),
+            project_title: "My App".to_string(),
+            module_builder_flake_url: "path:/tmp/logos-module-builder".to_string(),
+            basecamp_data_root: ".scaffold/runtime/LogosBasecamp".to_string(),
+            basecamp_runtime_variant: "dev".to_string(),
         };
 
         apply_overlay(&target, "default", &ctx).expect("failed to apply default overlay");
@@ -288,8 +321,13 @@ mod tests {
     fn gitignore_includes_scaffold_and_is_idempotent() {
         let target = mk_temp_dir("gitignore");
         let ctx = OverlayRenderContext {
-            crate_name: "my-app",
-            lez_pin: "abc123",
+            crate_name: "my-app".to_string(),
+            lez_pin: "abc123".to_string(),
+            plugin_name: "my_app".to_string(),
+            project_title: "My App".to_string(),
+            module_builder_flake_url: "path:/tmp/logos-module-builder".to_string(),
+            basecamp_data_root: ".scaffold/runtime/LogosBasecamp".to_string(),
+            basecamp_runtime_variant: "dev".to_string(),
         };
 
         apply_overlay(&target, "default", &ctx).expect("failed to apply default overlay");
@@ -331,8 +369,13 @@ mod tests {
     #[test]
     fn render_fails_on_unresolved_placeholder() {
         let ctx = OverlayRenderContext {
-            crate_name: "my-app",
-            lez_pin: "abc123",
+            crate_name: "my-app".to_string(),
+            lez_pin: "abc123".to_string(),
+            plugin_name: "my_app".to_string(),
+            project_title: "My App".to_string(),
+            module_builder_flake_url: "path:/tmp/logos-module-builder".to_string(),
+            basecamp_data_root: ".scaffold/runtime/LogosBasecamp".to_string(),
+            basecamp_runtime_variant: "dev".to_string(),
         };
 
         let err = render_template_text("name = \"{{unknown_token}}\"", &ctx)

--- a/templates/basecamp-qml/.gitignore
+++ b/templates/basecamp-qml/.gitignore
@@ -1,0 +1,3 @@
+.scaffold
+result
+result-*

--- a/templates/basecamp-qml/Main.qml
+++ b/templates/basecamp-qml/Main.qml
@@ -1,0 +1,118 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+Rectangle {
+    id: root
+    color: "#f5f2e8"
+
+    property int counter: 0
+    property string bridgeStatus: "Bridge not queried yet"
+
+    function queryBridge() {
+        if (typeof logos === "undefined" || !logos.callModule) {
+            bridgeStatus = "Logos bridge unavailable"
+            return
+        }
+
+        try {
+            bridgeStatus = String(logos.callModule("package_manager", "getValidVariants", []))
+        } catch (error) {
+            bridgeStatus = String(error)
+        }
+    }
+
+    ScrollView {
+        anchors.fill: parent
+        contentWidth: availableWidth
+
+        ColumnLayout {
+            width: parent.width
+            spacing: 18
+            anchors.margins: 24
+
+            Rectangle {
+                Layout.fillWidth: true
+                radius: 20
+                color: "#15332d"
+                implicitHeight: 180
+
+                ColumnLayout {
+                    anchors.fill: parent
+                    anchors.margins: 24
+                    spacing: 12
+
+                    Text {
+                        text: "{{project_title}}"
+                        color: "#f7f3e8"
+                        font.pixelSize: 28
+                        font.weight: Font.DemiBold
+                    }
+
+                    Text {
+                        text: "A pure QML Basecamp plugin scaffolded by logos-scaffold."
+                        color: "#d8d3c7"
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
+                    }
+
+                    RowLayout {
+                        spacing: 12
+
+                        Button {
+                            text: "Increment"
+                            onClicked: root.counter += 1
+                        }
+
+                        Label {
+                            text: "Counter: " + root.counter
+                            color: "#f7f3e8"
+                            font.pixelSize: 16
+                        }
+                    }
+                }
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                radius: 16
+                color: "#ffffff"
+                border.color: "#d7cfbf"
+                implicitHeight: 220
+
+                ColumnLayout {
+                    anchors.fill: parent
+                    anchors.margins: 20
+                    spacing: 12
+
+                    Text {
+                        text: "Local Loop"
+                        color: "#22322d"
+                        font.pixelSize: 20
+                        font.weight: Font.DemiBold
+                    }
+
+                    Text {
+                        text: "Use `logos-scaffold build` to stage the plugin bundle, then `logos-scaffold install` to sync it into your local Basecamp data directory."
+                        color: "#44544e"
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
+                    }
+
+                    Button {
+                        text: "Query package_manager bridge"
+                        onClicked: root.queryBridge()
+                    }
+
+                    TextArea {
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        readOnly: true
+                        wrapMode: TextEdit.Wrap
+                        text: root.bridgeStatus
+                    }
+                }
+            }
+        }
+    }
+}

--- a/templates/basecamp-qml/README.md
+++ b/templates/basecamp-qml/README.md
@@ -1,0 +1,45 @@
+# {{project_title}}
+
+This project was generated with:
+
+```bash
+logos-scaffold new <name> --template basecamp-qml
+```
+
+It targets the pure `ui_qml` Basecamp plugin workflow.
+
+## Local Development
+
+```bash
+logos-scaffold setup
+logos-scaffold build
+logos-scaffold install
+```
+
+Launch Basecamp against the scaffold-managed local data root:
+
+```bash
+export LOGOS_DATA_DIR="{{basecamp_data_root}}"
+```
+
+If your Basecamp binary is a non-portable dev build, it will load plugins from
+`$LOGOS_DATA_DIR` with `Dev` appended automatically. Portable builds use the
+data root directly.
+
+## Optional Packaging
+
+```bash
+logos-scaffold build --artifact all
+```
+
+That runs the raw staging flow and then builds:
+
+- `nix build .#lgx`
+- `nix build .#lgx-portable`
+
+## Files
+
+- `Main.qml` — QML entry point
+- `metadata.json` — Basecamp plugin metadata
+- `icons/app.svg` — sidebar icon
+- `flake.nix` — optional packaging and Nix-based outputs

--- a/templates/basecamp-qml/flake.nix
+++ b/templates/basecamp-qml/flake.nix
@@ -1,0 +1,14 @@
+{
+  description = "{{project_title}} QML plugin for Logos Basecamp";
+
+  inputs = {
+    logos-module-builder.url = "{{module_builder_flake_url}}";
+  };
+
+  outputs = inputs@{ logos-module-builder, ... }:
+    logos-module-builder.lib.mkLogosQmlModule {
+      src = ./.;
+      configFile = ./metadata.json;
+      flakeInputs = inputs;
+    };
+}

--- a/templates/basecamp-qml/icons/app.svg
+++ b/templates/basecamp-qml/icons/app.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="28" fill="#15332d"/>
+  <rect x="18" y="18" width="92" height="92" rx="20" fill="#f5f2e8"/>
+  <path d="M38 88V40h18c9 0 18 5 18 16 0 6-3 11-8 14 7 2 11 8 11 15 0 12-10 18-22 18H38zm14-29h4c5 0 8-3 8-7 0-5-3-7-8-7h-4v14zm0 17h6c6 0 9-3 9-8 0-6-4-8-10-8h-5v16z" fill="#15332d"/>
+  <circle cx="90" cy="38" r="10" fill="#c46b2d"/>
+</svg>

--- a/templates/basecamp-qml/metadata.json
+++ b/templates/basecamp-qml/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "{{plugin_name}}",
+  "version": "1.0.0",
+  "description": "{{project_title}} - pure QML plugin for Logos Basecamp",
+  "type": "ui_qml",
+  "view": "Main.qml",
+  "dependencies": [],
+  "category": "tools",
+  "icon": "icons/app.svg"
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -16,6 +16,7 @@ use tar::Archive;
 use tempfile::tempdir;
 
 const TEST_PIN: &str = "767b5afd388c7981bcdf6f5b5c80159607e07e5b";
+const MODULE_BUILDER_PIN: &str = "9b97f6b05987ea4145d7632ada644a2ee8357c26";
 const VALID_ACCOUNT_ID: &str = "6iArKUXxhUJqS7kCaPNhwMWt3ro71PDyBj7jwAyE2VQV";
 const VALID_PUBLIC_ADDRESS: &str = "Public/6iArKUXxhUJqS7kCaPNhwMWt3ro71PDyBj7jwAyE2VQV";
 const DEFAULT_WALLET_PASSWORD: &str = "logos-scaffold-v0";
@@ -38,6 +39,195 @@ fn create_help_does_not_mutate_filesystem() {
         !temp.path().join("--help").exists(),
         "--help must not be treated as project name"
     );
+}
+
+#[test]
+fn create_help_lists_basecamp_qml_template() {
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .arg("create")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("basecamp-qml"));
+}
+
+#[test]
+fn new_basecamp_qml_creates_expected_files() {
+    let temp = tempdir().expect("tempdir");
+    let module_builder = init_git_repo_with_commit(&temp.path().join("module-builder"), "README.md");
+    let bin_dir = prepare_basecamp_bin_dir(temp.path());
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .env("PATH", bin_dir.display().to_string())
+        .arg("new")
+        .arg("demo-app")
+        .arg("--template")
+        .arg("basecamp-qml")
+        .arg("--module-builder-path")
+        .arg(&module_builder)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Created Basecamp QML project"));
+
+    let project = temp.path().join("demo-app");
+    for rel in [
+        "Main.qml",
+        "metadata.json",
+        "flake.nix",
+        "README.md",
+        ".scaffold/commands.md",
+        "icons/app.svg",
+        "scaffold.toml",
+    ] {
+        assert!(project.join(rel).exists(), "missing generated file: {rel}");
+    }
+
+    let scaffold = fs::read_to_string(project.join("scaffold.toml")).expect("read scaffold.toml");
+    assert!(scaffold.contains("[project]"));
+    assert!(scaffold.contains("kind = \"basecamp-qml\""));
+    assert!(scaffold.contains("[repos.logos_module_builder]"));
+}
+
+#[test]
+fn new_basecamp_qml_vendor_deps_vendors_module_builder_repo() {
+    let temp = tempdir().expect("tempdir");
+    let module_builder = init_git_repo_with_commit(&temp.path().join("module-builder"), "README.md");
+    let bin_dir = prepare_basecamp_bin_dir(temp.path());
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .env("PATH", bin_dir.display().to_string())
+        .arg("new")
+        .arg("vendored-app")
+        .arg("--template")
+        .arg("basecamp-qml")
+        .arg("--vendor-deps")
+        .arg("--module-builder-path")
+        .arg(&module_builder)
+        .assert()
+        .success();
+
+    let vendored_repo = temp
+        .path()
+        .join("vendored-app/.scaffold/repos/logos-module-builder/.git");
+    assert!(vendored_repo.exists(), "expected vendored module-builder repo");
+}
+
+#[test]
+fn basecamp_build_stages_raw_plugin_output() {
+    let temp = tempdir().expect("tempdir");
+    let project = create_basecamp_project(temp.path(), "demo-app");
+    let bin_dir = prepare_basecamp_bin_dir(temp.path());
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(&project)
+        .env("PATH", bin_dir.display().to_string())
+        .arg("build")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Raw plugin staged for"));
+
+    let staged = project.join(".scaffold/build/raw/plugins/demo_app");
+    assert!(staged.join("Main.qml").exists());
+    assert!(staged.join("metadata.json").exists());
+    assert!(staged.join("icons/app.svg").exists());
+}
+
+#[test]
+fn basecamp_install_syncs_plugin_and_replaces_stale_files() {
+    let temp = tempdir().expect("tempdir");
+    let project = create_basecamp_project(temp.path(), "demo-app");
+    let bin_dir = prepare_basecamp_bin_dir(temp.path());
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(&project)
+        .env("PATH", bin_dir.display().to_string())
+        .arg("build")
+        .assert()
+        .success();
+
+    let install_dir = project.join(".scaffold/runtime/LogosBasecampDev/plugins/demo_app");
+    fs::create_dir_all(&install_dir).expect("create install dir");
+    fs::write(install_dir.join("stale.txt"), "old").expect("write stale file");
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(&project)
+        .env("PATH", bin_dir.display().to_string())
+        .arg("install")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Installed Basecamp plugin"));
+
+    assert!(install_dir.join("Main.qml").exists());
+    assert!(!install_dir.join("stale.txt").exists());
+}
+
+#[test]
+fn basecamp_build_all_fails_cleanly_without_nix() {
+    let temp = tempdir().expect("tempdir");
+    let project = create_basecamp_project(temp.path(), "demo-app");
+    let bin_dir = prepare_basecamp_bin_dir(temp.path());
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(&project)
+        .env("PATH", bin_dir.display().to_string())
+        .arg("build")
+        .arg("--artifact")
+        .arg("all")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Nix is required"));
+}
+
+#[test]
+fn basecamp_build_all_invokes_nix_targets_when_stubbed() {
+    let temp = tempdir().expect("tempdir");
+    let project = create_basecamp_project(temp.path(), "demo-app");
+    let bin_dir = prepare_basecamp_bin_dir(temp.path());
+    let log_path = temp.path().join("nix.log");
+    let nix_path = bin_dir.join("nix");
+    fs::write(
+        &nix_path,
+        format!(
+            "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" >> \"{}\"\n",
+            log_path.display()
+        ),
+    )
+    .expect("write nix stub");
+    make_executable(&nix_path);
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(&project)
+        .env("PATH", bin_dir.display().to_string())
+        .arg("build")
+        .arg("--artifact")
+        .arg("all")
+        .assert()
+        .success();
+
+    let log = fs::read_to_string(log_path).expect("read nix log");
+    assert!(log.contains("build .#lgx"));
+    assert!(log.contains("build .#lgx-portable"));
+}
+
+#[test]
+fn basecamp_deploy_command_is_rejected_with_project_kind_hint() {
+    let temp = tempdir().expect("tempdir");
+    let project = create_basecamp_project(temp.path(), "demo-app");
+    let bin_dir = prepare_basecamp_bin_dir(temp.path());
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(&project)
+        .env("PATH", bin_dir.display().to_string())
+        .arg("deploy")
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("only supported for LEZ projects")
+                .and(predicate::str::contains("logos-scaffold build"))
+                .and(predicate::str::contains("logos-scaffold install")),
+        );
 }
 
 #[test]
@@ -1452,6 +1642,99 @@ fn write_scaffold_toml_with_localnet(
     }
 
     fs::write(project_root.join("scaffold.toml"), content).expect("write scaffold.toml");
+}
+
+fn create_basecamp_project(root: &Path, name: &str) -> PathBuf {
+    let module_builder = init_git_repo_with_commit(&root.join("module-builder"), "README.md");
+    let project = root.join(name);
+    let bin_dir = prepare_basecamp_bin_dir(root);
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(root)
+        .env("PATH", bin_dir.display().to_string())
+        .arg("new")
+        .arg(name)
+        .arg("--template")
+        .arg("basecamp-qml")
+        .arg("--module-builder-path")
+        .arg(&module_builder)
+        .assert()
+        .success();
+
+    project
+}
+
+fn init_git_repo_with_commit(path: &Path, file_name: &str) -> PathBuf {
+    fs::create_dir_all(path).expect("create repo dir");
+    std::process::Command::new("git")
+        .arg("init")
+        .current_dir(path)
+        .output()
+        .expect("git init");
+    std::process::Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(path)
+        .output()
+        .expect("git config email");
+    std::process::Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(path)
+        .output()
+        .expect("git config name");
+    fs::write(path.join(file_name), "stub\n").expect("write repo file");
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(path)
+        .output()
+        .expect("git add");
+    std::process::Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(path)
+        .output()
+        .expect("git commit");
+    path.to_path_buf()
+}
+
+fn make_executable(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms).expect("chmod");
+    }
+}
+
+fn prepare_basecamp_bin_dir(root: &Path) -> PathBuf {
+    let bin_dir = root.join("test-bin");
+    fs::create_dir_all(&bin_dir).expect("create test bin dir");
+    write_git_pin_wrapper(&bin_dir.join("git"));
+    bin_dir
+}
+
+fn git_binary_path() -> String {
+    let path = std::env::var_os("PATH").expect("PATH");
+    for dir in std::env::split_paths(&path) {
+        let candidate = dir.join("git");
+        if candidate.exists() {
+            return candidate.display().to_string();
+        }
+    }
+    panic!("git binary not found in PATH");
+}
+
+fn write_git_pin_wrapper(path: &Path) {
+    let target = git_binary_path();
+    fs::write(
+        path,
+        format!(
+            "#!/bin/sh\nset -eu\nif [ \"${{1:-}}\" = \"rev-parse\" ]; then\n  if [ \"${{2:-}}\" = \"--verify\" ]; then\n    echo \"{pin}\"\n    exit 0\n  fi\n  if [ \"${{2:-}}\" = \"HEAD\" ]; then\n    echo \"{pin}\"\n    exit 0\n  fi\nfi\nif [ \"${{1:-}}\" = \"checkout\" ] && [ \"${{2:-}}\" = \"{pin}\" ]; then\n  exit 0\nfi\nexec \"{target}\" \"$@\"\n",
+            pin = MODULE_BUILDER_PIN,
+            target = target,
+        ),
+    )
+    .expect("write git wrapper");
+    make_executable(path);
 }
 
 fn unused_local_port() -> u16 {


### PR DESCRIPTION
### Description

This PR adds a new basecamp-qml template to logos-scaffold so it can bootstrap and manage pure Basecamp ui_qml projects, not just LEZ projects. The goal is to make the local Basecamp development loop straightforward: create a project, stage a raw plugin bundle locally, install it into a local Basecamp data dir, and optionally build LGX artifacts when Nix is available.

### Solution

I introduced project.kind with separate Basecamp config sections, added logos-scaffold new --template basecamp-qml, build --artifact raw|all, and a new install command. The generated template includes the Basecamp QML app files, local runtime docs, and a flake.nix wired to a pinned logos-module-builder. LEZ-only commands now fail clearly for Basecamp projects.