### PR TITLE
feat(localnet): add localnet reset command with --keep-wallet flag

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,47 @@
+# SPEC: `logos-scaffold localnet reset`
+
+## Context
+
+`logos-scaffold localnet reset [--keep-wallet]` — atomically resets the localnet environment to a clean state.
+
+## Problem
+
+Developers resetting localnet need to know undocumented internal file locations and execute deletions in the correct order. The failure mode when steps are skipped or reordered is silent: `spel` hangs forever on "Waiting for confirmation...", no errors anywhere, because sequencer on-chain nonces and wallet nonces are out of sync.
+
+## Solution
+
+Single command with atomic 8-step reset:
+1. Stop sequencer (releases RocksDB lock)
+2. Delete sequencer RocksDB at `.scaffold/cache/repos/lssa/rocksdb`
+3. Delete wallet dir (unless `--keep-wallet`)
+4. Delete `wallet.state` pointer (unless `--keep-wallet`)
+5. Delete `localnet.state`
+6. Run `setup` to recreate wallet and seed default address
+7. Start sequencer
+8. Poll `get_last_block` RPC until block height > 0 (30s timeout), confirming clean state
+
+## Usage
+
+```bash
+logos-scaffold localnet reset
+logos-scaffold localnet reset --keep-wallet
+```
+
+## CLI
+
+Add to `localnet` subcommand:
+- `reset` subcommand
+- `--keep-wallet` flag (boolean, defaults to false)
+
+## Files to Change
+
+- `src/cli.rs` — add `reset` subcommand
+- `src/commands/localnet.rs` — add `LocalnetAction::Reset { keep_wallet: bool }` variant and implementation
+- `src/error.rs` — add `ResetError` if needed
+
+## Constraints
+
+- Atomic: all steps succeed or rollback (already-run steps have no rollback, but failures are reported)
+- Non-fatal missing files: if a path doesn't exist, skip deletion and continue
+- `--keep-wallet`: skips wallet dir and wallet.state deletion
+- Timeout on block polling: 30s max, then error with helpful message

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -135,6 +135,8 @@ struct LocalnetArgs {
 enum LocalnetSubcommand {
     Start(LocalnetStartArgs),
     Stop,
+    #[command(about = "Reset localnet to a clean state")]
+    Reset(LocalnetResetArgs),
     Status(LocalnetStatusArgs),
     Logs(LocalnetLogsArgs),
 }
@@ -143,6 +145,13 @@ enum LocalnetSubcommand {
 struct LocalnetStartArgs {
     #[arg(long, default_value_t = 20)]
     timeout_sec: u64,
+}
+
+#[derive(Debug, clap::Args)]
+struct LocalnetResetArgs {
+    /// Keep wallet directory and wallet.state intact during reset
+    #[arg(long)]
+    keep_wallet: bool,
 }
 
 #[derive(Debug, clap::Args)]
@@ -253,6 +262,9 @@ pub(crate) fn run(args: Vec<String>) -> DynResult<()> {
                     timeout_sec: args.timeout_sec,
                 },
                 LocalnetSubcommand::Stop => LocalnetAction::Stop,
+                LocalnetSubcommand::Reset(args) => LocalnetAction::Reset {
+                    keep_wallet: args.keep_wallet,
+                },
                 LocalnetSubcommand::Status(args) => LocalnetAction::Status { json: args.json },
                 LocalnetSubcommand::Logs(args) => LocalnetAction::Logs { tail: args.tail },
             };

--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -8,6 +8,8 @@ use std::time::{Duration, Instant};
 use anyhow::{bail, Context};
 use serde_json::Value;
 
+use crate::commands::setup::cmd_setup;
+use crate::commands::wallet_support::{rpc_get_last_block, wallet_state_path};
 use crate::constants::{SEQUENCER_BIN_REL_PATH, SEQUENCER_CONFIG_REL_PATH};
 use crate::error::LocalnetError;
 use crate::model::{LocalnetOwnership, LocalnetState, LocalnetStatusReport, Project};
@@ -24,6 +26,7 @@ pub(crate) enum LocalnetAction {
     Stop,
     Status { json: bool },
     Logs { tail: usize },
+    Reset { keep_wallet: bool },
 }
 
 pub(crate) fn cmd_localnet(action: LocalnetAction) -> DynResult<()> {
@@ -36,6 +39,10 @@ pub(crate) fn cmd_localnet(action: LocalnetAction) -> DynResult<()> {
             } else {
                 cmd_localnet_stop_outside_project()
             }
+        }
+        LocalnetAction::Reset { keep_wallet } => {
+            let project = load_project()?;
+            cmd_localnet_reset(&project, keep_wallet)
         }
         _ => {
             let project = load_project()?;
@@ -80,6 +87,7 @@ fn cmd_localnet_in_project(project: &Project, action: LocalnetAction) -> DynResu
             cmd_localnet_status(&state_path, &log_path, json, &localnet_addr, localnet_port)
         }
         LocalnetAction::Logs { tail } => cmd_localnet_logs(&log_path, tail),
+        LocalnetAction::Reset { .. } => unreachable!("reset is handled in cmd_localnet"),
     }
 }
 
@@ -198,6 +206,117 @@ fn cmd_localnet_start(
 
     println!("localnet ready (sequencer pid={sequencer_pid})");
     Ok(())
+}
+
+fn cmd_localnet_reset(project: &Project, keep_wallet: bool) -> DynResult<()> {
+    let localnet_port = project.config.localnet.port;
+    let state_path = project.root.join(".scaffold/state/localnet.state");
+    let lez = PathBuf::from(&project.config.lez.path);
+
+    // Step 1: Stop sequencer if running
+    println!("step 1/8: stopping sequencer");
+    let state = read_localnet_state(&state_path).unwrap_or_default();
+    if let Some(pid) = state.sequencer_pid {
+        if pid_running(pid) {
+            println!("$ kill {pid} # sequencer");
+            let _ = Command::new("kill").arg(pid.to_string()).status();
+            // Wait briefly for process to exit
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while pid_alive(pid) && Instant::now() < deadline {
+                thread::sleep(Duration::from_millis(200));
+            }
+            if pid_alive(pid) {
+                bail!("sequencer pid={pid} did not exit after kill");
+            }
+        } else {
+            println!("sequencer pid={pid} not running (stale state)");
+        }
+    } else {
+        println!("no tracked sequencer process");
+    }
+
+    // Step 2: Delete sequencer RocksDB
+    println!("step 2/8: deleting sequencer RocksDB");
+    let rocksdb_path = lez.join("rocksdb");
+    if rocksdb_path.exists() {
+        fs::remove_dir_all(&rocksdb_path)
+            .with_context(|| format!("failed to remove {}", rocksdb_path.display()))?;
+        println!("  removed {}", rocksdb_path.display());
+    } else {
+        println!("  not found, skipping");
+    }
+
+    // Step 3: Delete wallet dir (unless --keep-wallet)
+    let wallet_home = project.root.join(&project.config.wallet_home_dir);
+    if keep_wallet {
+        println!("step 3/8: keeping wallet dir (--keep-wallet)");
+    } else {
+        println!("step 3/8: deleting wallet dir");
+        if wallet_home.exists() {
+            fs::remove_dir_all(&wallet_home)
+                .with_context(|| format!("failed to remove {}", wallet_home.display()))?;
+            println!("  removed {}", wallet_home.display());
+        } else {
+            println!("  not found, skipping");
+        }
+    }
+
+    // Step 4: Delete wallet.state (unless --keep-wallet)
+    let wallet_state = wallet_state_path(&project.root);
+    if keep_wallet {
+        println!("step 4/8: keeping wallet.state (--keep-wallet)");
+    } else {
+        println!("step 4/8: deleting wallet.state");
+        if wallet_state.exists() {
+            fs::remove_file(&wallet_state)
+                .with_context(|| format!("failed to remove {}", wallet_state.display()))?;
+            println!("  removed {}", wallet_state.display());
+        } else {
+            println!("  not found, skipping");
+        }
+    }
+
+    // Step 5: Delete localnet.state
+    println!("step 5/8: deleting localnet.state");
+    if state_path.exists() {
+        fs::remove_file(&state_path)
+            .with_context(|| format!("failed to remove {}", state_path.display()))?;
+        println!("  removed {}", state_path.display());
+    } else {
+        println!("  not found, skipping");
+    }
+
+    // Step 6: Run setup
+    println!("step 6/8: running setup");
+    cmd_setup()?;
+
+    // Step 7: Start sequencer
+    println!("step 7/8: starting sequencer");
+    cmd_localnet(LocalnetAction::Start { timeout_sec: 30 })?;
+
+    // Step 8: Poll get_last_block RPC until block height > 0
+    println!("step 8/8: waiting for first block");
+    let sequencer_addr = format!("http://127.0.0.1:{localnet_port}");
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        match rpc_get_last_block(&sequencer_addr) {
+            Ok(block) if block > 0 => {
+                println!("localnet reset complete (block height = {block})");
+                return Ok(());
+            }
+            _ => {}
+        }
+
+        if Instant::now() >= deadline {
+            bail!(
+                "localnet reset: timed out waiting for block height > 0 after 30s.\n\
+                 The sequencer is running but has not produced a block yet.\n\
+                 Check logs: `logos-scaffold localnet logs`"
+            );
+        }
+
+        thread::sleep(Duration::from_millis(500));
+    }
 }
 
 fn wait_for_readiness(


### PR DESCRIPTION
Fresh re-implementation of PR #56 on current master (b93d80a).

## Summary

`logos-scaffold localnet reset [--keep-wallet]` — atomically resets the localnet environment to a clean state.

## Problem

Developers resetting localnet need to know undocumented internal file locations and execute deletions in the correct order. Failure modes are silent: `spel` hangs forever because sequencer on-chain nonces and wallet nonces are out of sync.

## Solution

Single command with atomic 8-step reset:
1. Stop sequencer (releases RocksDB lock)
2. Delete sequencer RocksDB at `.scaffold/cache/repos/lssa/rocksdb`
3. Delete wallet dir (unless `--keep-wallet`)
4. Delete `wallet.state` pointer (unless `--keep-wallet`)
5. Delete `localnet.state`
6. Run `setup` to recreate wallet
7. Start sequencer
8. Poll `get_last_block` RPC until block height > 0 (30s timeout)

## Testing
- `cargo fmt --check` ✅
- `cargo check` ✅