### PR TITLE
fix: dynamic binary discovery + program ID output for deploy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,6 +541,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "ureq",
+ "walkdir",
 ]
 
 [[package]]
@@ -763,6 +764,15 @@ dependencies = [
  "ring",
  "rustls-pki-types",
  "untrusted",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1017,6 +1027,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,6 +1110,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,6 +333,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +539,7 @@ dependencies = [
  "bs58",
  "clap",
  "flate2",
+ "hex",
  "include_dir",
  "predicates",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ include = [
 
 [dependencies]
 walkdir = "2"
+hex = "0.4"
 anyhow = "1.0"
 bs58 = "0.5"
 clap = { version = "4.5", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ include = [
 ]
 
 [dependencies]
+walkdir = "2"
 anyhow = "1.0"
 bs58 = "0.5"
 clap = { version = "4.5", features = ["derive"] }

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -15,6 +15,32 @@ use super::wallet_support::{
 
 const GUEST_BIN_REL_PATH: &str =
     "target/riscv-guest/example_program_deployment_methods/example_program_deployment_programs/riscv32im-risc0-zkvm-elf/release";
+
+/// Dynamically discover the binary path for a program by searching methods/target/
+/// for .bin files matching the program name. Falls back to GUEST_BIN_REL_PATH.
+fn find_binary_path(project_root: &Path, program: &str) -> Option<PathBuf> {
+    let methods_target = project_root.join("methods/target");
+    if !methods_target.exists() {
+        return None;
+    }
+
+    // Walk methods/target/ looking for <program>.bin in riscv32im paths
+    let pattern = format!("{}.bin", program);
+    let walker = walkdir::WalkDir::new(&methods_target)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file());
+
+    for entry in walker {
+        let path = entry.path();
+        if path.file_name().and_then(|f| f.to_str()) == Some(pattern.as_str()) {
+            if path.to_string_lossy().contains("riscv32im") {
+                return Some(path.to_path_buf());
+            }
+        }
+    }
+    None
+}
 const DEFAULT_SEQUENCER_ADDR: &str = "http://127.0.0.1:3040";
 
 pub(crate) fn cmd_deploy(
@@ -60,7 +86,10 @@ pub(crate) fn cmd_deploy(
 
     let mut results = Vec::new();
     for program in selected_programs {
-        let binary_path = binaries_root.join(format!("{program}.bin"));
+        // Try dynamic discovery first, fall back to hardcoded path
+        let binary_path = find_binary_path(&project.root, &program)
+            .unwrap_or_else(|| binaries_root.join(format!("{program}.bin")));
+
         if !binary_path.exists() {
             println!("FAIL {program} deployment failed");
             println!("  Error: missing binary at {}", binary_path.display());

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -10,7 +10,8 @@ use crate::DynResult;
 
 use super::wallet_support::{
     extract_tx_identifier, is_connectivity_failure, load_wallet_runtime, rpc_get_last_block,
-    sequencer_unreachable_hint, summarize_command_failure, wallet_password, RpcReachabilityError,
+    rpc_get_program_ids, sequencer_unreachable_hint, summarize_command_failure, wallet_password,
+    RpcReachabilityError,
 };
 
 const GUEST_BIN_REL_PATH: &str =
@@ -157,6 +158,12 @@ pub(crate) fn cmd_deploy(
         println!("OK  {program} submitted");
         if let Some(tx) = tx.clone() {
             println!("  Tx: {tx}");
+        }
+        // Try to show the program ID from sequencer
+        let program_id = rpc_get_program_ids(&sequencer_addr)
+            .and_then(|ids| ids.get(&program).cloned());
+        if let Some(id) = &program_id {
+            println!("  Program ID: {id}");
         }
         results.push(DeployResult {
             program,

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -86,9 +86,6 @@ pub(crate) fn cmd_deploy(
 
     preflight_sequencer_reachability(&sequencer_addr)?;
 
-    // Fetch all program IDs once before the loop to avoid N RPC calls
-    let program_ids = rpc_get_program_ids(&sequencer_addr).unwrap_or_default();
-
     let mut results = Vec::new();
     for program in selected_programs {
         // Try dynamic discovery first, fall back to hardcoded path
@@ -163,16 +160,23 @@ pub(crate) fn cmd_deploy(
         if let Some(tx) = tx.clone() {
             println!("  Tx: {tx}");
         }
-        // Show program ID from pre-fetched map
-        if let Some(id) = program_ids.get(&program) {
-            println!("  Program ID: {id}");
-        }
+
         results.push(DeployResult {
             program,
             status: DeployStatus::Submitted,
             detail: "wallet submission command exited successfully".to_string(),
             tx,
         });
+    }
+
+    // Fetch program IDs after all deployments complete
+    let program_ids = rpc_get_program_ids(&sequencer_addr).unwrap_or_default();
+    for result in &results {
+        if matches!(result.status, DeployStatus::Submitted) {
+            if let Some(id) = program_ids.get(&result.program) {
+                println!("  {} → Program ID: {id}", result.program);
+            }
+        }
     }
 
     let success_count = results
@@ -326,18 +330,13 @@ fn deploy_single_program(
         .and_then(|ids| ids.get(program_name).cloned());
 
     if json {
-        let tx_val = tx
-            .as_deref()
-            .map(|t| format!("\"{}\"", t))
-            .unwrap_or_else(|| "null".to_string());
-        let id_val = program_id
-            .as_deref()
-            .map(|id| format!("\"{}\"", id))
-            .unwrap_or_else(|| "null".to_string());
-        println!(
-            "{{\"status\":\"submitted\",\"program\":\"{}\",\"tx\":{},\"program_id\":{}}}",
-            program_name, tx_val, id_val
-        );
+        let json_out = serde_json::json!({
+            "status": "submitted",
+            "program": program_name,
+            "tx": tx.as_deref(),
+            "program_id": program_id.as_deref(),
+        });
+        println!("{}", serde_json::to_string(&json_out).unwrap_or_default());
     } else {
         println!("OK  {program_name} submitted");
         println!("  Binary: {}", binary_path.display());

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -42,6 +42,7 @@ fn find_binary_path(project_root: &Path, program: &str) -> Option<PathBuf> {
     }
     None
 }
+
 const DEFAULT_SEQUENCER_ADDR: &str = "http://127.0.0.1:3040";
 
 pub(crate) fn cmd_deploy(
@@ -84,6 +85,9 @@ pub(crate) fn cmd_deploy(
     let binaries_root = project.root.join(GUEST_BIN_REL_PATH);
 
     preflight_sequencer_reachability(&sequencer_addr)?;
+
+    // Fetch all program IDs once before the loop to avoid N RPC calls
+    let program_ids = rpc_get_program_ids(&sequencer_addr).unwrap_or_default();
 
     let mut results = Vec::new();
     for program in selected_programs {
@@ -159,10 +163,8 @@ pub(crate) fn cmd_deploy(
         if let Some(tx) = tx.clone() {
             println!("  Tx: {tx}");
         }
-        // Try to show the program ID from sequencer
-        let program_id = rpc_get_program_ids(&sequencer_addr)
-            .and_then(|ids| ids.get(&program).cloned());
-        if let Some(id) = &program_id {
+        // Show program ID from pre-fetched map
+        if let Some(id) = program_ids.get(&program) {
             println!("  Program ID: {id}");
         }
         results.push(DeployResult {
@@ -320,20 +322,30 @@ fn deploy_single_program(
         bail!("deploy failed: {summary}");
     }
 
+    let program_id = rpc_get_program_ids(sequencer_addr)
+        .and_then(|ids| ids.get(program_name).cloned());
+
     if json {
         let tx_val = tx
             .as_deref()
             .map(|t| format!("\"{}\"", t))
             .unwrap_or_else(|| "null".to_string());
+        let id_val = program_id
+            .as_deref()
+            .map(|id| format!("\"{}\"", id))
+            .unwrap_or_else(|| "null".to_string());
         println!(
-            "{{\"status\":\"submitted\",\"program\":\"{}\",\"tx\":{}}}",
-            program_name, tx_val
+            "{{\"status\":\"submitted\",\"program\":\"{}\",\"tx\":{},\"program_id\":{}}}",
+            program_name, tx_val, id_val
         );
     } else {
         println!("OK  {program_name} submitted");
         println!("  Binary: {}", binary_path.display());
         if let Some(tx) = &tx {
             println!("  Tx: {tx}");
+        }
+        if let Some(id) = &program_id {
+            println!("  Program ID: {id}");
         }
     }
 
@@ -360,5 +372,56 @@ impl DeployStatus {
             DeployStatus::Submitted => "submitted",
             DeployStatus::Failed => "failed",
         }
+    }
+}
+
+#[cfg(test)]
+mod deploy_tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn find_binary_path_finds_bin_in_riscv32im_path() {
+        let temp = tempdir().unwrap();
+        let bin_dir = temp.path()
+            .join("methods/target/riscv-guest/my_methods/my_programs/riscv32im-risc0-zkvm-elf/release");
+        fs::create_dir_all(&bin_dir).unwrap();
+        fs::write(bin_dir.join("my_program.bin"), b"fake elf").unwrap();
+
+        let result = find_binary_path(temp.path(), "my_program");
+        assert!(result.is_some(), "should find binary in riscv32im path");
+        assert!(result.unwrap().ends_with("my_program.bin"));
+    }
+
+    #[test]
+    fn find_binary_path_returns_none_when_methods_target_missing() {
+        let temp = tempdir().unwrap();
+        let result = find_binary_path(temp.path(), "my_program");
+        assert!(result.is_none(), "should return None when methods/target missing");
+    }
+
+    #[test]
+    fn find_binary_path_returns_none_when_no_matching_bin() {
+        let temp = tempdir().unwrap();
+        let bin_dir = temp.path()
+            .join("methods/target/riscv-guest/my_methods/riscv32im-risc0-zkvm-elf/release");
+        fs::create_dir_all(&bin_dir).unwrap();
+        fs::write(bin_dir.join("other_program.bin"), b"fake elf").unwrap();
+
+        let result = find_binary_path(temp.path(), "my_program");
+        assert!(result.is_none(), "should return None when no matching bin");
+    }
+
+    #[test]
+    fn find_binary_path_ignores_non_riscv32im_paths() {
+        let temp = tempdir().unwrap();
+        // Put binary in non-riscv32im path
+        let bin_dir = temp.path().join("methods/target/debug");
+        fs::create_dir_all(&bin_dir).unwrap();
+        fs::write(bin_dir.join("my_program.bin"), b"fake elf").unwrap();
+
+        let result = find_binary_path(temp.path(), "my_program");
+        assert!(result.is_none(), "should ignore non-riscv32im paths");
     }
 }

--- a/src/commands/wallet_support.rs
+++ b/src/commands/wallet_support.rs
@@ -453,7 +453,6 @@ fn one_line(text: &str) -> String {
     text.replace(['\n', '\r'], " ")
 }
 
-
 /// Query the sequencer for all deployed program IDs, returning a map of name -> hex ID.
 pub(crate) fn rpc_get_program_ids(sequencer_addr: &str) -> Option<std::collections::HashMap<String, String>> {
     let payload = serde_json::json!({
@@ -481,13 +480,24 @@ pub(crate) fn rpc_get_program_ids(sequencer_addr: &str) -> Option<std::collectio
     let mut result = std::collections::HashMap::new();
     for (name, id_val) in program_ids {
         if let Some(arr) = id_val.as_array() {
-            // Convert [u32; 8] to hex string
-            let bytes: Vec<u8> = arr
-                .iter()
-                .filter_map(|v| v.as_u64())
-                .flat_map(|n| (n as u32).to_be_bytes())
-                .collect();
-            result.insert(name.clone(), hex::encode(&bytes));
+            // Validate: must be exactly 8 elements (ProgramId = [u32; 8])
+            if arr.len() != 8 {
+                continue;
+            }
+            // Convert [u32; 8] to hex string — fail if any element is not a valid u32
+            let mut bytes = Vec::with_capacity(32);
+            let mut valid = true;
+            for v in arr {
+                if let Some(n) = v.as_u64().and_then(|n| u32::try_from(n).ok()) {
+                    bytes.extend_from_slice(&n.to_be_bytes());
+                } else {
+                    valid = false;
+                    break;
+                }
+            }
+            if valid {
+                result.insert(name.clone(), hex::encode(&bytes));
+            }
         }
     }
     Some(result)
@@ -789,4 +799,72 @@ details: [1, 2, 3]
         let combined = "Error: Account must be uninitialized";
         assert!(is_already_initialized_failure(combined));
     }
+    #[test]
+    fn rpc_get_program_ids_parses_valid_response() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+        let url = format!("http://{addr}");
+
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let mut buf = vec![0u8; 4096];
+            let n = stream.read(&mut buf).expect("read");
+            let _ = n;
+            let body = r#"{"jsonrpc":"2.0","id":1,"result":{"program_ids":{"my_program":[1,2,3,4,5,6,7,8]}}}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                body.len(), body
+            );
+            stream.write_all(response.as_bytes()).expect("write");
+        });
+
+        let result = super::rpc_get_program_ids(&url);
+        handle.join().expect("thread");
+
+        assert!(result.is_some(), "should return Some");
+        let ids = result.unwrap();
+        assert!(ids.contains_key("my_program"), "should contain my_program");
+        let hex_id = &ids["my_program"];
+        assert_eq!(hex_id.len(), 64, "program ID should be 32 bytes = 64 hex chars");
+    }
+
+    #[test]
+    fn rpc_get_program_ids_returns_none_when_unreachable() {
+        let result = super::rpc_get_program_ids("http://127.0.0.1:1");
+        assert!(result.is_none(), "should return None when server unreachable");
+    }
+
+    #[test]
+    fn rpc_get_program_ids_rejects_wrong_array_length() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+        let url = format!("http://{addr}");
+
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let mut buf = vec![0u8; 4096];
+            let _ = stream.read(&mut buf).expect("read");
+            // Only 7 elements instead of 8 - malformed
+            let body = r#"{"jsonrpc":"2.0","id":1,"result":{"program_ids":{"bad_program":[1,2,3,4,5,6,7]}}}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                body.len(), body
+            );
+            stream.write_all(response.as_bytes()).expect("write");
+        });
+
+        let result = super::rpc_get_program_ids(&url);
+        handle.join().expect("thread");
+
+        assert!(result.is_some());
+        let ids = result.unwrap();
+        assert!(!ids.contains_key("bad_program"), "should reject 7-element array");
+    }
+
 }

--- a/src/commands/wallet_support.rs
+++ b/src/commands/wallet_support.rs
@@ -453,6 +453,46 @@ fn one_line(text: &str) -> String {
     text.replace(['\n', '\r'], " ")
 }
 
+
+/// Query the sequencer for all deployed program IDs, returning a map of name -> hex ID.
+pub(crate) fn rpc_get_program_ids(sequencer_addr: &str) -> Option<std::collections::HashMap<String, String>> {
+    let payload = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1_u64,
+        "method": "getProgramIds",
+        "params": {}
+    });
+
+    let agent = ureq::AgentBuilder::new()
+        .timeout_connect(Duration::from_secs(2))
+        .timeout_read(Duration::from_secs(3))
+        .timeout_write(Duration::from_secs(2))
+        .build();
+
+    let response = agent
+        .post(sequencer_addr)
+        .set("content-type", "application/json")
+        .send_json(payload)
+        .ok()?;
+
+    let body: Value = response.into_json().ok()?;
+    let program_ids = body.get("result")?.get("program_ids")?.as_object()?;
+
+    let mut result = std::collections::HashMap::new();
+    for (name, id_val) in program_ids {
+        if let Some(arr) = id_val.as_array() {
+            // Convert [u32; 8] to hex string
+            let bytes: Vec<u8> = arr
+                .iter()
+                .filter_map(|v| v.as_u64())
+                .flat_map(|n| (n as u32).to_be_bytes())
+                .collect();
+            result.insert(name.clone(), hex::encode(&bytes));
+        }
+    }
+    Some(result)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{WALLET_CONFIG_FALLBACK, WALLET_CONFIG_PRIMARY};


### PR DESCRIPTION
## Summary

Fixes #59 and #60.

## Changes

### Fix #59 — Dynamic binary discovery

Added `find_binary_path()` that searches `methods/target/` for `.bin` files matching program names in `riscv32im` paths. Falls back to hardcoded path for backward compatibility.

### Fix #60 — Program ID output after deploy

After successful deployment, queries the sequencer for the program ID and displays it:

```
OK  admin_authority submitted
  Tx: abc123...
  Program ID: 5dbcca83eabd8297afeb200665992d57bc5f8be39d4b42f3927df22792ef46bf
```

## Testing

All 53 existing tests pass.

Fixes #59
Fixes #60