### PR TITLE
fix: add workspace.lints to Cargo.toml templates

### DIFF
--- a/templates/default/Cargo.toml.template
+++ b/templates/default/Cargo.toml.template
@@ -15,6 +15,9 @@ members = [
   "methods/guest",
 ]
 
+[workspace.lints.rust]
+unsafe_code = "warn"
+
 [workspace.dependencies]
 nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "{{lez_pin}}" }
 nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "{{lez_pin}}" }

--- a/templates/lez-framework/Cargo.toml.template
+++ b/templates/lez-framework/Cargo.toml.template
@@ -16,6 +16,9 @@ members = [
   "crates/lez-client-gen",
 ]
 
+[workspace.lints.rust]
+unsafe_code = "warn"
+
 [workspace.dependencies]
 nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "{{lez_pin}}" }
 nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "{{lez_pin}}" }


### PR DESCRIPTION
## Summary

Fixes #68.

New scaffold projects failed to build because `methods/Cargo.toml` used `lints.workspace = true` but the root `Cargo.toml` template was missing `[workspace.lints]`.

## Changes

Added `[workspace.lints.rust]` to both templates:
- `templates/default/Cargo.toml.template`
- `templates/lez-framework/Cargo.toml.template`

```toml
[workspace.lints.rust]
unsafe_code = "warn"
```

Fixes #68