### PR TITLE
fix(rpc): call getLastBlockId and parse result as u64

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -9,7 +9,7 @@ use crate::project::load_project;
 use crate::DynResult;
 
 use super::wallet_support::{
-    extract_tx_identifier, is_connectivity_failure, load_wallet_runtime, rpc_get_last_block,
+    extract_tx_identifier, is_connectivity_failure, load_wallet_runtime, rpc_get_last_block_id,
     sequencer_unreachable_hint, summarize_command_failure, wallet_password, RpcReachabilityError,
 };
 
@@ -168,7 +168,7 @@ pub(crate) fn cmd_deploy(
 }
 
 fn preflight_sequencer_reachability(sequencer_addr: &str) -> DynResult<()> {
-    match rpc_get_last_block(sequencer_addr) {
+    match rpc_get_last_block_id(sequencer_addr) {
         Ok(_) => Ok(()),
         Err(RpcReachabilityError::Connectivity(err)) => {
             bail!(

--- a/src/commands/wallet_support.rs
+++ b/src/commands/wallet_support.rs
@@ -415,6 +415,19 @@ pub(crate) fn rpc_get_last_block_id(sequencer_addr: &str) -> Result<u64, RpcReac
         ))
     })?;
 
+    if let Some(err_obj) = body.get("error") {
+        let code = err_obj.get("code").and_then(Value::as_i64);
+        let message = err_obj.get("message").and_then(Value::as_str).unwrap_or("");
+        let formatted = match code {
+            Some(c) => format!("getLastBlockId RPC error {c}: {message}"),
+            None => format!(
+                "getLastBlockId RPC error: {}",
+                one_line(&err_obj.to_string())
+            ),
+        };
+        return Err(RpcReachabilityError::Other(formatted));
+    }
+
     body.get("result").and_then(Value::as_u64).ok_or_else(|| {
         RpcReachabilityError::Other(format!(
             "getLastBlockId response missing numeric `result`: {}",
@@ -762,7 +775,18 @@ details: [1, 2, 3]
         });
 
         let result = super::rpc_get_last_block_id(&url);
-        assert!(result.is_err(), "method-not-found should surface as error");
+        let err_msg = result
+            .expect_err("method-not-found should surface as error")
+            .to_string();
+        assert!(
+            err_msg.contains("-32601") && err_msg.contains("Method not found"),
+            "expected JSON-RPC error code and message to surface, got: {err_msg}"
+        );
+        assert!(
+            !err_msg.contains("missing numeric"),
+            "JSON-RPC error should surface structurally, not fall through to the \
+             generic missing-result branch; got: {err_msg}"
+        );
         handle.join().expect("server thread");
     }
 

--- a/src/commands/wallet_support.rs
+++ b/src/commands/wallet_support.rs
@@ -389,11 +389,11 @@ impl std::fmt::Display for RpcReachabilityError {
 
 impl std::error::Error for RpcReachabilityError {}
 
-pub(crate) fn rpc_get_last_block(sequencer_addr: &str) -> Result<u64, RpcReachabilityError> {
+pub(crate) fn rpc_get_last_block_id(sequencer_addr: &str) -> Result<u64, RpcReachabilityError> {
     let payload = serde_json::json!({
         "jsonrpc": "2.0",
         "id": 1_u64,
-        "method": "get_last_block",
+        "method": "getLastBlockId",
         "params": {}
     });
 
@@ -411,19 +411,16 @@ pub(crate) fn rpc_get_last_block(sequencer_addr: &str) -> Result<u64, RpcReachab
 
     let body: Value = response.into_json().map_err(|err| {
         RpcReachabilityError::Other(format!(
-            "failed to decode get_last_block response from {sequencer_addr}: {err}"
+            "failed to decode getLastBlockId response from {sequencer_addr}: {err}"
         ))
     })?;
 
-    body.get("result")
-        .and_then(|result| result.get("last_block"))
-        .and_then(Value::as_u64)
-        .ok_or_else(|| {
-            RpcReachabilityError::Other(format!(
-                "get_last_block response missing `result.last_block`: {}",
-                one_line(&body.to_string())
-            ))
-        })
+    body.get("result").and_then(Value::as_u64).ok_or_else(|| {
+        RpcReachabilityError::Other(format!(
+            "getLastBlockId response missing numeric `result`: {}",
+            one_line(&body.to_string())
+        ))
+    })
 }
 
 fn map_ureq_error(err: ureq::Error) -> RpcReachabilityError {
@@ -665,7 +662,7 @@ details: [1, 2, 3]
     }
 
     #[test]
-    fn rpc_get_last_block_parses_valid_response() {
+    fn rpc_get_last_block_id_parses_valid_response() {
         use std::io::{Read, Write};
         use std::net::TcpListener;
 
@@ -678,7 +675,7 @@ details: [1, 2, 3]
             let mut buf = [0_u8; 4096];
             let _ = stream.read(&mut buf);
 
-            let body = r#"{"jsonrpc":"2.0","result":{"last_block":42},"id":1}"#;
+            let body = r#"{"jsonrpc":"2.0","result":42,"id":1}"#;
             let response = format!(
                 "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
                 body.len(),
@@ -688,14 +685,15 @@ details: [1, 2, 3]
             stream.flush().expect("flush");
         });
 
-        let block = super::rpc_get_last_block(&url).expect("rpc_get_last_block should succeed");
+        let block =
+            super::rpc_get_last_block_id(&url).expect("rpc_get_last_block_id should succeed");
         assert_eq!(block, 42);
         handle.join().expect("server thread");
     }
 
     #[test]
-    fn rpc_get_last_block_returns_connectivity_error_when_unreachable() {
-        let result = super::rpc_get_last_block("http://127.0.0.1:1");
+    fn rpc_get_last_block_id_returns_connectivity_error_when_unreachable() {
+        let result = super::rpc_get_last_block_id("http://127.0.0.1:1");
         assert!(result.is_err());
         match result.unwrap_err() {
             super::RpcReachabilityError::Connectivity(_) => {}
@@ -704,7 +702,7 @@ details: [1, 2, 3]
     }
 
     #[test]
-    fn rpc_get_last_block_returns_error_on_malformed_response() {
+    fn rpc_get_last_block_id_returns_error_on_malformed_response() {
         use std::io::{Read, Write};
         use std::net::TcpListener;
 
@@ -717,7 +715,7 @@ details: [1, 2, 3]
             let mut buf = [0_u8; 4096];
             let _ = stream.read(&mut buf);
 
-            // Response missing `result.last_block`
+            // Response with non-numeric `result`
             let body = r#"{"jsonrpc":"2.0","result":{},"id":1}"#;
             let response = format!(
                 "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
@@ -728,13 +726,43 @@ details: [1, 2, 3]
             stream.flush().expect("flush");
         });
 
-        let result = super::rpc_get_last_block(&url);
+        let result = super::rpc_get_last_block_id(&url);
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(
-            err_msg.contains("missing `result.last_block`"),
-            "expected missing last_block error, got: {err_msg}"
+            err_msg.contains("missing numeric `result`"),
+            "expected missing numeric result error, got: {err_msg}"
         );
+        handle.join().expect("server thread");
+    }
+
+    #[test]
+    fn rpc_get_last_block_id_returns_error_on_method_not_found() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+        let url = format!("http://{addr}");
+
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let mut buf = [0_u8; 4096];
+            let _ = stream.read(&mut buf);
+
+            let body =
+                r#"{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found"},"id":1}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream.write_all(response.as_bytes()).expect("write");
+            stream.flush().expect("flush");
+        });
+
+        let result = super::rpc_get_last_block_id(&url);
+        assert!(result.is_err(), "method-not-found should surface as error");
         handle.join().expect("server thread");
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1252,7 +1252,8 @@ fn deploy_single_program_submits_successfully() {
                     "Submission confirmed by wallet exit status",
                 ))
                 .and(predicate::str::contains("Succeeded: 1"))
-                .and(predicate::str::contains("Failed: 0")),
+                .and(predicate::str::contains("Failed: 0"))
+                .and(predicate::str::contains("reachability probe failed").not()),
         );
 }
 
@@ -1666,7 +1667,7 @@ fn respond_last_block(stream: &mut TcpStream) {
     let mut buf = [0_u8; 4096];
     let _ = stream.read(&mut buf);
 
-    let body = r#"{"jsonrpc":"2.0","result":{"last_block":123},"id":1}"#;
+    let body = r#"{"jsonrpc":"2.0","result":123,"id":1}"#;
     let response = format!(
         "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
         body.len(),


### PR DESCRIPTION
## Summary

Fixes #73.

The sequencer's RPC surface was refactored in LEZ PR #394 on 2026-03-20: `get_last_block` was renamed to `getLastBlockId` and the response changed from `{\"result\":{\"last_block\":<u64>}}` to `{\"result\":<u64>}`. The scaffold's pinned LEZ (`35d8df0d`, 2026-04-08) is 19 days past that refactor, but the scaffold client at `src/commands/wallet_support.rs:396` was never updated — so every call returns `-32601 Method not found`. This silently breaks:

- `logos-scaffold localnet reset` block-production verification
- `logos-scaffold deploy` sequencer-reachability preflight

## Changes

- `rpc_get_last_block` → **`rpc_get_last_block_id`** (name reflects the semantic change: block → block ID).
- Method string: `\"get_last_block\"` → `\"getLastBlockId\"`.
- Response parsing: `result.last_block` (nested) → `result` (bare `u64`).
- Updated the single caller in `deploy.rs`.
- Updated unit tests to match the new response shape; added a new test asserting `-32601 Method not found` surfaces as an error.

## Verification

- `cargo fmt --check` — clean
- `cargo test --all-targets` — 53 passed
- Dogfooded against live sequencer in `~/src/fryorcraken/cryptarchs`: started localnet → `curl getLastBlockId` returned `{\"result\":3}`; unit tests cover the parse/error paths.

## Test plan

- [x] Unit tests cover: valid response, connectivity error, non-numeric `result`, `Method not found` response.
- [x] Manual: `logos-scaffold localnet reset` (with PR #56) — verification step succeeds rather than timing out. Dogfooded 2026-04-20 against live sequencer in `~/src/fryorcraken/cryptarchs`: reset reported `block_height=1` after restart.
- [ ] Manual: `logos-scaffold deploy` — preflight passes rather than warning about probe failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)