### PR TITLE
docs: prioritize user-driven PRs and cap weekly contributions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,4 +40,4 @@ Generic "this would be nice" does not count.
 - [ ] CI is green
 - [ ] Relevant DOGFOODING scenarios rerun (listed above)
 - [ ] Docs updated (`README.md`, `DOGFOODING.md`) if user-facing behavior changed
-- [ ] I have read [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) and this PR fits within the weekly contribution cap
+- [ ] I have read [CONTRIBUTING.md](/CONTRIBUTING.md) and this PR fits within the weekly contribution cap

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+<!--
+Thanks for opening a PR. Please fill every section below.
+See CONTRIBUTING.md for the full policy.
+
+PRs missing the "Your Project or User Demand" or "User Story" sections
+may be closed without further explanation.
+-->
+
+## Your Project or User Demand
+
+<!--
+Provide ONE of:
+- Link or short description of the project you are building with `logos-scaffold` on the Logos stack.
+- Evidence of user demand: linked issue/discussion, message from someone building on the stack, or similar concrete signal.
+
+Generic "this would be nice" does not count.
+-->
+
+## User Story
+
+<!--
+- What friction did you (or the user you represent) hit?
+- Which `logos-scaffold` command or DOGFOODING scenario (D1–L4) surfaced it?
+- What did you try before this fix?
+-->
+
+## Change Summary
+
+<!-- What this PR does, in 1–3 sentences. -->
+
+## Verification
+
+<!--
+- Which DOGFOODING scenarios did you rerun? List the IDs (D1, D2, L1, …).
+- Tests added or updated.
+-->
+
+## Checklist
+
+- [ ] CI is green
+- [ ] Relevant DOGFOODING scenarios rerun (listed above)
+- [ ] Docs updated (`README.md`, `DOGFOODING.md`) if user-facing behavior changed
+- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and this PR fits within the weekly contribution cap

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,4 +40,4 @@ Generic "this would be nice" does not count.
 - [ ] CI is green
 - [ ] Relevant DOGFOODING scenarios rerun (listed above)
 - [ ] Docs updated (`README.md`, `DOGFOODING.md`) if user-facing behavior changed
-- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and this PR fits within the weekly contribution cap
+- [ ] I have read [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) and this PR fits within the weekly contribution cap

--- a/.github/rate-limit-allowlist.txt
+++ b/.github/rate-limit-allowlist.txt
@@ -1,0 +1,4 @@
+# GitHub usernames exempt from the PR rate limit in .github/workflows/pr-rate-limit.yml.
+# Public members of the logos-co GitHub org are auto-exempted and do not need to be listed here.
+# Use this file for private org members or trusted external contributors.
+# One username per line. Lines starting with # are ignored.

--- a/.github/rate-limit-allowlist.txt
+++ b/.github/rate-limit-allowlist.txt
@@ -2,3 +2,10 @@
 # Public members of the logos-co GitHub org are auto-exempted and do not need to be listed here.
 # Use this file for private org members or trusted external contributors.
 # One username per line. Lines starting with # are ignored.
+marclawclaw
+fryorcraken
+danisharora099
+weboko
+jimmy-claw
+jzaki
+vpavlink

--- a/.github/workflows/pr-rate-limit.yml
+++ b/.github/workflows/pr-rate-limit.yml
@@ -14,12 +14,12 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Checkout default branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.repository.default_branch }}
 
       - name: Enforce rate limit
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/pr-rate-limit.yml
+++ b/.github/workflows/pr-rate-limit.yml
@@ -1,0 +1,106 @@
+name: PR Rate Limit
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  enforce:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Enforce rate limit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const org = 'logos-co';
+            const threshold = 3;
+            const windowDays = 7;
+
+            const pr = context.payload.pull_request;
+            const login = pr.user.login;
+            const prNumber = pr.number;
+            const { owner, repo } = context.repo;
+
+            core.info(`Checking PR #${prNumber} by ${login}`);
+
+            // Exemption A: public logos-co org member.
+            try {
+              await github.rest.orgs.checkPublicMembershipForUser({ org, username: login });
+              core.info(`${login} is a public member of ${org} — exempt.`);
+              return;
+            } catch (err) {
+              if (err.status !== 404) {
+                core.warning(`Org membership check failed with ${err.status}; falling back to file allowlist.`);
+              }
+            }
+
+            // Exemption B: file allowlist.
+            const allowlistPath = path.join('.github', 'rate-limit-allowlist.txt');
+            if (fs.existsSync(allowlistPath)) {
+              const allowed = fs.readFileSync(allowlistPath, 'utf8')
+                .split('\n')
+                .map(l => l.trim())
+                .filter(l => l && !l.startsWith('#'));
+              if (allowed.includes(login)) {
+                core.info(`${login} is in ${allowlistPath} — exempt.`);
+                return;
+              }
+            }
+
+            // Count this author's PRs in the last `windowDays` days.
+            const since = new Date(Date.now() - windowDays * 24 * 3600 * 1000)
+              .toISOString()
+              .split('T')[0];
+            const q = `repo:${owner}/${repo} is:pr author:${login} created:>=${since}`;
+            const search = await github.rest.search.issuesAndPullRequests({ q, per_page: 100 });
+            let count = search.data.total_count;
+            const currentIncluded = search.data.items.some(it => it.number === prNumber);
+            if (!currentIncluded) {
+              // Search indexing can lag just-opened PRs; include it explicitly.
+              count += 1;
+            }
+            core.info(`${login} has opened ${count} PR(s) in the last ${windowDays} days (threshold: ${threshold}).`);
+
+            if (count <= threshold) {
+              return;
+            }
+
+            const repoUrl = context.payload.repository.html_url;
+            const defaultBranch = context.payload.repository.default_branch;
+            const body = [
+              `Thanks for the contribution, @${login}.`,
+              ``,
+              `This PR exceeds the rate limit of **${threshold} PRs per contributor per rolling ${windowDays}-day window**.`,
+              `You currently have ${count} PR(s) opened in that window against this repo.`,
+              ``,
+              `See [CONTRIBUTING.md](${repoUrl}/blob/${defaultBranch}/CONTRIBUTING.md#rate-limit) for the policy.`,
+              `If you need to exceed the cap for a coordinated change, please open an issue first.`,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: prNumber,
+              body,
+            });
+
+            await github.rest.pulls.update({
+              owner,
+              repo,
+              pull_number: prNumber,
+              state: 'closed',
+            });
+
+            core.notice(`Closed PR #${prNumber} by ${login} (over rate limit).`);

--- a/.github/workflows/pr-rate-limit.yml
+++ b/.github/workflows/pr-rate-limit.yml
@@ -2,7 +2,7 @@ name: PR Rate Limit
 
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, reopened]
 
 permissions:
   pull-requests: write
@@ -11,14 +11,15 @@ permissions:
 jobs:
   enforce:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - name: Checkout default branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.repository.default_branch }}
 
       - name: Enforce rate limit
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');
@@ -35,14 +36,26 @@ jobs:
 
             core.info(`Checking PR #${prNumber} by ${login}`);
 
+            // Exemption: bots (dependabot, renovate, etc.) — automated PR floods
+            // are expected and should not be rate-limited like human contributors.
+            if (pr.user.type === 'Bot') {
+              core.info(`${login} is a bot — exempt.`);
+              return;
+            }
+
             // Exemption A: public logos-co org member.
             try {
               await github.rest.orgs.checkPublicMembershipForUser({ org, username: login });
               core.info(`${login} is a public member of ${org} — exempt.`);
               return;
             } catch (err) {
-              if (err.status !== 404) {
-                core.warning(`Org membership check failed with ${err.status}; falling back to file allowlist.`);
+              if (err.status === 404) {
+                // Not a public member; continue to file allowlist check.
+              } else {
+                // Fail open on transient API errors rather than incorrectly
+                // rate-limiting a legitimate org member during GitHub flakes.
+                core.warning(`Org membership check failed with status ${err.status}; skipping rate limit enforcement for this PR.`);
+                return;
               }
             }
 

--- a/.github/workflows/pr-rate-limit.yml
+++ b/.github/workflows/pr-rate-limit.yml
@@ -77,7 +77,14 @@ jobs:
               .toISOString()
               .split('T')[0];
             const q = `repo:${owner}/${repo} is:pr author:${login} created:>=${since}`;
-            const search = await github.rest.search.issuesAndPullRequests({ q, per_page: 100 });
+            let search;
+            try {
+              search = await github.rest.search.issuesAndPullRequests({ q, per_page: 100 });
+            } catch (err) {
+              // Fail open on transient API errors, mirroring the org-membership check above.
+              core.warning(`Search API failed with status ${err.status}; skipping rate limit enforcement for this PR.`);
+              return;
+            }
             let count = search.data.total_count;
             const currentIncluded = search.data.items.some(it => it.number === prNumber);
             if (!currentIncluded) {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,52 @@
 # Contributing to `logos-scaffold`
 
+## Who This Project Is For
+
+`logos-scaffold` exists to help developers build on the Logos stack. Contributions are prioritized accordingly:
+
+1. Developers using `logos-scaffold` to build a real project on the Logos stack, contributing fixes and features based on friction they actually hit.
+2. Contributors who can demonstrate confirmed demand from such users — a linked issue, a discussion, or a concrete request.
+
+Generic cleanups, cosmetic refactors, and "this would be nice" PRs from contributors with no connection to either of the above are the lowest triage priority and are likely to be closed.
+
+## Before You Open a PR
+
+You should have:
+
+- A real project (even a prototype) built with `logos-scaffold` where you hit the friction this PR addresses, **or**
+- Evidence of user demand from someone who does: a linked issue, discussion, or direct request.
+
+Plus:
+
+- Rerun the relevant [DOGFOODING](./DOGFOODING.md) scenarios (`D1`–`L4`). See the "Minimum Rerun Guidance" section at the bottom of that doc.
+- Read the PR template and fill in every section.
+
+## What Makes a High-Quality PR
+
+- **Scoped.** One concern per PR. No drive-by refactors.
+- **Green CI.**
+- **Verified.** Applicable DOGFOODING scenarios rerun. See [DOGFOODING.md](./DOGFOODING.md) — "Minimum Rerun Guidance for Future Changes".
+- **Documented.** If the change affects user-facing behavior, update `README.md` and `DOGFOODING.md` in the same PR.
+
+## LLM-Assisted PRs
+
+LLM assistance is welcome. The contributor is accountable for the diff: you have read every line, you understand why the change is correct, and you have run the verification steps above. Disclosure is not required — every PR is reviewed against the same bar regardless of how it was authored.
+
+## Rate Limit
+
+We cap contributions at **3 PRs per contributor per rolling 7-day window**. A GitHub Action (`.github/workflows/pr-rate-limit.yml`) enforces this automatically on PR open.
+
+Exemptions:
+
+- Public members of the [`logos-co`](https://github.com/logos-co) GitHub organization are auto-exempt.
+- Additional trusted contributors (including private `logos-co` members) can be added to [`.github/rate-limit-allowlist.txt`](./.github/rate-limit-allowlist.txt).
+
+If you need to exceed the cap for a coordinated change, open an issue first.
+
+## When Maintainers Close PRs
+
+Maintainers may close any PR that does not adhere to this guideline or does not add clear requested value, pointing back to this document. Closing is not a judgment of the contributor — it is a triage signal.
+
 ## Local Development
 
 Build the scaffold CLI itself:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,8 @@ Exemptions:
 
 If you need to exceed the cap for a coordinated change, open an issue first.
 
+Reopening an auto-closed PR re-triggers the check and will close it again. To override, a maintainer must add the author to the allowlist, or the author must wait until older PRs fall outside the 7-day window.
+
 ## When Maintainers Close PRs
 
 Maintainers may close any PR that does not adhere to this guideline or does not add clear requested value, pointing back to this document. Closing is not a judgment of the contributor — it is a triage signal.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ You should have:
 
 Plus:
 
-- Rerun the relevant [DOGFOODING](./DOGFOODING.md) scenarios (`D1`–`L4`). See the "Minimum Rerun Guidance" section at the bottom of that doc.
+- Rerun the relevant [DOGFOODING](./DOGFOODING.md#minimum-rerun-guidance-for-future-changes) scenarios (`D1`–`L4`).
 - Read the PR template and fill in every section.
 
 ## What Makes a High-Quality PR


### PR DESCRIPTION
## Your Project or User Demand

Maintainer-initiated: as the project gains visibility we expect drive-by and low-context PRs (including LLM-generated ones) to become a triage cost. This PR sets an explicit policy so that review effort stays aligned with signal from contributors actually building on the Logos stack.

## User Story

Current `CONTRIBUTING.md` is purely mechanical (build, test, dogfooding). There is no policy distinguishing high-signal PRs from drive-bys, no prompt for contributors to share context about the project driving the change, and no mechanism to protect maintainer time from a single contributor flooding the queue.

## Change Summary

- `CONTRIBUTING.md`: adds policy sections (who this project is for, pre-PR checklist, high-quality PR bar, LLM-assisted PRs welcome with contributor ownership, rate limit, close rights). Existing build/test/dogfooding sections preserved.
- `.github/PULL_REQUEST_TEMPLATE.md`: new. Required sections — Your Project or User Demand, User Story, Change Summary, Verification, checklist.
- `.github/workflows/pr-rate-limit.yml`: new. On `pull_request_target: opened`, exempts public `logos-co` org members (via `checkPublicMembershipForUser`), then file allowlist; otherwise counts author PRs in the last 7 days and comments + closes if > 3.
- `.github/rate-limit-allowlist.txt`: new. Header only; for private `logos-co` members and trusted externals.

## Verification

- YAML syntax validated with `python -c "import yaml; yaml.safe_load(...)"`.
- No product code changes; existing CI (`cargo fmt --check`, `cargo check`, `cargo test`) unaffected.
- Rate-limit workflow can only be e2e-verified post-merge against real PR traffic:
  - Allowlist path: open a PR from a `logos-co` public member — expect workflow to exit cleanly with no comment/close.
  - Rate-limited path: a non-exempt account opening a 4th PR in 7 days — expect comment linking CONTRIBUTING.md#rate-limit and automatic close.
- DOGFOODING scenarios: not applicable (no CLI or template behavior changed).

## Checklist

- [x] CI is green
- [x] Relevant DOGFOODING scenarios rerun (N/A — no product surface changes)
- [x] Docs updated (`CONTRIBUTING.md`) for new policy
- [x] I have read `CONTRIBUTING.md` and this PR fits within the weekly contribution cap

## Known caveats

- The default `GITHUB_TOKEN` cannot see **private** `logos-co` org membership. Private members need to be added to `.github/rate-limit-allowlist.txt`, or a PAT with `read:org` would need to be wired in (out of scope).
- Search API indexing can lag a just-opened PR by a few seconds; the workflow compensates by explicitly incrementing the count if the current PR is absent from results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)