### PR TITLE
fix(deploy): dynamic binary discovery for non-template projects

### DIFF
--- a/ADR.md
+++ b/ADR.md
@@ -147,6 +147,9 @@ construction.
 
 The deploy command must work for any scaffolded project regardless of its name.
 Binary discovery should derive paths from the actual project structure, not assume the template's naming.
-Use a two-tier strategy: walk `methods/target/` for program-name-matched `.bin` files in `riscv32im` paths (primary),
-with the hardcoded template path as a backward-compatible fallback.
-This keeps the scaffold general and avoids coupling to specific build-tool configuration formats.
+The implementation walks both `target/riscv-guest/` (the canonical risc0 layout used by the
+scaffold template) and `methods/target/` (the sub-crate workspace layout), matching `<program>.bin`
+files whose path components include both a `riscv32im*` target triple and a `release` directory.
+Release builds are preferred; if only a debug build exists, that is used as a fallback. When
+multiple matches exist, the shallowest path wins. This keeps the scaffold general and avoids
+coupling to a specific project name or workspace layout.

--- a/ADR.md
+++ b/ADR.md
@@ -149,4 +149,4 @@ The deploy command must work for any scaffolded project regardless of its name.
 Binary discovery should derive paths from the actual project structure, not assume the template's naming.
 Use a two-tier strategy: walk `methods/target/` for program-name-matched `.bin` files in `riscv32im` paths (primary),
 with the hardcoded template path as a backward-compatible fallback.
-This keeps the scaffold general and avoids coupling to spel configuration formats.
+This keeps the scaffold general and avoids coupling to specific build-tool configuration formats.

--- a/ADR.md
+++ b/ADR.md
@@ -30,7 +30,7 @@ Use native Cargo-based build flow as the primary compilation path.
 Developers need explicit, editable environment targeting for local and DevNet workflows.
 Use environment-file based network configuration as the default model.
 Generated projects include env files for local and DevNet,
-wallet interaction settings used by deploy and interact commands.
+wallet interaction settings used by deploy and wallet-based interaction commands.
 Env files are familiar and automation-friendly,
 but require strict handling to avoid credential leakage.
 
@@ -142,3 +142,11 @@ logic. The tradeoff is one extra argument on an internal helper; the upside is
 that any resolver fix automatically applies to both commands, and the "only
 `.#lgx-portable` found" and "only `.#lgx` found" error paths are symmetric by
 construction.
+
+## Build Output Discovery
+
+The deploy command must work for any scaffolded project regardless of its name.
+Binary discovery should derive paths from the actual project structure, not assume the template's naming.
+Use a two-tier strategy: walk `methods/target/` for program-name-matched `.bin` files in `riscv32im` paths (primary),
+with the hardcoded template path as a backward-compatible fallback.
+This keeps the scaffold general and avoids coupling to spel configuration formats.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "ureq",
+ "walkdir",
 ]
 
 [[package]]
@@ -841,6 +842,15 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "semver"
@@ -1100,6 +1110,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,6 +1248,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tar = "0.4.44"
 tempfile = "3.18.0"
 thiserror = "2.0"
 ureq = { version = "2.12", features = ["json"] }
+walkdir = "2"
 
 [dev-dependencies]
 assert_cmd = "2.0.16"

--- a/FURPS.md
+++ b/FURPS.md
@@ -7,6 +7,7 @@
 1. One public DevNet vertical slice: generate wallet, fund wallet, deploy contract, execute one transaction type, verify result.
 2. Integrate wallet generation as part of the scaffold workflow for bootstrap and interaction flows.
 3. Support native token topup for wallet operations on local and DevNet environments.
+4. Deploy command auto-discovers program binaries from `methods/target/` by matching program names, so non-template projects deploy without `--program-path`.
 
 ### Usability
 

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -14,8 +15,12 @@ use super::wallet_support::{
     sequencer_unreachable_hint, summarize_command_failure, wallet_password, RpcReachabilityError,
 };
 
-const GUEST_BIN_REL_PATH: &str =
-    "target/riscv-guest/example_program_deployment_methods/example_program_deployment_programs/riscv32im-risc0-zkvm-elf/release";
+/// Roots searched (in order) for guest `.bin` artefacts. Both layouts exist in
+/// the wild: risc0's default workspace layout emits to `target/riscv-guest/...`
+/// (used by the scaffold template), while sub-crate builds can land in
+/// `methods/target/...`. Discovery walks both so renamed projects work
+/// regardless of which layout cargo/risc0 chose.
+const GUEST_BIN_SEARCH_ROOTS: &[&str] = &["target/riscv-guest", "methods/target"];
 const DEFAULT_SEQUENCER_ADDR: &str = "http://127.0.0.1:3040";
 
 pub(crate) fn cmd_deploy(
@@ -55,17 +60,20 @@ pub(crate) fn cmd_deploy(
     }
 
     let selected_programs = resolve_selected_programs(program_name, &available_programs)?;
-    let binaries_root = project.root.join(GUEST_BIN_REL_PATH);
+    let discovered = discover_program_binaries(&project.root, &selected_programs);
 
     preflight_sequencer_reachability(&sequencer_addr)?;
 
     let mut results = Vec::new();
     for program in selected_programs {
-        let binary_path = find_binary_path(&project.root, &program)
-            .unwrap_or_else(|| binaries_root.join(format!("{program}.bin")));
-        if !binary_path.exists() {
+        let Some(binary_path) = discovered.get(&program).cloned() else {
+            let searched = GUEST_BIN_SEARCH_ROOTS
+                .iter()
+                .map(|r| project.root.join(r).display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
             println!("FAIL {program} deployment failed");
-            println!("  Error: missing binary at {}", binary_path.display());
+            println!("  Error: missing binary `{program}.bin` (searched: {searched})");
             println!("  Hint: run `logos-scaffold build` first.");
             results.push(DeployResult {
                 program,
@@ -74,7 +82,7 @@ pub(crate) fn cmd_deploy(
                 tx: None,
             });
             continue;
-        }
+        };
 
         let mut command = Command::new(&wallet.wallet_binary);
         command
@@ -329,57 +337,95 @@ impl DeployStatus {
     }
 }
 
-/// Walk `methods/target/` looking for `<program>.bin` in paths containing "riscv32im".
-/// Returns the first match, preferring release paths over debug. Returns `None` if not found.
-fn find_binary_path(project_root: &Path, program: &str) -> Option<PathBuf> {
-    // Sanity-check the program name to prevent pathological inputs
-    if program.len() > 128
-        || program.contains('/')
-        || program.contains('\\')
-        || program.contains("..")
-    {
-        return None;
+fn is_valid_program_name(program: &str) -> bool {
+    !program.is_empty()
+        && program.len() <= 128
+        && !program.contains('/')
+        && !program.contains('\\')
+        && !program.contains("..")
+}
+
+/// Walk every `GUEST_BIN_SEARCH_ROOTS` once and return a `program -> binary_path`
+/// map. Only paths whose components include both a `riscv32im*` target triple
+/// and a `release` directory match (debug builds are ignored as a fallback).
+/// When multiple matches exist for the same program, the shallowest path wins
+/// (preferring the canonical risc0 layout over nested workspace duplicates).
+pub(crate) fn discover_program_binaries(
+    project_root: &Path,
+    programs: &[String],
+) -> HashMap<String, PathBuf> {
+    let wanted: HashMap<String, &str> = programs
+        .iter()
+        .filter(|p| is_valid_program_name(p))
+        .map(|p| (format!("{p}.bin"), p.as_str()))
+        .collect();
+    if wanted.is_empty() {
+        return HashMap::new();
     }
-    let target_dir = project_root.join("methods/target");
-    if !target_dir.exists() {
-        return None;
-    }
-    let expected_filename = format!("{program}.bin");
-    let mut release_candidate: Option<PathBuf> = None;
-    for entry in WalkDir::new(&target_dir)
-        .follow_links(false)
-        .into_iter()
-        .filter_map(|e| e.ok())
-    {
-        let path = entry.path();
-        if path.file_name().and_then(|f| f.to_str()) != Some(expected_filename.as_str()) {
+
+    let mut release: HashMap<String, (usize, PathBuf)> = HashMap::new();
+    let mut debug_fallback: HashMap<String, (usize, PathBuf)> = HashMap::new();
+
+    for root in GUEST_BIN_SEARCH_ROOTS {
+        let search_dir = project_root.join(root);
+        if !search_dir.exists() {
             continue;
         }
-        let mut has_riscv32im = false;
-        let mut has_release = false;
-        for component in path.components() {
-            if let std::path::Component::Normal(name) = component {
-                if let Some(name) = name.to_str() {
-                    if name.starts_with("riscv32im") {
-                        has_riscv32im = true;
-                    }
-                    if name == "release" {
-                        has_release = true;
+        for entry in WalkDir::new(&search_dir)
+            .follow_links(false)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            let path = entry.path();
+            let Some(filename) = path.file_name().and_then(|f| f.to_str()) else {
+                continue;
+            };
+            let Some(&program) = wanted.get(filename) else {
+                continue;
+            };
+
+            let mut has_riscv32im = false;
+            let mut has_release = false;
+            let mut depth = 0usize;
+            for component in path.components() {
+                if let std::path::Component::Normal(name) = component {
+                    depth += 1;
+                    if let Some(name) = name.to_str() {
+                        if name.starts_with("riscv32im") {
+                            has_riscv32im = true;
+                        }
+                        if name == "release" {
+                            has_release = true;
+                        }
                     }
                 }
             }
-        }
-        if !has_riscv32im {
-            continue;
-        }
-        if has_release {
-            return Some(path.to_path_buf());
-        }
-        if release_candidate.is_none() {
-            release_candidate = Some(path.to_path_buf());
+            if !has_riscv32im {
+                continue;
+            }
+
+            let bucket = if has_release {
+                &mut release
+            } else {
+                &mut debug_fallback
+            };
+            match bucket.get(program) {
+                Some((existing_depth, _)) if *existing_depth <= depth => {}
+                _ => {
+                    bucket.insert(program.to_string(), (depth, path.to_path_buf()));
+                }
+            }
         }
     }
-    release_candidate
+
+    let mut out = HashMap::new();
+    for (program, (_, path)) in release {
+        out.insert(program, path);
+    }
+    for (program, (_, path)) in debug_fallback {
+        out.entry(program).or_insert(path);
+    }
+    out
 }
 
 #[cfg(test)]
@@ -388,8 +434,13 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
+    fn lookup(root: &Path, program: &str) -> Option<PathBuf> {
+        discover_program_binaries(root, &[program.to_string()])
+            .remove(program)
+    }
+
     #[test]
-    fn find_binary_in_riscv32im_path() {
+    fn finds_binary_in_methods_target_layout() {
         let tmp = TempDir::new().unwrap();
         let bin_dir = tmp
             .path()
@@ -397,15 +448,35 @@ mod tests {
         fs::create_dir_all(&bin_dir).unwrap();
         fs::write(bin_dir.join("my_program.bin"), b"fake").unwrap();
 
-        let result = find_binary_path(tmp.path(), "my_program");
-        assert!(result.is_some());
-        assert!(result.unwrap().ends_with("my_program.bin"));
+        let result = lookup(tmp.path(), "my_program").unwrap();
+        assert!(result.ends_with("my_program.bin"));
+    }
+
+    /// Regression test for issue #59: a project named anything other than
+    /// the scaffold template (`example_program_deployment`) places its guest
+    /// binaries under `target/riscv-guest/<project>_methods/<project>_programs/...`.
+    /// Before this PR, deploy hardcoded the template name and could never
+    /// find these binaries.
+    #[test]
+    fn finds_binary_for_renamed_project_in_riscv_guest_layout() {
+        let tmp = TempDir::new().unwrap();
+        let bin_dir = tmp.path().join(
+            "target/riscv-guest/my_app_methods/my_app_programs/riscv32im-risc0-zkvm-elf/release",
+        );
+        fs::create_dir_all(&bin_dir).unwrap();
+        fs::write(bin_dir.join("foo.bin"), b"fake").unwrap();
+
+        let result = lookup(tmp.path(), "foo").unwrap();
+        assert!(result.ends_with("foo.bin"));
+        assert!(result
+            .components()
+            .any(|c| c.as_os_str() == "my_app_methods"));
     }
 
     #[test]
-    fn returns_none_when_methods_target_missing() {
+    fn returns_none_when_no_search_roots_exist() {
         let tmp = TempDir::new().unwrap();
-        assert!(find_binary_path(tmp.path(), "my_program").is_none());
+        assert!(lookup(tmp.path(), "my_program").is_none());
     }
 
     #[test]
@@ -417,7 +488,7 @@ mod tests {
         fs::create_dir_all(&bin_dir).unwrap();
         fs::write(bin_dir.join("other_program.bin"), b"fake").unwrap();
 
-        assert!(find_binary_path(tmp.path(), "my_program").is_none());
+        assert!(lookup(tmp.path(), "my_program").is_none());
     }
 
     #[test]
@@ -429,21 +500,21 @@ mod tests {
         fs::create_dir_all(&bin_dir).unwrap();
         fs::write(bin_dir.join("my_program.bin"), b"fake").unwrap();
 
-        assert!(find_binary_path(tmp.path(), "my_program").is_none());
+        assert!(lookup(tmp.path(), "my_program").is_none());
     }
 
     #[test]
     fn rejects_path_traversal_in_program_name() {
         let tmp = TempDir::new().unwrap();
-        assert!(find_binary_path(tmp.path(), "../etc/passwd").is_none());
-        assert!(find_binary_path(tmp.path(), "foo/../bar").is_none());
+        assert!(lookup(tmp.path(), "../etc/passwd").is_none());
+        assert!(lookup(tmp.path(), "foo/../bar").is_none());
     }
 
     #[test]
     fn rejects_overlong_program_name() {
         let tmp = TempDir::new().unwrap();
         let long_name = "a".repeat(200);
-        assert!(find_binary_path(tmp.path(), &long_name).is_none());
+        assert!(lookup(tmp.path(), &long_name).is_none());
     }
 
     #[test]
@@ -460,8 +531,21 @@ mod tests {
         fs::write(debug_dir.join("my_program.bin"), b"debug").unwrap();
         fs::write(release_dir.join("my_program.bin"), b"release").unwrap();
 
-        let result = find_binary_path(tmp.path(), "my_program").unwrap();
+        let result = lookup(tmp.path(), "my_program").unwrap();
         assert!(result.components().any(|c| c.as_os_str() == "release"));
+    }
+
+    #[test]
+    fn falls_back_to_debug_when_only_debug_exists() {
+        let tmp = TempDir::new().unwrap();
+        let debug_dir = tmp
+            .path()
+            .join("methods/target/some_crate/riscv32im-risc0-zkvm-elf/debug");
+        fs::create_dir_all(&debug_dir).unwrap();
+        fs::write(debug_dir.join("my_program.bin"), b"debug").unwrap();
+
+        let result = lookup(tmp.path(), "my_program").unwrap();
+        assert!(result.components().any(|c| c.as_os_str() == "debug"));
     }
 
     #[test]
@@ -473,6 +557,25 @@ mod tests {
         fs::create_dir_all(&bin_dir).unwrap();
         fs::write(bin_dir.join("my_program.bin"), b"fake").unwrap();
 
-        assert!(find_binary_path(tmp.path(), "my_program").is_none());
+        assert!(lookup(tmp.path(), "my_program").is_none());
+    }
+
+    #[test]
+    fn discover_handles_multiple_programs_in_one_walk() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join(
+            "target/riscv-guest/my_app_methods/my_app_programs/riscv32im-risc0-zkvm-elf/release",
+        );
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("foo.bin"), b"a").unwrap();
+        fs::write(dir.join("bar.bin"), b"b").unwrap();
+
+        let map = discover_program_binaries(
+            tmp.path(),
+            &["foo".to_string(), "bar".to_string(), "missing".to_string()],
+        );
+        assert!(map.get("foo").unwrap().ends_with("foo.bin"));
+        assert!(map.get("bar").unwrap().ends_with("bar.bin"));
+        assert!(!map.contains_key("missing"));
     }
 }

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -435,8 +435,7 @@ mod tests {
     use tempfile::TempDir;
 
     fn lookup(root: &Path, program: &str) -> Option<PathBuf> {
-        discover_program_binaries(root, &[program.to_string()])
-            .remove(program)
+        discover_program_binaries(root, &[program.to_string()]).remove(program)
     }
 
     #[test]
@@ -551,9 +550,7 @@ mod tests {
     #[test]
     fn rejects_substring_only_riscv32im_components() {
         let tmp = TempDir::new().unwrap();
-        let bin_dir = tmp
-            .path()
-            .join("methods/target/not-riscv32im-foo/release");
+        let bin_dir = tmp.path().join("methods/target/not-riscv32im-foo/release");
         fs::create_dir_all(&bin_dir).unwrap();
         fs::write(bin_dir.join("my_program.bin"), b"fake").unwrap();
 

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{bail, Context};
+use walkdir::WalkDir;
 
 use crate::process::run_with_stdin;
 use crate::project::load_project;
@@ -60,7 +61,8 @@ pub(crate) fn cmd_deploy(
 
     let mut results = Vec::new();
     for program in selected_programs {
-        let binary_path = binaries_root.join(format!("{program}.bin"));
+        let binary_path = find_binary_path(&project.root, &program)
+            .unwrap_or_else(|| binaries_root.join(format!("{program}.bin")));
         if !binary_path.exists() {
             println!("FAIL {program} deployment failed");
             println!("  Error: missing binary at {}", binary_path.display());
@@ -324,5 +326,108 @@ impl DeployStatus {
             DeployStatus::Submitted => "submitted",
             DeployStatus::Failed => "failed",
         }
+    }
+}
+
+/// Walk `methods/target/` looking for `<program>.bin` in paths containing "riscv32im".
+/// Returns the first match, preferring release paths over debug. Returns `None` if not found.
+fn find_binary_path(project_root: &Path, program: &str) -> Option<PathBuf> {
+    // Sanity-check the program name to prevent pathological inputs
+    if program.len() > 128
+        || program.contains('/')
+        || program.contains('\\')
+        || program.contains("..")
+    {
+        return None;
+    }
+    let target_dir = project_root.join("methods/target");
+    if !target_dir.exists() {
+        return None;
+    }
+    let expected_filename = format!("{program}.bin");
+    let mut release_candidate: Option<PathBuf> = None;
+    for entry in WalkDir::new(&target_dir)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path();
+        if path.file_name().and_then(|f| f.to_str()) == Some(expected_filename.as_str()) {
+            let path_str = path.to_string_lossy();
+            if path_str.contains("riscv32im") {
+                if path_str.contains("/release/") || path_str.contains("\\release\\") {
+                    return Some(path.to_path_buf());
+                }
+                if release_candidate.is_none() {
+                    release_candidate = Some(path.to_path_buf());
+                }
+            }
+        }
+    }
+    release_candidate
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn find_binary_in_riscv32im_path() {
+        let tmp = TempDir::new().unwrap();
+        let bin_dir = tmp
+            .path()
+            .join("methods/target/some_crate/riscv32im-risc0-zkvm-elf/release");
+        fs::create_dir_all(&bin_dir).unwrap();
+        fs::write(bin_dir.join("my_program.bin"), b"fake").unwrap();
+
+        let result = find_binary_path(tmp.path(), "my_program");
+        assert!(result.is_some());
+        assert!(result.unwrap().ends_with("my_program.bin"));
+    }
+
+    #[test]
+    fn returns_none_when_methods_target_missing() {
+        let tmp = TempDir::new().unwrap();
+        assert!(find_binary_path(tmp.path(), "my_program").is_none());
+    }
+
+    #[test]
+    fn returns_none_when_no_matching_bin() {
+        let tmp = TempDir::new().unwrap();
+        let bin_dir = tmp
+            .path()
+            .join("methods/target/some_crate/riscv32im-risc0-zkvm-elf/release");
+        fs::create_dir_all(&bin_dir).unwrap();
+        fs::write(bin_dir.join("other_program.bin"), b"fake").unwrap();
+
+        assert!(find_binary_path(tmp.path(), "my_program").is_none());
+    }
+
+    #[test]
+    fn ignores_non_riscv32im_paths() {
+        let tmp = TempDir::new().unwrap();
+        let bin_dir = tmp
+            .path()
+            .join("methods/target/some_crate/x86_64-unknown-linux/release");
+        fs::create_dir_all(&bin_dir).unwrap();
+        fs::write(bin_dir.join("my_program.bin"), b"fake").unwrap();
+
+        assert!(find_binary_path(tmp.path(), "my_program").is_none());
+    }
+
+    #[test]
+    fn rejects_path_traversal_in_program_name() {
+        let tmp = TempDir::new().unwrap();
+        assert!(find_binary_path(tmp.path(), "../etc/passwd").is_none());
+        assert!(find_binary_path(tmp.path(), "foo/../bar").is_none());
+    }
+
+    #[test]
+    fn rejects_overlong_program_name() {
+        let tmp = TempDir::new().unwrap();
+        let long_name = "a".repeat(200);
+        assert!(find_binary_path(tmp.path(), &long_name).is_none());
     }
 }

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -352,16 +352,31 @@ fn find_binary_path(project_root: &Path, program: &str) -> Option<PathBuf> {
         .filter_map(|e| e.ok())
     {
         let path = entry.path();
-        if path.file_name().and_then(|f| f.to_str()) == Some(expected_filename.as_str()) {
-            let path_str = path.to_string_lossy();
-            if path_str.contains("riscv32im") {
-                if path_str.contains("/release/") || path_str.contains("\\release\\") {
-                    return Some(path.to_path_buf());
-                }
-                if release_candidate.is_none() {
-                    release_candidate = Some(path.to_path_buf());
+        if path.file_name().and_then(|f| f.to_str()) != Some(expected_filename.as_str()) {
+            continue;
+        }
+        let mut has_riscv32im = false;
+        let mut has_release = false;
+        for component in path.components() {
+            if let std::path::Component::Normal(name) = component {
+                if let Some(name) = name.to_str() {
+                    if name.starts_with("riscv32im") {
+                        has_riscv32im = true;
+                    }
+                    if name == "release" {
+                        has_release = true;
+                    }
                 }
             }
+        }
+        if !has_riscv32im {
+            continue;
+        }
+        if has_release {
+            return Some(path.to_path_buf());
+        }
+        if release_candidate.is_none() {
+            release_candidate = Some(path.to_path_buf());
         }
     }
     release_candidate
@@ -429,5 +444,35 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let long_name = "a".repeat(200);
         assert!(find_binary_path(tmp.path(), &long_name).is_none());
+    }
+
+    #[test]
+    fn prefers_release_over_debug() {
+        let tmp = TempDir::new().unwrap();
+        let debug_dir = tmp
+            .path()
+            .join("methods/target/some_crate/riscv32im-risc0-zkvm-elf/debug");
+        let release_dir = tmp
+            .path()
+            .join("methods/target/some_crate/riscv32im-risc0-zkvm-elf/release");
+        fs::create_dir_all(&debug_dir).unwrap();
+        fs::create_dir_all(&release_dir).unwrap();
+        fs::write(debug_dir.join("my_program.bin"), b"debug").unwrap();
+        fs::write(release_dir.join("my_program.bin"), b"release").unwrap();
+
+        let result = find_binary_path(tmp.path(), "my_program").unwrap();
+        assert!(result.components().any(|c| c.as_os_str() == "release"));
+    }
+
+    #[test]
+    fn rejects_substring_only_riscv32im_components() {
+        let tmp = TempDir::new().unwrap();
+        let bin_dir = tmp
+            .path()
+            .join("methods/target/not-riscv32im-foo/release");
+        fs::create_dir_all(&bin_dir).unwrap();
+        fs::write(bin_dir.join("my_program.bin"), b"fake").unwrap();
+
+        assert!(find_binary_path(tmp.path(), "my_program").is_none());
     }
 }

--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -23,7 +23,6 @@ use crate::state::write_text;
 use crate::DynResult;
 
 const REPORT_WARNING: &str = "WARNING: This diagnostics bundle is sanitized on a best-effort basis and may still contain sensitive data. Inspect every file before sharing it publicly.";
-const GUEST_BIN_REL_PATH: &str = "target/riscv-guest/example_program_deployment_methods/example_program_deployment_programs/riscv32im-risc0-zkvm-elf/release";
 
 pub(crate) fn cmd_report(out: Option<PathBuf>, tail: usize) -> DynResult<()> {
     let project = load_project().context(
@@ -630,7 +629,6 @@ fn collect_build_evidence(
     sanitize_ctx: &SanitizeContext,
 ) -> BuildEvidenceReport {
     let guest_src_dir = project.root.join("methods/guest/src/bin");
-    let guest_bin_dir = project.root.join(GUEST_BIN_REL_PATH);
     let workspace_target = project.root.join("target");
 
     let mut guest_programs = Vec::new();
@@ -647,38 +645,34 @@ fn collect_build_evidence(
     }
     guest_programs.sort();
 
+    let discovered = super::deploy::discover_program_binaries(&project.root, &guest_programs);
+
     let mut expected_binaries = Vec::new();
     for program in &guest_programs {
-        let path = guest_bin_dir.join(format!("{program}.bin"));
+        let path = discovered
+            .get(program)
+            .cloned()
+            .unwrap_or_else(|| project.root.join(format!("{program}.bin")));
+        let exists = discovered.contains_key(program);
         expected_binaries.push(BinaryArtifactSummary {
             program: program.clone(),
             relative_path: scrub_path_string(&rel_path(&path, &project.root), sanitize_ctx),
-            exists: path.exists(),
-            modified_unix: file_mtime_unix(&path),
-            size_bytes: file_size_bytes(&path),
+            exists,
+            modified_unix: if exists { file_mtime_unix(&path) } else { None },
+            size_bytes: if exists { file_size_bytes(&path) } else { None },
         });
     }
 
-    let mut discovered_binaries = Vec::new();
-    if let Ok(entries) = fs::read_dir(&guest_bin_dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().and_then(|ext| ext.to_str()) != Some("bin") {
-                continue;
-            }
-            discovered_binaries.push(BinaryArtifactSummary {
-                program: path
-                    .file_stem()
-                    .and_then(|stem| stem.to_str())
-                    .unwrap_or("unknown")
-                    .to_string(),
-                relative_path: scrub_path_string(&rel_path(&path, &project.root), sanitize_ctx),
-                exists: true,
-                modified_unix: file_mtime_unix(&path),
-                size_bytes: file_size_bytes(&path),
-            });
-        }
-    }
+    let mut discovered_binaries: Vec<BinaryArtifactSummary> = discovered
+        .iter()
+        .map(|(program, path)| BinaryArtifactSummary {
+            program: program.clone(),
+            relative_path: scrub_path_string(&rel_path(path, &project.root), sanitize_ctx),
+            exists: true,
+            modified_unix: file_mtime_unix(path),
+            size_bytes: file_size_bytes(path),
+        })
+        .collect();
     discovered_binaries.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
 
     BuildEvidenceReport {


### PR DESCRIPTION
## Summary

Fixes #59.

`logos-scaffold deploy` previously hardcoded the scaffold template's binary path (`target/riscv-guest/example_program_deployment_methods/example_program_deployment_programs/riscv32im-risc0-zkvm-elf/release/`). Any project with a different name fell through to a "missing binary" error even after a successful build.

## Changes

- New `discover_program_binaries()` walks both candidate roots — `target/riscv-guest/` (canonical risc0 layout) and `methods/target/` (sub-crate workspace layout) — once per `deploy` invocation, returning a `program → path` map.
- Match criteria: filename `<program>.bin` AND a path component starting with `riscv32im` (component-level, not substring — rejects e.g. `not-riscv32im-foo/`).
- Deterministic precedence: release > debug; on ties, shallowest path wins.
- Input validation on program names (length, `/`, `\`, `..`) prevents pathological inputs from driving the walk.
- Error message now lists the directories actually searched instead of a phantom hardcoded path.
- `report.rs` uses the same discovery so diagnostic bundles reflect real binaries on renamed projects (the same hardcoded-path bug existed there).
- `--program-path` escape hatch is unchanged.

## Tests

11 unit tests in `deploy.rs` covering:
- Both layouts (`methods/target/` and `target/riscv-guest/<renamed_project>_methods/...`) — the latter is the explicit #59 regression test
- Missing search roots, no matching `.bin`, non-`riscv32im` paths
- Path traversal and overlong program-name rejection
- Release-over-debug precedence + debug-only fallback
- Substring-only `riscv32im` rejection (e.g. `not-riscv32im-foo`)
- Multi-program single-walk behaviour

Full test suite: 300 pass (200 lib + 100 cli).

## Test plan

- [x] `cargo test` (full suite)
- [x] `cargo clippy --all-targets`
- [ ] Manual: `lgs new my_app && cd my_app && lgs build && lgs deploy` resolves binaries under `target/riscv-guest/my_app_methods/...`