### PR TITLE
fix(wallet,deploy): default sequencer URL from scaffold localnet port

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -9,13 +9,13 @@ use crate::project::load_project;
 use crate::DynResult;
 
 use super::wallet_support::{
-    extract_tx_identifier, is_connectivity_failure, load_wallet_runtime, rpc_get_last_block_id,
-    sequencer_unreachable_hint, summarize_command_failure, wallet_password, RpcReachabilityError,
+    default_sequencer_http_url_for_project, extract_tx_identifier, is_connectivity_failure,
+    load_wallet_runtime, rpc_get_last_block_id, sequencer_unreachable_hint,
+    summarize_command_failure, wallet_password, RpcReachabilityError,
 };
 
 const GUEST_BIN_REL_PATH: &str =
     "target/riscv-guest/example_program_deployment_methods/example_program_deployment_programs/riscv32im-risc0-zkvm-elf/release";
-const DEFAULT_SEQUENCER_ADDR: &str = "http://127.0.0.1:3040";
 
 pub(crate) fn cmd_deploy(
     program_name: Option<String>,
@@ -30,7 +30,7 @@ pub(crate) fn cmd_deploy(
     let sequencer_addr = wallet
         .sequencer_addr
         .clone()
-        .unwrap_or_else(|| DEFAULT_SEQUENCER_ADDR.to_string());
+        .unwrap_or_else(|| default_sequencer_http_url_for_project(&project));
 
     // --program-path: deploy a single custom ELF directly, skip auto-discovery
     if let Some(custom_path) = program_path {

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -12,8 +12,9 @@ use crate::project::{load_project, resolve_repo_path};
 use crate::DynResult;
 
 use super::wallet_support::{
-    extract_tx_identifier, is_connectivity_failure, load_wallet_runtime, rpc_get_last_block_id,
-    sequencer_unreachable_hint, summarize_command_failure, wallet_password, RpcReachabilityError,
+    default_sequencer_http_url_for_project, extract_tx_identifier, is_connectivity_failure,
+    load_wallet_runtime, rpc_get_last_block_id, sequencer_unreachable_hint,
+    summarize_command_failure, wallet_password, RpcReachabilityError,
 };
 
 /// Roots searched (in order) for guest `.bin` artefacts. Both layouts exist in
@@ -24,7 +25,6 @@ use super::wallet_support::{
 /// this constant is the same project-relative directory that `build.rs`
 /// compiles via `crate::constants::METHODS_DIR`; keep them in sync.
 const GUEST_BIN_SEARCH_ROOTS: &[&str] = &["target/riscv-guest", "methods/target"];
-const DEFAULT_SEQUENCER_ADDR: &str = "http://127.0.0.1:3040";
 
 /// `spel inspect` line prefix that carries the risc0 image ID — the value the
 /// sequencer uses as the on-chain program ID. Format is whitespace-tolerant:
@@ -44,7 +44,7 @@ pub(crate) fn cmd_deploy(
     let sequencer_addr = wallet
         .sequencer_addr
         .clone()
-        .unwrap_or_else(|| DEFAULT_SEQUENCER_ADDR.to_string());
+        .unwrap_or_else(|| default_sequencer_http_url_for_project(&project));
 
     // --program-path: deploy a single custom ELF directly, skip auto-discovery
     if let Some(custom_path) = program_path {

--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -7,10 +7,11 @@ use crate::project::load_project;
 use crate::DynResult;
 
 use super::wallet_support::{
-    extract_tx_identifier, is_already_initialized_failure, is_confirmation_timeout_failure,
-    is_connectivity_failure, is_uninitialized_account_output, load_wallet_runtime,
-    read_default_wallet_address, resolve_wallet_address, sequencer_unreachable_hint,
-    summarize_command_failure, wallet_password, wallet_state_path, write_default_wallet_address,
+    default_sequencer_http_url_for_project, extract_tx_identifier, is_already_initialized_failure,
+    is_confirmation_timeout_failure, is_connectivity_failure, is_uninitialized_account_output,
+    load_wallet_runtime, read_default_wallet_address, resolve_wallet_address,
+    sequencer_unreachable_hint, summarize_command_failure, wallet_password, wallet_state_path,
+    write_default_wallet_address,
 };
 
 #[derive(Debug, Clone)]
@@ -98,7 +99,7 @@ fn cmd_wallet_topup(
     let sequencer_addr = wallet
         .sequencer_addr
         .clone()
-        .unwrap_or_else(|| "http://127.0.0.1:3040".to_string());
+        .unwrap_or_else(|| default_sequencer_http_url_for_project(project));
     let wallet_home = wallet.wallet_home.as_os_str().to_string_lossy().to_string();
     let password_input = format!("{}\n", wallet_password());
 

--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -7,10 +7,11 @@ use crate::project::load_project;
 use crate::DynResult;
 
 use super::wallet_support::{
-    extract_tx_identifier, is_already_initialized_failure, is_confirmation_timeout_failure,
-    is_connectivity_failure, is_uninitialized_account_output, load_wallet_runtime,
-    read_default_wallet_address, resolve_wallet_address, sequencer_unreachable_hint,
-    summarize_command_failure, wallet_password, wallet_state_path, write_default_wallet_address,
+    default_sequencer_http_url_for_project, extract_tx_identifier, is_already_initialized_failure,
+    is_confirmation_timeout_failure, is_connectivity_failure, is_uninitialized_account_output,
+    load_wallet_runtime, read_default_wallet_address, resolve_wallet_address,
+    sequencer_unreachable_hint, summarize_command_failure, wallet_password, wallet_state_path,
+    write_default_wallet_address,
 };
 
 /// Result of a wallet topup attempt. `cmd_run` distinguishes the
@@ -117,7 +118,7 @@ pub(crate) fn cmd_wallet_topup_inner(
     let sequencer_addr = wallet
         .sequencer_addr
         .clone()
-        .unwrap_or_else(|| "http://127.0.0.1:3040".to_string());
+        .unwrap_or_else(|| default_sequencer_http_url_for_project(project));
     let wallet_home = wallet.wallet_home.as_os_str().to_string_lossy().to_string();
     let password_input = format!("{}\n", wallet_password());
 

--- a/src/commands/wallet_support.rs
+++ b/src/commands/wallet_support.rs
@@ -20,6 +20,12 @@ pub(crate) struct WalletRuntimeContext {
     pub(crate) sequencer_addr: Option<String>,
 }
 
+/// When `wallet_config.json` omits `sequencer_addr`, RPC calls should target the same host/port
+/// as `logos-scaffold localnet` (`[localnet] port` in `scaffold.toml`, default 3040).
+pub(crate) fn default_sequencer_http_url_for_project(project: &Project) -> String {
+    format!("http://127.0.0.1:{}", project.config.localnet.port)
+}
+
 pub(crate) fn load_wallet_runtime(project: &Project) -> DynResult<WalletRuntimeContext> {
     let lez = PathBuf::from(&project.config.lez.path);
     let wallet_binary = lez.join(WALLET_BIN_REL_PATH);
@@ -465,7 +471,7 @@ fn one_line(text: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{WALLET_CONFIG_FALLBACK, WALLET_CONFIG_PRIMARY};
+    use super::WALLET_CONFIG_PRIMARY;
     use std::fs;
 
     use tempfile::tempdir;

--- a/src/commands/wallet_support.rs
+++ b/src/commands/wallet_support.rs
@@ -21,6 +21,12 @@ pub(crate) struct WalletRuntimeContext {
     pub(crate) sequencer_addr: Option<String>,
 }
 
+/// When `wallet_config.json` omits `sequencer_addr`, RPC calls should target the same host/port
+/// as `logos-scaffold localnet` (`[localnet] port` in `scaffold.toml`, default 3040).
+pub(crate) fn default_sequencer_http_url_for_project(project: &Project) -> String {
+    format!("http://127.0.0.1:{}", project.config.localnet.port)
+}
+
 pub(crate) fn load_wallet_runtime(project: &Project) -> DynResult<WalletRuntimeContext> {
     let lez = resolve_repo_path(project, &project.config.lez, "lez")?;
     let wallet_binary = lez.join(WALLET_BIN_REL_PATH);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1344,6 +1344,32 @@ fn deploy_continues_and_summarizes_mixed_results() {
 }
 
 #[test]
+fn deploy_preflight_targets_localnet_port_when_wallet_omits_sequencer_addr() {
+    let temp = tempdir().expect("tempdir");
+    let lez_path = temp.path().join("lez");
+    fs::create_dir_all(&lez_path).expect("create lez path");
+    write_wallet_stub(&lez_path);
+    let port = unused_local_port();
+    write_scaffold_toml_with_localnet(temp.path(), &lez_path, Some(port), Some(true));
+    write_wallet_config(temp.path(), None);
+    write_guest_program(temp.path(), "hello");
+    write_guest_binary(temp.path(), "hello");
+
+    let url = format!("http://127.0.0.1:{port}");
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .arg("deploy")
+        .arg("hello")
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("cannot deploy programs")
+                .and(predicate::str::contains(&url))
+                .and(predicate::str::contains("sequencer appears unavailable")),
+        );
+}
+
+#[test]
 fn deploy_shows_hint_when_sequencer_is_unreachable_with_configured_addr() {
     let temp = tempdir().expect("tempdir");
     setup_wallet_project(temp.path(), Some("http://127.0.0.1:65535"));

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -843,6 +843,30 @@ fn wallet_passthrough_requires_args_after_double_dash() {
 }
 
 #[test]
+fn wallet_topup_dry_run_planned_network_uses_localnet_port_without_wallet_sequencer_addr() {
+    let temp = tempdir().expect("tempdir");
+    let lez_path = temp.path().join("lez");
+    fs::create_dir_all(&lez_path).expect("create lez path");
+    write_wallet_stub(&lez_path);
+    let port = unused_local_port();
+    write_scaffold_toml_with_localnet(temp.path(), &lez_path, Some(port), Some(true));
+    write_wallet_config(temp.path(), None);
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .arg("wallet")
+        .arg("topup")
+        .arg("--address")
+        .arg(VALID_PUBLIC_ADDRESS)
+        .arg("--dry-run")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "planned network: local sequencer (http://127.0.0.1:{port})"
+        )));
+}
+
+#[test]
 fn wallet_topup_dry_run_renders_pinata_claim_command() {
     let temp = tempdir().expect("tempdir");
     setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));
@@ -1341,8 +1365,8 @@ fn deploy_shows_hint_when_sequencer_is_unreachable_with_configured_addr() {
 
 #[test]
 fn deploy_shows_hint_when_sequencer_is_unreachable_with_fallback_addr() {
-    // This test assumes fallback `http://127.0.0.1:3040` is unreachable.
-    // Skip in environments where another process is already listening there.
+    // Wallet omits `sequencer_addr`; deploy falls back to `http://127.0.0.1:<localnet.port>`
+    // (default 3040 when `[localnet]` is omitted). Skip if something is already listening.
     if TcpStream::connect("127.0.0.1:3040").is_ok() {
         return;
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1140,6 +1140,30 @@ fn wallet_passthrough_requires_args_after_double_dash() {
 }
 
 #[test]
+fn wallet_topup_dry_run_planned_network_uses_localnet_port_without_wallet_sequencer_addr() {
+    let temp = tempdir().expect("tempdir");
+    let lez_path = temp.path().join("lez");
+    fs::create_dir_all(&lez_path).expect("create lez path");
+    write_wallet_stub(&lez_path);
+    let port = unused_local_port();
+    write_scaffold_toml_with_localnet(temp.path(), &lez_path, Some(port), Some(true));
+    write_wallet_config(temp.path(), None);
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .arg("wallet")
+        .arg("topup")
+        .arg("--address")
+        .arg(VALID_PUBLIC_ADDRESS)
+        .arg("--dry-run")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "planned network: local sequencer (http://127.0.0.1:{port})"
+        )));
+}
+
+#[test]
 fn wallet_topup_dry_run_renders_pinata_claim_command() {
     let temp = tempdir().expect("tempdir");
     setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));
@@ -1643,8 +1667,8 @@ fn deploy_shows_hint_when_sequencer_is_unreachable_with_configured_addr() {
 
 #[test]
 fn deploy_shows_hint_when_sequencer_is_unreachable_with_fallback_addr() {
-    // This test assumes fallback `http://127.0.0.1:3040` is unreachable.
-    // Skip in environments where another process is already listening there.
+    // Wallet omits `sequencer_addr`; deploy falls back to `http://127.0.0.1:<localnet.port>`
+    // (default 3040 when `[localnet]` is omitted). Skip if something is already listening.
     if TcpStream::connect("127.0.0.1:3040").is_ok() {
         return;
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1646,6 +1646,32 @@ fn deploy_continues_and_summarizes_mixed_results() {
 }
 
 #[test]
+fn deploy_preflight_targets_localnet_port_when_wallet_omits_sequencer_addr() {
+    let temp = tempdir().expect("tempdir");
+    let lez_path = temp.path().join("lez");
+    fs::create_dir_all(&lez_path).expect("create lez path");
+    write_wallet_stub(&lez_path);
+    let port = unused_local_port();
+    write_scaffold_toml_with_localnet(temp.path(), &lez_path, Some(port), Some(true));
+    write_wallet_config(temp.path(), None);
+    write_guest_program(temp.path(), "hello");
+    write_guest_binary(temp.path(), "hello");
+
+    let url = format!("http://127.0.0.1:{port}");
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .arg("deploy")
+        .arg("hello")
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("cannot deploy programs")
+                .and(predicate::str::contains(&url))
+                .and(predicate::str::contains("sequencer appears unavailable")),
+        );
+}
+
+#[test]
 fn deploy_shows_hint_when_sequencer_is_unreachable_with_configured_addr() {
     let temp = tempdir().expect("tempdir");
     setup_wallet_project(temp.path(), Some("http://127.0.0.1:65535"));


### PR DESCRIPTION
### Problem

When `wallet_config.json` omits `sequencer_addr`, `wallet topup` and `deploy` still defaulted to `http://127.0.0.1:3040`. That ignores `[localnet] port` in `scaffold.toml`, so a non-default localnet port and an unset wallet address pointed RPC at the wrong URL.

### Solution

- Add `default_sequencer_http_url_for_project` in `wallet_support` to build `http://127.0.0.1:{project.config.localnet.port}` (same default as localnet when `[localnet]` is omitted).
- Use it as the fallback when `sequencer_addr` is missing in both `deploy` and `wallet topup`.
- Follow-up to #83: once `[localnet] port` is authoritative, default `sequencer_addr` for `deploy` / `wallet topup` should use the same port instead of hardcoding `3040`.

### Tests

- New integration test: `wallet_topup_dry_run_planned_network_uses_localnet_port_without_wallet_sequencer_addr` asserts dry-run output shows the URL with the configured port when the wallet omits `sequencer_addr`.
- Comment on deploy fallback test updated to describe `localnet.port`-based fallback.

### How to verify

```bash
cargo test wallet_topup_dry_run_planned_network
cargo test
```