### PR TITLE
feat: add `logos-scaffold run` command (MVP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+docs/specs/
+docs/ideas/
+graphify-out/

--- a/ADR.md
+++ b/ADR.md
@@ -329,11 +329,10 @@ The dev's "change → build → deploy → interact" cycle was multiple commands
 (`build`, `localnet start`, `wallet topup`, `deploy`, then ad-hoc post-deploy
 calls). Scaffold could have stayed at primitives and let projects script the
 sequence themselves; instead, `lgs run` collapses the sequence into one
-command with numbered step headers, optional post-deploy hooks, named
-profiles, and a watch loop.
+command with numbered step headers and optional post-deploy hooks.
 
 Tradeoff: scaffold takes on responsibility for the pipeline shape. Adding or
-reordering steps becomes a coordinated change across cmd_run, cli args,
+reordering steps becomes a coordinated change across `cmd_run`, cli args,
 serializer, and the dogfooding doc. Upside: every project gets the same
 discoverable inner-loop story without per-project shell-script drift, and
 the env contract that hooks see is uniform across projects.
@@ -346,25 +345,15 @@ new step is needed, it joins the chain rather than offering a knob.
 ## Hook Env Contract is a Documented Public Surface
 
 Post-deploy hooks run via `sh -c` with `cwd` at the project root. The env
-they see is stable, documented in README, and validated by unit tests:
+they see is stable, documented in README, and validated by unit and
+integration tests:
 
 - `SEQUENCER_URL` / `NSSA_WALLET_HOME_DIR` / `SCAFFOLD_PROJECT_ROOT` /
   `SCAFFOLD_IDL_DIR` — pipeline state.
-- `SCAFFOLD_PROGRAMS` (space-separated names) plus per-program
-  `SCAFFOLD_PROGRAM_ID_<name>` / `SCAFFOLD_GUEST_BIN_<name>` /
-  `SCAFFOLD_DEPLOY_SKIPPED_<name>` — deployed-program metadata, indexed by
-  program name (the same identifier the dev sees in
-  `methods/guest/src/bin/`, in `deploy` output, in `spel` arg flags).
-  Sanitized for env-var-suffix legality.
-- `SCAFFOLD_PROGRAM_NAME` / `SCAFFOLD_PROGRAM_ID` / `SCAFFOLD_GUEST_BIN` /
-  `SCAFFOLD_DEPLOY_SKIPPED` — single-program shortcuts. Set only when
-  exactly one program is deployed; absent for multi-program projects so
-  hooks can't accidentally pick up a stale shortcut from a prior config.
-
-Indexed-by-name was preferred over indexed-by-integer because adding a
-second program shouldn't shift the first program's variable. Bash
-indirection (`${!var}`) makes per-name access ergonomic without jq for
-multi-program hooks.
+- `SCAFFOLD_PROGRAM_ID` / `SCAFFOLD_GUEST_BIN` — single-program shortcuts.
+  Set only when exactly one program is deployable; absent for
+  multi-program projects so hooks fail loudly rather than silently
+  picking up the wrong program.
 
 `NSSA_WALLET_HOME_DIR` keeps its upstream-wallet name rather than being
 renamed to a `SCAFFOLD_*` prefix: hooks that exec the wallet binary
@@ -372,151 +361,9 @@ renamed to a `SCAFFOLD_*` prefix: hooks that exec the wallet binary
 binary's `WalletCore::from_env()` reads. Renaming for hook ergonomics
 would silently break those hooks.
 
-## Hash-Based Deploy Idempotence
-
-For tight inner loops, re-deploying an unchanged binary is wasted work
-(seconds per program). Scaffold persists per-program SHA-256 hashes at
-`.scaffold/state/run_deploy.json`; the deploy step is skipped when every
-hash matches the prior run. To force a fresh deploy, use `--reset`
-(which clears the cache as a side effect of the wipe) or delete the
-state file manually. No dedicated bypass flag — the workflows that
-really need a fresh deploy almost always also need a fresh chain, which
-is what `--reset` provides; the standalone "deploy again without
-touching the chain" case is rare enough to keep the surface narrow.
-
-The hash domain includes both the guest `.bin` and the per-program IDL
-JSON (with a `\x00idl\x00` domain separator), so an ABI-only edit
-invalidates the cache even when the compiled binary is byte-identical.
-This catches the case where `lez-framework`'s IDL output changes without
-the underlying ELF changing.
-
-The state file is wiped on `--reset` because reset implies "fresh chain,"
-and the prior deploy's on-chain state is gone — a fresh deploy is
-required regardless of hash equality.
-
-Tradeoff: the cache adds a small read-and-compute step before deploy
-(walking the binary directory, hashing each `.bin` and IDL, comparing).
-The cost is bounded by binary count × file size; in practice negligible
-compared to the savings of skipping a real deploy. The state file format
-is unversioned today; a future schema change must coordinate a wipe path
-or version field.
-
-## Named Profiles and CLI Override Resolution
-
-A single `[run]` block worked for one workflow per project, but real
-projects have multiple post-deploy intents (`play`, `e2e`, `smoke`,
-`fuzz`). Hardcoding "one hook fits all" forced shell scripts that branch
-on env vars, which obscured intent.
-
-`[run.profiles.<name>]` is the schema for multi-workflow projects.
-`[run].default_profile` selects which profile runs when `--profile`
-is absent. Inline `[run]` keys (the legacy/unnamed slot) are still
-honored when neither `--profile` nor `default_profile` resolves —
-backward compatibility for single-workflow projects that pre-date the
-profiles feature.
-
-CLI overrides for one invocation: `--profile <name>` selects a profile;
-`--post-deploy <cmd>` (repeatable) replaces the resolved profile's hooks;
-`--no-post-deploy` skips hooks entirely. These conflict with each other
-at clap parse time so an inconsistent invocation is rejected, not
-silently coerced.
-
-`resolve_profile` enumerates three precedence cases (explicit selector →
-`default_profile` → inline) and produces actionable errors listing known
-profiles when a name is missing. The model deduplicates by storing the
-inline keys in a `RunProfile` field (`RunConfig.inline`) shared with the
-named profiles map — one source of truth for "what's in a profile."
-
-## `lgs run --reset` is a Lifecycle Reset, Not the Localnet Primitive
-
-`lgs run --reset` (renamed from `--reset-localnet`) wipes rocksdb + wallet,
-restarts the sequencer, **re-seeds the default wallet from the
-preconfigured public account**, and continues the deploy cycle. It
-re-establishes the documented "fresh project" state that a clean
-`lgs setup` produces.
-
-`lgs localnet reset` is the **lower-level primitive**. Wipes rocksdb only
-by default; preserves the wallet. Useful when a dev wants chain-fresh but
-keeps hand-seeded extra accounts (Alice/Bob/Charlie) and re-runs their
-own project setup script afterward.
-
-The asymmetry is intentional: `lgs run` owns the full lifecycle and
-assumes "fresh project," `lgs localnet reset` is surgical and assumes
-"the dev knows what they're doing." Renaming the run-level flag from
-`--reset-localnet` to `--reset` removes the false parallel — the original
-name read as "do what `lgs localnet reset` does" but actually did more
-(wallet wipe + re-seed) and differently (no opt-out).
-
-The flag is suitable for two equally-legitimate use cases, treated
-identically by the code: (1) **fixture-based deterministic test suites**
-where fixed seeds collide on PDA keys across consecutive runs, so
-per-run reset is the *normal* behavior; and (2) **manual recovery** —
-"it's all fucked up." Same code path, different motivation.
-
-No top-level `lgs reset` command is added today. The two existing
-surfaces cover the known use cases. If a "wipe without deploy" need
-surfaces, that's a separate command rather than another flag.
-
-A `--preserve-wallet` flag on `lgs run --reset` is explicitly **not**
-added until evidence shows a project that wants it. Multi-account
-projects use the `lgs localnet reset` primitive instead.
-
-## `lgs run` Surface: Two Localnet Modes, No Bypass Flags
-
-After dogfooding, the `lgs run` knobs collapsed to two clean localnet
-intents — "use what's running" (default) and "fresh project" (`--reset`)
-— with everything in between deliberately removed.
-
-Removed surface:
-
-- **`--restart-localnet` / `--no-restart-localnet`** and the
-  corresponding `[run].restart_localnet` TOML key. The flag occupied a
-  thin middle ground: "stop+start the sequencer process, preserve
-  rocksdb and wallet." That intent is mostly vestigial because source
-  edits drive fresh program identity for free via image-ID rotation,
-  and the rare "the sequencer process is wedged but I want my chain
-  state" case is already covered by the lower-level
-  `lgs localnet stop && lgs localnet start` primitive. Keeping the flag
-  inside `lgs run` blurred the abstraction line we drew between
-  full-lifecycle commands and surgical primitives.
-- **`--force-deploy`**. The flag bypassed the hash-cache idempotence
-  check. Two narrow use cases motivated it (debugging the deploy step,
-  CI safety net), but both have cleaner workarounds: `--reset` (clears
-  the cache as a side effect of the wipe) or `rm
-  .scaffold/state/run_deploy.json`. Re-deploying a content-addressed
-  binary produces no new on-chain effect, so the flag's only output was
-  "did the submission run again," which is rarely what someone actually
-  needs.
-
-Both flags can be added back if dogfooding surfaces a real workflow
-that needs them — but the bar is "name the workflow," not "it might be
-useful." KISS says don't ship surface for hypothetical demand.
-
-The clean two-mode story now reads: **default is "use what's running,
-start if needed"; `--reset` is "fresh project, suitable for fixture-CI
-and manual recovery alike."**
-
-## Watch Mode Is Tail-Iteration, Not a Daemon
-
-`lgs run --watch` is for tight inner-loop iteration: after the initial
-pipeline, scaffold watches the project root via `notify` and re-runs
-build → IDL → deploy → hooks on every file change, debounced ~500ms.
-
-Reset is forced off on re-runs — re-establishing localnet state mid-loop
-would clobber whatever the hooks just observed. Hook failures don't end
-the loop (the dev fixes the source and the next file event re-triggers);
-a permanent error is the dev's signal to Ctrl-C and investigate.
-
-The IDL output directory is added to the ignore list alongside
-`.scaffold/`, `target/`, and `.git/`, because the IDL build itself
-writes JSON files into `framework.idl.path` on every iteration — without
-ignoring it, the watcher would self-trigger and loop forever.
-
-Watch mode is intentionally a CLI flag rather than a top-level
-`lgs watch` command: it's not a daemon, it's the same pipeline plus
-"re-run on change." Splitting it would force users to choose between
-"lgs run does X" and "lgs watch does X again." Keeping them
-together makes "the run command, but iterating" the explicit framing.
+The single-program metadata is resolved once per `lgs run` invocation
+and reused across every hook so multiple hooks don't multiply the cost
+of `spel inspect`.
 
 ## Build Output Discovery
 

--- a/ADR.md
+++ b/ADR.md
@@ -323,6 +323,201 @@ because users would never get nudged hard enough to actually
 migrate. Hard-fail + targeted hint is the same model as the original
 `[repos.spel]` migration.
 
+## `lgs run` is a Single-Command Inner Loop
+
+The dev's "change → build → deploy → interact" cycle was multiple commands
+(`build`, `localnet start`, `wallet topup`, `deploy`, then ad-hoc post-deploy
+calls). Scaffold could have stayed at primitives and let projects script the
+sequence themselves; instead, `lgs run` collapses the sequence into one
+command with numbered step headers, optional post-deploy hooks, named
+profiles, and a watch loop.
+
+Tradeoff: scaffold takes on responsibility for the pipeline shape. Adding or
+reordering steps becomes a coordinated change across cmd_run, cli args,
+serializer, and the dogfooding doc. Upside: every project gets the same
+discoverable inner-loop story without per-project shell-script drift, and
+the env contract that hooks see is uniform across projects.
+
+The pipeline composes the existing primitives (`cmd_build_shortcut`,
+`build_idl_for_current_project`, `cmd_localnet`, `cmd_wallet_topup_inner`,
+`cmd_deploy`) — no parallel implementation. Step ordering is fixed; if a
+new step is needed, it joins the chain rather than offering a knob.
+
+## Hook Env Contract is a Documented Public Surface
+
+Post-deploy hooks run via `sh -c` with `cwd` at the project root. The env
+they see is stable, documented in README, and validated by unit tests:
+
+- `SEQUENCER_URL` / `NSSA_WALLET_HOME_DIR` / `SCAFFOLD_PROJECT_ROOT` /
+  `SCAFFOLD_IDL_DIR` — pipeline state.
+- `SCAFFOLD_PROGRAMS` (space-separated names) plus per-program
+  `SCAFFOLD_PROGRAM_ID_<name>` / `SCAFFOLD_GUEST_BIN_<name>` /
+  `SCAFFOLD_DEPLOY_SKIPPED_<name>` — deployed-program metadata, indexed by
+  program name (the same identifier the dev sees in
+  `methods/guest/src/bin/`, in `deploy` output, in `spel` arg flags).
+  Sanitized for env-var-suffix legality.
+- `SCAFFOLD_PROGRAM_NAME` / `SCAFFOLD_PROGRAM_ID` / `SCAFFOLD_GUEST_BIN` /
+  `SCAFFOLD_DEPLOY_SKIPPED` — single-program shortcuts. Set only when
+  exactly one program is deployed; absent for multi-program projects so
+  hooks can't accidentally pick up a stale shortcut from a prior config.
+
+Indexed-by-name was preferred over indexed-by-integer because adding a
+second program shouldn't shift the first program's variable. Bash
+indirection (`${!var}`) makes per-name access ergonomic without jq for
+multi-program hooks.
+
+`NSSA_WALLET_HOME_DIR` keeps its upstream-wallet name rather than being
+renamed to a `SCAFFOLD_*` prefix: hooks that exec the wallet binary
+(directly or via `cargo run --bin run_*`) need the var under the name the
+binary's `WalletCore::from_env()` reads. Renaming for hook ergonomics
+would silently break those hooks.
+
+## Hash-Based Deploy Idempotence
+
+For tight inner loops, re-deploying an unchanged binary is wasted work
+(seconds per program). Scaffold persists per-program SHA-256 hashes at
+`.scaffold/state/run_deploy.json`; the deploy step is skipped when every
+hash matches the prior run. To force a fresh deploy, use `--reset`
+(which clears the cache as a side effect of the wipe) or delete the
+state file manually. No dedicated bypass flag — the workflows that
+really need a fresh deploy almost always also need a fresh chain, which
+is what `--reset` provides; the standalone "deploy again without
+touching the chain" case is rare enough to keep the surface narrow.
+
+The hash domain includes both the guest `.bin` and the per-program IDL
+JSON (with a `\x00idl\x00` domain separator), so an ABI-only edit
+invalidates the cache even when the compiled binary is byte-identical.
+This catches the case where `lez-framework`'s IDL output changes without
+the underlying ELF changing.
+
+The state file is wiped on `--reset` because reset implies "fresh chain,"
+and the prior deploy's on-chain state is gone — a fresh deploy is
+required regardless of hash equality.
+
+Tradeoff: the cache adds a small read-and-compute step before deploy
+(walking the binary directory, hashing each `.bin` and IDL, comparing).
+The cost is bounded by binary count × file size; in practice negligible
+compared to the savings of skipping a real deploy. The state file format
+is unversioned today; a future schema change must coordinate a wipe path
+or version field.
+
+## Named Profiles and CLI Override Resolution
+
+A single `[run]` block worked for one workflow per project, but real
+projects have multiple post-deploy intents (`play`, `e2e`, `smoke`,
+`fuzz`). Hardcoding "one hook fits all" forced shell scripts that branch
+on env vars, which obscured intent.
+
+`[run.profiles.<name>]` is the schema for multi-workflow projects.
+`[run].default_profile` selects which profile runs when `--profile`
+is absent. Inline `[run]` keys (the legacy/unnamed slot) are still
+honored when neither `--profile` nor `default_profile` resolves —
+backward compatibility for single-workflow projects that pre-date the
+profiles feature.
+
+CLI overrides for one invocation: `--profile <name>` selects a profile;
+`--post-deploy <cmd>` (repeatable) replaces the resolved profile's hooks;
+`--no-post-deploy` skips hooks entirely. These conflict with each other
+at clap parse time so an inconsistent invocation is rejected, not
+silently coerced.
+
+`resolve_profile` enumerates three precedence cases (explicit selector →
+`default_profile` → inline) and produces actionable errors listing known
+profiles when a name is missing. The model deduplicates by storing the
+inline keys in a `RunProfile` field (`RunConfig.inline`) shared with the
+named profiles map — one source of truth for "what's in a profile."
+
+## `lgs run --reset` is a Lifecycle Reset, Not the Localnet Primitive
+
+`lgs run --reset` (renamed from `--reset-localnet`) wipes rocksdb + wallet,
+restarts the sequencer, **re-seeds the default wallet from the
+preconfigured public account**, and continues the deploy cycle. It
+re-establishes the documented "fresh project" state that a clean
+`lgs setup` produces.
+
+`lgs localnet reset` is the **lower-level primitive**. Wipes rocksdb only
+by default; preserves the wallet. Useful when a dev wants chain-fresh but
+keeps hand-seeded extra accounts (Alice/Bob/Charlie) and re-runs their
+own project setup script afterward.
+
+The asymmetry is intentional: `lgs run` owns the full lifecycle and
+assumes "fresh project," `lgs localnet reset` is surgical and assumes
+"the dev knows what they're doing." Renaming the run-level flag from
+`--reset-localnet` to `--reset` removes the false parallel — the original
+name read as "do what `lgs localnet reset` does" but actually did more
+(wallet wipe + re-seed) and differently (no opt-out).
+
+The flag is suitable for two equally-legitimate use cases, treated
+identically by the code: (1) **fixture-based deterministic test suites**
+where fixed seeds collide on PDA keys across consecutive runs, so
+per-run reset is the *normal* behavior; and (2) **manual recovery** —
+"it's all fucked up." Same code path, different motivation.
+
+No top-level `lgs reset` command is added today. The two existing
+surfaces cover the known use cases. If a "wipe without deploy" need
+surfaces, that's a separate command rather than another flag.
+
+A `--preserve-wallet` flag on `lgs run --reset` is explicitly **not**
+added until evidence shows a project that wants it. Multi-account
+projects use the `lgs localnet reset` primitive instead.
+
+## `lgs run` Surface: Two Localnet Modes, No Bypass Flags
+
+After dogfooding, the `lgs run` knobs collapsed to two clean localnet
+intents — "use what's running" (default) and "fresh project" (`--reset`)
+— with everything in between deliberately removed.
+
+Removed surface:
+
+- **`--restart-localnet` / `--no-restart-localnet`** and the
+  corresponding `[run].restart_localnet` TOML key. The flag occupied a
+  thin middle ground: "stop+start the sequencer process, preserve
+  rocksdb and wallet." That intent is mostly vestigial because source
+  edits drive fresh program identity for free via image-ID rotation,
+  and the rare "the sequencer process is wedged but I want my chain
+  state" case is already covered by the lower-level
+  `lgs localnet stop && lgs localnet start` primitive. Keeping the flag
+  inside `lgs run` blurred the abstraction line we drew between
+  full-lifecycle commands and surgical primitives.
+- **`--force-deploy`**. The flag bypassed the hash-cache idempotence
+  check. Two narrow use cases motivated it (debugging the deploy step,
+  CI safety net), but both have cleaner workarounds: `--reset` (clears
+  the cache as a side effect of the wipe) or `rm
+  .scaffold/state/run_deploy.json`. Re-deploying a content-addressed
+  binary produces no new on-chain effect, so the flag's only output was
+  "did the submission run again," which is rarely what someone actually
+  needs.
+
+Both flags can be added back if dogfooding surfaces a real workflow
+that needs them — but the bar is "name the workflow," not "it might be
+useful." KISS says don't ship surface for hypothetical demand.
+
+The clean two-mode story now reads: **default is "use what's running,
+start if needed"; `--reset` is "fresh project, suitable for fixture-CI
+and manual recovery alike."**
+
+## Watch Mode Is Tail-Iteration, Not a Daemon
+
+`lgs run --watch` is for tight inner-loop iteration: after the initial
+pipeline, scaffold watches the project root via `notify` and re-runs
+build → IDL → deploy → hooks on every file change, debounced ~500ms.
+
+Reset is forced off on re-runs — re-establishing localnet state mid-loop
+would clobber whatever the hooks just observed. Hook failures don't end
+the loop (the dev fixes the source and the next file event re-triggers);
+a permanent error is the dev's signal to Ctrl-C and investigate.
+
+The IDL output directory is added to the ignore list alongside
+`.scaffold/`, `target/`, and `.git/`, because the IDL build itself
+writes JSON files into `framework.idl.path` on every iteration — without
+ignoring it, the watcher would self-trigger and loop forever.
+
+Watch mode is intentionally a CLI flag rather than a top-level
+`lgs watch` command: it's not a daemon, it's the same pipeline plus
+"re-run on change." Splitting it would force users to choose between
+"lgs run does X" and "lgs watch does X again." Keeping them
+together makes "the run command, but iterating" the explicit framing.
+
 ## Build Output Discovery
 
 The deploy command must work for any scaffolded project regardless of its name.

--- a/DOGFOODING.md
+++ b/DOGFOODING.md
@@ -75,6 +75,8 @@ The `lgs` binary is a short alias for `logos-scaffold` produced by the same crat
 | D4 | `default` | Core | Wallet management, default-address behavior, and passthrough UX | `wallet list`, `wallet default set`, `wallet topup --dry-run`, `wallet topup`, `wallet -- ...` |
 | D5 | `default` | Advanced | Diagnostics bundle and support artifact hygiene | `report`, `report --out`, `report --tail` |
 | D6 | `default` | Core | Example runner interaction and account state verification | `cargo run --bin run_hello_world`, `cargo run --bin run_hello_world_with_move_function`, `wallet -- account get` |
+| D7 | `default` | Core | One-step `run` pipeline, post-deploy hooks, and reset semantics | `run`, `run --reset`, `[run]` config |
+| D8 | `default` | Advanced | `run` profiles, post-deploy CLI overrides, deploy idempotence, watch loop | `run --profile`, `run --post-deploy`, `run --no-post-deploy`, `run --watch` |
 | L1 | `lez-framework` | Core | Fresh LEZ project bootstrap to ready state | `new --template lez-framework`, `setup`, `localnet start`, `doctor`, `build` |
 | L2 | `lez-framework` | Core | LEZ IDL regeneration | `build idl` |
 | L3 | `lez-framework` | Advanced | LEZ client generation from current IDL | `build client` |
@@ -439,6 +441,146 @@ The first runner (`run_hello_world`) submits a basic public transaction. The sec
 - `NSSA_WALLET_HOME_DIR` must be set for runners that initialize `WalletCore::from_env()`. The scaffold wallet commands set this automatically, but direct `cargo run` does not.
 - Use the fresh public account created in the preconditions rather than reusing accounts from other scenarios. This avoids confusion about pre-existing state.
 - If additional runners are available (e.g., `run_hello_world_private`, `run_hello_world_through_tail_call`), exercising them is valuable but not required for this scenario.
+
+## D7. `run` Pipeline and Post-Deploy Hooks
+
+### Goal
+
+Validate that `lgs run` collapses the build → IDL → localnet → topup → deploy chain into a single command, fires `[run].post_deploy` hooks with the documented environment, and that `--reset` produces a fresh-project state end-to-end.
+
+### Preconditions
+
+- A default-template project exists at `$SCRATCH_ROOT/dogfood-default` with `setup` already complete.
+- No existing scaffold localnet running on the configured port (the scenario will start one). If one exists from a prior scenario, stop it first.
+- `wallet topup` has worked at least once for this project (D1 or D4 covers this).
+
+### Commands / Actions
+
+From the project root:
+
+```bash
+"$SCAFFOLD_BIN" run
+"$SCAFFOLD_BIN" run --reset
+```
+
+Then add a `[run]` section to `scaffold.toml` and re-run:
+
+```toml
+[run]
+post_deploy = [
+  "echo 'sequencer:' $SEQUENCER_URL",
+  "echo 'idl:' $SCAFFOLD_IDL_DIR",
+  "echo 'project root:' $SCAFFOLD_PROJECT_ROOT",
+  "echo 'wallet home:' $NSSA_WALLET_HOME_DIR",
+  "echo 'programs:' $SCAFFOLD_PROGRAMS",
+  "echo 'first program id:' ${SCAFFOLD_PROGRAM_ID:-unavailable}",
+]
+```
+
+```bash
+"$SCAFFOLD_BIN" run
+```
+
+### Expected Success Signals
+
+- The first `run` prints a numbered step header for each phase (`[1/5] Building...` through `[5/5] Deploying...`) and ends with a deployed-programs summary because no hooks are configured yet.
+- A second `run` (with no source changes) reuses the running localnet (`localnet already running (sequencer pid=...)`) and prints `Deploy skipped (guest binaries + IDL unchanged; ...)`.
+- `run --reset` wipes RocksDB and the project wallet, restarts the sequencer, re-seeds the default wallet from the preconfigured public account, verifies block production, and clears `.scaffold/state/run_deploy.json` so the deploy step runs unconditionally. The pipeline continues through topup → deploy → hooks without manual intervention.
+- After adding the `[run]` block, `run` reports `[6/6] Running N post-deploy hook(s)` and each hook prints a non-empty value for its env var. `cwd` for each hook is the project root (verifiable with a `pwd` hook). For a single-program project, `$SCAFFOLD_PROGRAM_ID` is the deployed program's risc0 image ID; for multi-program projects, use `$SCAFFOLD_PROGRAMS` plus `${!var}` indirection on `SCAFFOLD_PROGRAM_ID_<name>`.
+- A non-zero hook exit aborts the run with a clear `post-deploy hook exited with status N` message.
+
+### Failure Signals / Common Pitfalls
+
+- A `run` invocation that restarts the sequencer when one is already running healthy is a regression in the localnet-reuse path. (To force a restart, use `lgs localnet stop && lgs run`, or `lgs run --reset` for a full lifecycle reset.)
+- Hooks running with `cwd` somewhere other than the project root, or missing any of `SEQUENCER_URL` / `NSSA_WALLET_HOME_DIR` / `SCAFFOLD_PROJECT_ROOT` / `SCAFFOLD_IDL_DIR` / `SCAFFOLD_PROGRAMS`, is a regression in the env contract.
+- `run --reset` that fails to re-seed the wallet (manifesting as a topup failure on the next step) is a regression — the wipe + re-seed is one atomic operation in the pipeline.
+- `$SCAFFOLD_PROGRAM_ID_<name>` unset after a successful deploy on a project with a vendored `spel` binary is a regression in the program-info env injection. Hint: `lgs setup` builds the spel binary; if it's missing, `program_id: unavailable` will also appear in the deploy summary.
+
+### Evidence to Capture
+
+- Console output of the first `run` showing the step headers and the deployed-programs summary.
+- Output of `run` after the `[run]` block is added, showing the `===> post_deploy[i/n]:` markers and the resolved env values.
+- Output of `run --reset` showing the wipe + re-seed + verify-block-production lines.
+
+## D8. `run` Profiles, CLI Overrides, Idempotence, and Watch Loop
+
+### Goal
+
+Validate the advanced `run` surface introduced for multi-workflow projects: named `[run.profiles.<name>]` selection, ad-hoc `--post-deploy` / `--no-post-deploy` overrides, deploy idempotence keyed on guest-bin SHA-256, and the file-watch re-run loop.
+
+### Preconditions
+
+- D7 has been completed at least once for this project (so a deployed program exists and `.scaffold/state/run_deploy.json` is populated).
+- `inotify` filesystem events are available (Linux) or the platform's notify backend is functional. Headless CI without filesystem-event support can skip the `--watch` portion.
+
+### Commands / Actions
+
+Replace the inline `[run]` block from D7 with named profiles in `scaffold.toml`:
+
+```toml
+[run]
+default_profile = "dev"
+
+[run.profiles.dev]
+post_deploy = "echo profile=dev"
+
+[run.profiles.e2e]
+reset = true
+post_deploy = ["echo profile=e2e step1", "echo profile=e2e step2"]
+```
+
+Then exercise:
+
+```bash
+"$SCAFFOLD_BIN" run                                  # uses default_profile = "dev"
+"$SCAFFOLD_BIN" run --profile e2e                    # uses [run.profiles.e2e]
+"$SCAFFOLD_BIN" run --profile no-such-profile        # expect error listing known profiles
+"$SCAFFOLD_BIN" run --post-deploy "echo override"    # one-shot override
+"$SCAFFOLD_BIN" run --no-post-deploy                 # skip hooks
+"$SCAFFOLD_BIN" run --post-deploy "x" --no-post-deploy  # expect clap conflict error
+
+# Deploy idempotence (cache hit on second consecutive run with no source changes)
+"$SCAFFOLD_BIN" run
+
+# To force a fresh deploy without resetting the chain, delete the cache file:
+rm .scaffold/state/run_deploy.json
+"$SCAFFOLD_BIN" run
+
+# Watch loop (interactive — Ctrl-C to exit)
+"$SCAFFOLD_BIN" run --watch
+# In another shell, touch a file under methods/ to trigger a re-run, then quit.
+```
+
+### Expected Success Signals
+
+- `run` with no `--profile` prints `Using [run.profiles.dev] (default_profile)` and fires only the `dev` hook.
+- `run --profile e2e` prints `Using [run.profiles.e2e]`, performs a localnet reset (because `reset = true` on that profile), and fires both `e2e` hooks in order.
+- `run --profile no-such-profile` errors with a message naming the profile and listing the known profiles `[dev, e2e]`. Exit code is non-zero.
+- `--post-deploy "echo override"` ignores the resolved profile's hooks and runs only the override.
+- `--no-post-deploy` skips the post-deploy step entirely; the run prints the deployed-programs summary instead.
+- `--post-deploy` with `--no-post-deploy` errors at clap parse time with a `cannot be used with` message.
+- A second consecutive `run` with no source changes prints `Deploy skipped (guest binaries + IDL unchanged; ...)` and the `[5/N]` step is the skip message rather than a real deploy. The hash cache folds the per-program IDL JSON into the SHA-256 alongside the `.bin`, so an ABI-only edit (changing the IDL output without touching the binary) also invalidates the cache. Deleting `.scaffold/state/run_deploy.json` (or running `--reset`) forces a fresh deploy.
+- `run --watch` prints a `===> watching <project> for changes (Ctrl-C to exit)` line after the initial pipeline. Touching a file under `methods/` (or the project's source tree) triggers `===> change detected, re-running pipeline`, debounced ~500ms. Edits under `.scaffold/`, `target/`, `.git/`, or the IDL output directory do NOT trigger re-runs. Subsequent re-runs skip reset regardless of the resolved profile's value. A failing hook prints the error and the watcher continues, waiting for the next change.
+
+### Failure Signals / Common Pitfalls
+
+- A run that silently falls back to inline `[run]` keys when `default_profile` is set but the named profile is missing is a regression — parse should fail with a clear error.
+- Deploy idempotence falsely skipping after the guest source changed (i.e., after a real `cargo build` produced a different `.bin`) is a regression. Verify by editing a guest source file, running `lgs build`, then `lgs run` — the deploy step should fire.
+- `--watch` re-running on every `target/` write would create a feedback loop. If you observe re-runs that you didn't trigger, capture the inciting file path.
+- Watch mode that tears down the localnet between iterations is a regression — only the initial iteration should ever (re)start the sequencer.
+
+### Evidence to Capture
+
+- Console output of `run` (default_profile path) and `run --profile e2e`, both showing the `Using [run.profiles.<name>]` banner.
+- Console output of the unknown-profile error showing the known-profiles list.
+- The two consecutive `run` invocations showing first a real deploy and then the skip message; the post-`rm` invocation showing a real deploy again.
+- A short transcript of `run --watch` showing one triggered re-run after a file edit.
+
+### Execution Notes
+
+- `--watch` is interactive and not suitable for unattended CI. Skip the watch step or replace it with a scripted background invocation that exits after one trigger.
+- Because the watch loop forces `reset=false` on re-runs, a file edit that requires a clean localnet (e.g., new program initializer assumes empty state) needs a manual `lgs localnet reset` between iterations.
+- `--reset` on the profile path clears `.scaffold/state/run_deploy.json` so the next `run` deploys regardless of hash equality. Confirm by inspecting the state file before and after.
 
 ## L1. LEZ Template Bootstrap
 
@@ -1030,6 +1172,8 @@ ls .scaffold/basecamp/portable 2>/dev/null || find .scaffold -maxdepth 4 -name '
 - Changes to wallet flows or wallet-related defaults: rerun `D4`.
 - Changes to diagnostics, report contents, or redaction logic: rerun `D5`.
 - Changes to example runner binaries or template `src/bin/*` code: rerun `D6`.
+- Changes to `run` step ordering, post-deploy env vars, restart/reset precedence, or `[run]` config parsing: rerun `D7`.
+- Changes to `[run.profiles]` semantics, post-deploy CLI overrides, deploy idempotence (`run_deploy.json` schema, hash policy), or `--watch` behavior: rerun `D8`.
 - Changes to LEZ template scaffolding or generated outputs: rerun `L1`, `L2`, `L3`, and `L4`.
 - Changes to CLI argument parsing, help text, or error messages: rerun `E1`.
 - Changes to `create`/`new` flags or template selection logic: rerun `E2`.

--- a/DOGFOODING.md
+++ b/DOGFOODING.md
@@ -75,8 +75,7 @@ The `lgs` binary is a short alias for `logos-scaffold` produced by the same crat
 | D4 | `default` | Core | Wallet management, default-address behavior, and passthrough UX | `wallet list`, `wallet default set`, `wallet topup --dry-run`, `wallet topup`, `wallet -- ...` |
 | D5 | `default` | Advanced | Diagnostics bundle and support artifact hygiene | `report`, `report --out`, `report --tail` |
 | D6 | `default` | Core | Example runner interaction and account state verification | `cargo run --bin run_hello_world`, `cargo run --bin run_hello_world_with_move_function`, `wallet -- account get` |
-| D7 | `default` | Core | One-step `run` pipeline, post-deploy hooks, and reset semantics | `run`, `run --reset`, `[run]` config |
-| D8 | `default` | Advanced | `run` profiles, post-deploy CLI overrides, deploy idempotence, watch loop | `run --profile`, `run --post-deploy`, `run --no-post-deploy`, `run --watch` |
+| D7 | `default` | Core | One-step `run` pipeline and post-deploy hooks | `run`, `run --post-deploy`, `run --no-post-deploy`, `[run]` config |
 | L1 | `lez-framework` | Core | Fresh LEZ project bootstrap to ready state | `new --template lez-framework`, `setup`, `localnet start`, `doctor`, `build` |
 | L2 | `lez-framework` | Core | LEZ IDL regeneration | `build idl` |
 | L3 | `lez-framework` | Advanced | LEZ client generation from current IDL | `build client` |
@@ -446,7 +445,7 @@ The first runner (`run_hello_world`) submits a basic public transaction. The sec
 
 ### Goal
 
-Validate that `lgs run` collapses the build → IDL → localnet → topup → deploy chain into a single command, fires `[run].post_deploy` hooks with the documented environment, and that `--reset` produces a fresh-project state end-to-end.
+Validate that `lgs run` collapses the build → IDL → localnet → topup → deploy chain into a single command, fires `[run].post_deploy` hooks with the documented environment, and that `--post-deploy` / `--no-post-deploy` flags override the configured hooks correctly.
 
 ### Preconditions
 
@@ -456,14 +455,13 @@ Validate that `lgs run` collapses the build → IDL → localnet → topup → d
 
 ### Commands / Actions
 
-From the project root:
+From the project root, exercise the bare pipeline:
 
 ```bash
 "$SCAFFOLD_BIN" run
-"$SCAFFOLD_BIN" run --reset
 ```
 
-Then add a `[run]` section to `scaffold.toml` and re-run:
+Then add a `[run]` section to `scaffold.toml` and re-run with hooks:
 
 ```toml
 [run]
@@ -472,115 +470,40 @@ post_deploy = [
   "echo 'idl:' $SCAFFOLD_IDL_DIR",
   "echo 'project root:' $SCAFFOLD_PROJECT_ROOT",
   "echo 'wallet home:' $NSSA_WALLET_HOME_DIR",
-  "echo 'programs:' $SCAFFOLD_PROGRAMS",
-  "echo 'first program id:' ${SCAFFOLD_PROGRAM_ID:-unavailable}",
+  "echo 'program id:' ${SCAFFOLD_PROGRAM_ID:-unavailable}",
+  "echo 'guest bin:' ${SCAFFOLD_GUEST_BIN:-unavailable}",
 ]
 ```
 
 ```bash
 "$SCAFFOLD_BIN" run
+"$SCAFFOLD_BIN" run --post-deploy "echo override"    # one-shot override
+"$SCAFFOLD_BIN" run --no-post-deploy                 # skip hooks
+"$SCAFFOLD_BIN" run --post-deploy "x" --no-post-deploy  # expect clap conflict error
 ```
 
 ### Expected Success Signals
 
-- The first `run` prints a numbered step header for each phase (`[1/5] Building...` through `[5/5] Deploying...`) and ends with a deployed-programs summary because no hooks are configured yet.
-- A second `run` (with no source changes) reuses the running localnet (`localnet already running (sequencer pid=...)`) and prints `Deploy skipped (guest binaries + IDL unchanged; ...)`.
-- `run --reset` wipes RocksDB and the project wallet, restarts the sequencer, re-seeds the default wallet from the preconfigured public account, verifies block production, and clears `.scaffold/state/run_deploy.json` so the deploy step runs unconditionally. The pipeline continues through topup → deploy → hooks without manual intervention.
-- After adding the `[run]` block, `run` reports `[6/6] Running N post-deploy hook(s)` and each hook prints a non-empty value for its env var. `cwd` for each hook is the project root (verifiable with a `pwd` hook). For a single-program project, `$SCAFFOLD_PROGRAM_ID` is the deployed program's risc0 image ID; for multi-program projects, use `$SCAFFOLD_PROGRAMS` plus `${!var}` indirection on `SCAFFOLD_PROGRAM_ID_<name>`.
+- The first `run` (no hooks configured) prints a numbered step header for each phase (`[1/5] Building...` through `[5/5] Deploying...`) and ends with a deployed-programs summary.
+- A second `run` reuses the running localnet (`localnet already running (sequencer pid=...)`) instead of starting a new sequencer.
+- After adding the `[run]` block, `run` reports `[6/6] Running N post-deploy hook(s)` and each hook prints a non-empty value for its env var. `cwd` for each hook is the project root (verifiable with a `pwd` hook). For a single-program project, `$SCAFFOLD_PROGRAM_ID` is the deployed program's risc0 image ID and `$SCAFFOLD_GUEST_BIN` is the absolute path to the guest binary.
+- `--post-deploy "echo override"` ignores `[run].post_deploy` and runs only the override.
+- `--no-post-deploy` skips the post-deploy step entirely; the run prints the deployed-programs summary instead.
+- `--post-deploy` with `--no-post-deploy` errors at clap parse time with a `cannot be used with` message; exit code is non-zero.
 - A non-zero hook exit aborts the run with a clear `post-deploy hook exited with status N` message.
 
 ### Failure Signals / Common Pitfalls
 
-- A `run` invocation that restarts the sequencer when one is already running healthy is a regression in the localnet-reuse path. (To force a restart, use `lgs localnet stop && lgs run`, or `lgs run --reset` for a full lifecycle reset.)
-- Hooks running with `cwd` somewhere other than the project root, or missing any of `SEQUENCER_URL` / `NSSA_WALLET_HOME_DIR` / `SCAFFOLD_PROJECT_ROOT` / `SCAFFOLD_IDL_DIR` / `SCAFFOLD_PROGRAMS`, is a regression in the env contract.
-- `run --reset` that fails to re-seed the wallet (manifesting as a topup failure on the next step) is a regression — the wipe + re-seed is one atomic operation in the pipeline.
-- `$SCAFFOLD_PROGRAM_ID_<name>` unset after a successful deploy on a project with a vendored `spel` binary is a regression in the program-info env injection. Hint: `lgs setup` builds the spel binary; if it's missing, `program_id: unavailable` will also appear in the deploy summary.
+- A `run` invocation that restarts the sequencer when one is already running healthy is a regression in the localnet-reuse path.
+- Hooks running with `cwd` somewhere other than the project root, or missing any of `SEQUENCER_URL` / `NSSA_WALLET_HOME_DIR` / `SCAFFOLD_PROJECT_ROOT` / `SCAFFOLD_IDL_DIR`, is a regression in the env contract.
+- `$SCAFFOLD_PROGRAM_ID` unset after a successful deploy on a single-program project with a vendored `spel` binary is a regression. Hint: `lgs setup` builds the spel binary; if it's missing, `program_id: unavailable` will also appear in the deploy summary.
 
 ### Evidence to Capture
 
 - Console output of the first `run` showing the step headers and the deployed-programs summary.
 - Output of `run` after the `[run]` block is added, showing the `===> post_deploy[i/n]:` markers and the resolved env values.
-- Output of `run --reset` showing the wipe + re-seed + verify-block-production lines.
-
-## D8. `run` Profiles, CLI Overrides, Idempotence, and Watch Loop
-
-### Goal
-
-Validate the advanced `run` surface introduced for multi-workflow projects: named `[run.profiles.<name>]` selection, ad-hoc `--post-deploy` / `--no-post-deploy` overrides, deploy idempotence keyed on guest-bin SHA-256, and the file-watch re-run loop.
-
-### Preconditions
-
-- D7 has been completed at least once for this project (so a deployed program exists and `.scaffold/state/run_deploy.json` is populated).
-- `inotify` filesystem events are available (Linux) or the platform's notify backend is functional. Headless CI without filesystem-event support can skip the `--watch` portion.
-
-### Commands / Actions
-
-Replace the inline `[run]` block from D7 with named profiles in `scaffold.toml`:
-
-```toml
-[run]
-default_profile = "dev"
-
-[run.profiles.dev]
-post_deploy = "echo profile=dev"
-
-[run.profiles.e2e]
-reset = true
-post_deploy = ["echo profile=e2e step1", "echo profile=e2e step2"]
-```
-
-Then exercise:
-
-```bash
-"$SCAFFOLD_BIN" run                                  # uses default_profile = "dev"
-"$SCAFFOLD_BIN" run --profile e2e                    # uses [run.profiles.e2e]
-"$SCAFFOLD_BIN" run --profile no-such-profile        # expect error listing known profiles
-"$SCAFFOLD_BIN" run --post-deploy "echo override"    # one-shot override
-"$SCAFFOLD_BIN" run --no-post-deploy                 # skip hooks
-"$SCAFFOLD_BIN" run --post-deploy "x" --no-post-deploy  # expect clap conflict error
-
-# Deploy idempotence (cache hit on second consecutive run with no source changes)
-"$SCAFFOLD_BIN" run
-
-# To force a fresh deploy without resetting the chain, delete the cache file:
-rm .scaffold/state/run_deploy.json
-"$SCAFFOLD_BIN" run
-
-# Watch loop (interactive — Ctrl-C to exit)
-"$SCAFFOLD_BIN" run --watch
-# In another shell, touch a file under methods/ to trigger a re-run, then quit.
-```
-
-### Expected Success Signals
-
-- `run` with no `--profile` prints `Using [run.profiles.dev] (default_profile)` and fires only the `dev` hook.
-- `run --profile e2e` prints `Using [run.profiles.e2e]`, performs a localnet reset (because `reset = true` on that profile), and fires both `e2e` hooks in order.
-- `run --profile no-such-profile` errors with a message naming the profile and listing the known profiles `[dev, e2e]`. Exit code is non-zero.
-- `--post-deploy "echo override"` ignores the resolved profile's hooks and runs only the override.
-- `--no-post-deploy` skips the post-deploy step entirely; the run prints the deployed-programs summary instead.
-- `--post-deploy` with `--no-post-deploy` errors at clap parse time with a `cannot be used with` message.
-- A second consecutive `run` with no source changes prints `Deploy skipped (guest binaries + IDL unchanged; ...)` and the `[5/N]` step is the skip message rather than a real deploy. The hash cache folds the per-program IDL JSON into the SHA-256 alongside the `.bin`, so an ABI-only edit (changing the IDL output without touching the binary) also invalidates the cache. Deleting `.scaffold/state/run_deploy.json` (or running `--reset`) forces a fresh deploy.
-- `run --watch` prints a `===> watching <project> for changes (Ctrl-C to exit)` line after the initial pipeline. Touching a file under `methods/` (or the project's source tree) triggers `===> change detected, re-running pipeline`, debounced ~500ms. Edits under `.scaffold/`, `target/`, `.git/`, or the IDL output directory do NOT trigger re-runs. Subsequent re-runs skip reset regardless of the resolved profile's value. A failing hook prints the error and the watcher continues, waiting for the next change.
-
-### Failure Signals / Common Pitfalls
-
-- A run that silently falls back to inline `[run]` keys when `default_profile` is set but the named profile is missing is a regression — parse should fail with a clear error.
-- Deploy idempotence falsely skipping after the guest source changed (i.e., after a real `cargo build` produced a different `.bin`) is a regression. Verify by editing a guest source file, running `lgs build`, then `lgs run` — the deploy step should fire.
-- `--watch` re-running on every `target/` write would create a feedback loop. If you observe re-runs that you didn't trigger, capture the inciting file path.
-- Watch mode that tears down the localnet between iterations is a regression — only the initial iteration should ever (re)start the sequencer.
-
-### Evidence to Capture
-
-- Console output of `run` (default_profile path) and `run --profile e2e`, both showing the `Using [run.profiles.<name>]` banner.
-- Console output of the unknown-profile error showing the known-profiles list.
-- The two consecutive `run` invocations showing first a real deploy and then the skip message; the post-`rm` invocation showing a real deploy again.
-- A short transcript of `run --watch` showing one triggered re-run after a file edit.
-
-### Execution Notes
-
-- `--watch` is interactive and not suitable for unattended CI. Skip the watch step or replace it with a scripted background invocation that exits after one trigger.
-- Because the watch loop forces `reset=false` on re-runs, a file edit that requires a clean localnet (e.g., new program initializer assumes empty state) needs a manual `lgs localnet reset` between iterations.
-- `--reset` on the profile path clears `.scaffold/state/run_deploy.json` so the next `run` deploys regardless of hash equality. Confirm by inspecting the state file before and after.
+- Output of `run --post-deploy "echo override"` showing only the override hook fires.
+- Output of `run --no-post-deploy` showing the deployed-programs summary instead of hooks.
 
 ## L1. LEZ Template Bootstrap
 

--- a/DOGFOODING.md
+++ b/DOGFOODING.md
@@ -1095,8 +1095,7 @@ ls .scaffold/basecamp/portable 2>/dev/null || find .scaffold -maxdepth 4 -name '
 - Changes to wallet flows or wallet-related defaults: rerun `D4`.
 - Changes to diagnostics, report contents, or redaction logic: rerun `D5`.
 - Changes to example runner binaries or template `src/bin/*` code: rerun `D6`.
-- Changes to `run` step ordering, post-deploy env vars, restart/reset precedence, or `[run]` config parsing: rerun `D7`.
-- Changes to `[run.profiles]` semantics, post-deploy CLI overrides, deploy idempotence (`run_deploy.json` schema, hash policy), or `--watch` behavior: rerun `D8`.
+- Changes to `run` step ordering, post-deploy env vars, post-deploy CLI override flag handling, or `[run]` config parsing: rerun `D7`.
 - Changes to LEZ template scaffolding or generated outputs: rerun `L1`, `L2`, `L3`, and `L4`.
 - Changes to CLI argument parsing, help text, or error messages: rerun `E1`.
 - Changes to `create`/`new` flags or template selection logic: rerun `E2`.

--- a/FURPS.md
+++ b/FURPS.md
@@ -70,41 +70,34 @@
 
 ### Functionality
 
-1. `lgs run` collapses the inner-loop sequence — build → IDL build → ensure-localnet (or restart, or reset) → wallet topup → deploy → optional post-deploy hooks — into one command. Every step's failure aborts the pipeline with a numbered step header (`[3/N] …`) so the failing phase is unambiguous in console output.
+1. `lgs run` collapses the inner-loop sequence — build → IDL build → ensure-localnet → wallet topup → deploy → optional post-deploy hooks — into one command. Every step's failure aborts the pipeline with a numbered step header (`[3/N] …`) so the failing phase is unambiguous in console output.
 2. Source edits drive fresh on-chain program identity automatically: when the guest ELF changes, its risc0 image ID changes, and the new program's storage starts empty. Scaffold relies on this for the default cycle and adds no per-run reset.
-3. Deploy idempotence: scaffold persists a SHA-256 per program (binary + IDL JSON, domain-separated) at `.scaffold/state/run_deploy.json`. When every per-program hash matches the prior deploy, the deploy step is skipped with a one-line notice. `--reset` clears the cache as a side effect of the wipe; deleting the file manually is the supported way to force a fresh deploy without touching chain state.
-4. Post-deploy hooks: `[run].post_deploy` (or `[run.profiles.<name>].post_deploy`) is a list of shell commands executed in order via `sh -c` with `cwd` set to the project root. Hooks see a documented env contract: `SEQUENCER_URL`, `NSSA_WALLET_HOME_DIR`, `SCAFFOLD_PROJECT_ROOT`, `SCAFFOLD_IDL_DIR`, plus per-program `SCAFFOLD_PROGRAMS` / `SCAFFOLD_PROGRAM_ID_<name>` / `SCAFFOLD_GUEST_BIN_<name>` / `SCAFFOLD_DEPLOY_SKIPPED_<name>` and single-program shortcuts `SCAFFOLD_PROGRAM_NAME` / `SCAFFOLD_PROGRAM_ID` / `SCAFFOLD_GUEST_BIN` / `SCAFFOLD_DEPLOY_SKIPPED` (set only when exactly one program is deployed). Hook names with characters outside `[A-Za-z0-9_]` are sanitized for env-var-suffix legality.
-5. Named profiles: `[run.profiles.<name>]` carries per-profile `reset` / `post_deploy`. `[run].default_profile = "<name>"` selects a default. `--profile <name>` overrides; an unknown name errors with the list of known profiles. With no `--profile` and no `default_profile`, scaffold uses the inline `[run]` keys.
-6. CLI overrides: `--reset` / `--no-reset` and `--post-deploy <cmd>` (repeatable) override the resolved profile's values for one invocation. `--no-post-deploy` skips hooks entirely. Conflicting flag pairs (`--reset --no-reset`, `--post-deploy --no-post-deploy`) are rejected at clap parse time.
-7. Reset semantics: `--reset` (or `[run].reset = true` / `[run.profiles.<name>].reset = true`) wipes rocksdb + wallet directory, restarts the sequencer, **re-seeds the default wallet from the preconfigured public account**, and continues the pipeline. Suitable both as a manual recovery and as the per-run default for fixture-based deterministic test suites where PDA-key collisions force a wipe. Asymmetric with `lgs localnet reset` (the surgical primitive that preserves the wallet by default) — different abstraction levels, different defaults.
-8. Watch mode (`--watch`): after the initial pipeline, scaffold watches the project root via `notify` and re-runs build → IDL → deploy → hooks on every file change, debounced ~500ms. Re-runs reuse the running localnet (reset is forced off in the loop) and tolerate hook failures (loop continues, waiting for the next change). The IDL output directory and `.scaffold/`, `target/`, `.git/` are excluded so writes during a re-run don't self-trigger.
+3. Post-deploy hooks: `[run].post_deploy` is a list of shell commands executed in order via `sh -c` with `cwd` set to the project root. Hooks see a documented env contract: `SEQUENCER_URL`, `NSSA_WALLET_HOME_DIR`, `SCAFFOLD_PROJECT_ROOT`, `SCAFFOLD_IDL_DIR`, plus single-program shortcuts `SCAFFOLD_PROGRAM_ID` / `SCAFFOLD_GUEST_BIN` (set only when exactly one program is deployable).
+4. CLI overrides: `--post-deploy <cmd>` (repeatable) replaces `[run].post_deploy` for one invocation. `--no-post-deploy` skips hooks entirely. The two flags conflict and are rejected at clap parse time.
+5. Localnet reuse: if a managed sequencer is already running, the run reuses it. If the configured port is held by an unrelated process, the run aborts with a diagnostic naming the foreign PID.
+6. Topup safety: a wallet-topup confirmation timeout aborts before deploy so the developer is never left wondering whether deploy used a half-funded wallet.
 
 ### Usability
 
 1. The command produces a single human-readable output stream with numbered step headers and one-line summaries per phase. No JSON output flag — `--json` is reserved for `deploy`'s programmatic consumers.
-2. Hook env vars are addressable by program name (`SCAFFOLD_PROGRAM_ID_counter`), not by integer index. Adding a second program doesn't shift the first program's variable name.
-3. Single-program shortcuts (`SCAFFOLD_PROGRAM_ID` etc.) make the common case ergonomic without sacrificing multi-program correctness — shortcuts are unset when exactly one program is *not* deployed.
-4. `--reset` prints a post-wipe confirmation showing the deleted wallet path and the re-seeded default account address, so a dev who customized the wallet learns at the moment of wipe rather than via downstream confusion.
-5. Hook log markers (`===> post_deploy[i/n]:` and `<=== post_deploy[i/n] OK`) frame each hook's stdout for grep-friendly log reading.
+2. The single-program shortcuts (`SCAFFOLD_PROGRAM_ID` / `SCAFFOLD_GUEST_BIN`) cover the most common dogfooding shape (one guest program per project) without leaking ambiguous values into multi-program projects — they're unset when the project has more than one deployable program.
+3. Hook log markers (`===> post_deploy[i/n]:` and `<=== post_deploy[i/n] OK`) frame each hook's stdout for grep-friendly log reading.
 
 ### Reliability
 
-1. After `lgs run --reset`, `.scaffold/state/wallet.state` is byte-equivalent to the file produced by `rm -rf .scaffold && lgs setup`. Locks the re-seed path to the setup-path's seed logic; an integration test enforces this contract.
-2. Conflicting CLI flag pairs (`--reset --no-reset`, `--post-deploy --no-post-deploy`) are rejected at parse time, not silently coerced.
-3. Watch loop never tears down the localnet between iterations; only the initial iteration starts the sequencer.
-4. Hash cache invalidation: adding or removing a program in `methods/guest/src/bin/` always triggers a deploy (the hash map differs from the prior). Editing only the IDL output for a program also invalidates the cache via the IDL fold-in.
+1. The conflicting flag pair (`--post-deploy --no-post-deploy`) is rejected at parse time, not silently coerced.
+2. The pipeline anchors itself at the discovered project root: `lgs run` from a subdirectory builds and deploys from the project root, not from cwd.
 
 ### Performance
 
-1. The initial run is bounded by the underlying tools (cargo build, IDL test harness, sequencer startup, wallet topup, wallet deploy-program). Scaffold adds no waiting steps beyond a 30-second block-production verification when reset runs.
-2. Watch mode re-runs reuse the running localnet, so the per-edit overhead is build + IDL + deploy + hooks; localnet restart is not in the hot path.
+1. The run is bounded by the underlying tools (cargo build, IDL test harness, sequencer startup, wallet topup, wallet deploy-program); scaffold adds no waiting steps beyond what each underlying command already imposes.
+2. Single-program metadata (program ID, guest binary path) is resolved once per invocation and reused across every post-deploy hook, so multiple hooks don't multiply `spel inspect` cost.
 
 ### Supportability
 
-1. `[run]` and `[run.profiles.<name>]` round-trip cleanly through `parse_config` / `serialize_config`. Default values are omitted from the serialized output to keep diffs minimal.
-2. The hook env contract is documented in `README.md` and validated by unit tests in `src/commands/run.rs::tests`.
-3. Conflict-flag rejection messages list the conflicting flags and exit non-zero, matching clap's standard error format.
-4. Dogfooding scenarios D7 and D8 in `DOGFOODING.md` cover the pipeline, profiles, idempotence, watch loop, reset semantics, and the program-info env contract.
+1. `[run]` round-trips cleanly through `parse_config` / `serialize_config`. Default values are omitted from the serialized output to keep diffs minimal.
+2. The hook env contract is documented in `README.md` and validated by unit and integration tests in `src/commands/run.rs::tests` and `tests/cli.rs`.
+3. Flag-conflict rejection messages list the conflicting flags and exit non-zero, matching clap's standard error format.
 
 ### + (Privacy, Anonymity, Censorship-Resistance)
 
@@ -117,10 +110,9 @@
 
 - `cmd_build_shortcut` for the build phase.
 - `build_idl_for_current_project` for IDL generation (no-op for non-lez-framework projects).
-- `cmd_localnet` (start/stop) and `cmd_localnet_reset` for localnet lifecycle.
+- `cmd_localnet` (start) for localnet lifecycle when no managed sequencer is already running.
 - `cmd_wallet_topup_inner` for the topup phase.
 - `cmd_deploy` for deploy submission and `extract_program_id` for image-ID extraction.
-- `notify` crate for the `--watch` filesystem event source.
 
 ## FURPS+ — Basecamp
 

--- a/FURPS.md
+++ b/FURPS.md
@@ -66,6 +66,62 @@
 - Wallet available for signing transactions initiated by CLI interaction commands.
 - Network-aware wallet configuration to prevent cross-network key misuse.
 
+## FURPS+ — `lgs run`
+
+### Functionality
+
+1. `lgs run` collapses the inner-loop sequence — build → IDL build → ensure-localnet (or restart, or reset) → wallet topup → deploy → optional post-deploy hooks — into one command. Every step's failure aborts the pipeline with a numbered step header (`[3/N] …`) so the failing phase is unambiguous in console output.
+2. Source edits drive fresh on-chain program identity automatically: when the guest ELF changes, its risc0 image ID changes, and the new program's storage starts empty. Scaffold relies on this for the default cycle and adds no per-run reset.
+3. Deploy idempotence: scaffold persists a SHA-256 per program (binary + IDL JSON, domain-separated) at `.scaffold/state/run_deploy.json`. When every per-program hash matches the prior deploy, the deploy step is skipped with a one-line notice. `--reset` clears the cache as a side effect of the wipe; deleting the file manually is the supported way to force a fresh deploy without touching chain state.
+4. Post-deploy hooks: `[run].post_deploy` (or `[run.profiles.<name>].post_deploy`) is a list of shell commands executed in order via `sh -c` with `cwd` set to the project root. Hooks see a documented env contract: `SEQUENCER_URL`, `NSSA_WALLET_HOME_DIR`, `SCAFFOLD_PROJECT_ROOT`, `SCAFFOLD_IDL_DIR`, plus per-program `SCAFFOLD_PROGRAMS` / `SCAFFOLD_PROGRAM_ID_<name>` / `SCAFFOLD_GUEST_BIN_<name>` / `SCAFFOLD_DEPLOY_SKIPPED_<name>` and single-program shortcuts `SCAFFOLD_PROGRAM_NAME` / `SCAFFOLD_PROGRAM_ID` / `SCAFFOLD_GUEST_BIN` / `SCAFFOLD_DEPLOY_SKIPPED` (set only when exactly one program is deployed). Hook names with characters outside `[A-Za-z0-9_]` are sanitized for env-var-suffix legality.
+5. Named profiles: `[run.profiles.<name>]` carries per-profile `reset` / `post_deploy`. `[run].default_profile = "<name>"` selects a default. `--profile <name>` overrides; an unknown name errors with the list of known profiles. With no `--profile` and no `default_profile`, scaffold uses the inline `[run]` keys.
+6. CLI overrides: `--reset` / `--no-reset` and `--post-deploy <cmd>` (repeatable) override the resolved profile's values for one invocation. `--no-post-deploy` skips hooks entirely. Conflicting flag pairs (`--reset --no-reset`, `--post-deploy --no-post-deploy`) are rejected at clap parse time.
+7. Reset semantics: `--reset` (or `[run].reset = true` / `[run.profiles.<name>].reset = true`) wipes rocksdb + wallet directory, restarts the sequencer, **re-seeds the default wallet from the preconfigured public account**, and continues the pipeline. Suitable both as a manual recovery and as the per-run default for fixture-based deterministic test suites where PDA-key collisions force a wipe. Asymmetric with `lgs localnet reset` (the surgical primitive that preserves the wallet by default) — different abstraction levels, different defaults.
+8. Watch mode (`--watch`): after the initial pipeline, scaffold watches the project root via `notify` and re-runs build → IDL → deploy → hooks on every file change, debounced ~500ms. Re-runs reuse the running localnet (reset is forced off in the loop) and tolerate hook failures (loop continues, waiting for the next change). The IDL output directory and `.scaffold/`, `target/`, `.git/` are excluded so writes during a re-run don't self-trigger.
+
+### Usability
+
+1. The command produces a single human-readable output stream with numbered step headers and one-line summaries per phase. No JSON output flag — `--json` is reserved for `deploy`'s programmatic consumers.
+2. Hook env vars are addressable by program name (`SCAFFOLD_PROGRAM_ID_counter`), not by integer index. Adding a second program doesn't shift the first program's variable name.
+3. Single-program shortcuts (`SCAFFOLD_PROGRAM_ID` etc.) make the common case ergonomic without sacrificing multi-program correctness — shortcuts are unset when exactly one program is *not* deployed.
+4. `--reset` prints a post-wipe confirmation showing the deleted wallet path and the re-seeded default account address, so a dev who customized the wallet learns at the moment of wipe rather than via downstream confusion.
+5. Hook log markers (`===> post_deploy[i/n]:` and `<=== post_deploy[i/n] OK`) frame each hook's stdout for grep-friendly log reading.
+
+### Reliability
+
+1. After `lgs run --reset`, `.scaffold/state/wallet.state` is byte-equivalent to the file produced by `rm -rf .scaffold && lgs setup`. Locks the re-seed path to the setup-path's seed logic; an integration test enforces this contract.
+2. Conflicting CLI flag pairs (`--reset --no-reset`, `--post-deploy --no-post-deploy`) are rejected at parse time, not silently coerced.
+3. Watch loop never tears down the localnet between iterations; only the initial iteration starts the sequencer.
+4. Hash cache invalidation: adding or removing a program in `methods/guest/src/bin/` always triggers a deploy (the hash map differs from the prior). Editing only the IDL output for a program also invalidates the cache via the IDL fold-in.
+
+### Performance
+
+1. The initial run is bounded by the underlying tools (cargo build, IDL test harness, sequencer startup, wallet topup, wallet deploy-program). Scaffold adds no waiting steps beyond a 30-second block-production verification when reset runs.
+2. Watch mode re-runs reuse the running localnet, so the per-edit overhead is build + IDL + deploy + hooks; localnet restart is not in the hot path.
+
+### Supportability
+
+1. `[run]` and `[run.profiles.<name>]` round-trip cleanly through `parse_config` / `serialize_config`. Default values are omitted from the serialized output to keep diffs minimal.
+2. The hook env contract is documented in `README.md` and validated by unit tests in `src/commands/run.rs::tests`.
+3. Conflict-flag rejection messages list the conflicting flags and exit non-zero, matching clap's standard error format.
+4. Dogfooding scenarios D7 and D8 in `DOGFOODING.md` cover the pipeline, profiles, idempotence, watch loop, reset semantics, and the program-info env contract.
+
+### + (Privacy, Anonymity, Censorship-Resistance)
+
+- Hooks run locally with the developer's own wallet; no network egress beyond what the deploy step already needs.
+- Post-deploy hooks have direct access to the deployer's wallet home via `NSSA_WALLET_HOME_DIR`. Hooks are user-authored and trusted — same threat model as `scaffold.toml` itself.
+
+### Dependencies
+
+#### Internal Dependencies
+
+- `cmd_build_shortcut` for the build phase.
+- `build_idl_for_current_project` for IDL generation (no-op for non-lez-framework projects).
+- `cmd_localnet` (start/stop) and `cmd_localnet_reset` for localnet lifecycle.
+- `cmd_wallet_topup_inner` for the topup phase.
+- `cmd_deploy` for deploy submission and `extract_program_id` for image-ID extraction.
+- `notify` crate for the `--watch` filesystem event source.
+
 ## FURPS+ — Basecamp
 
 ### Functionality

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ logos-scaffold wallet topup [<address> | --address <address-ref>] [--dry-run]
 logos-scaffold wallet default set <address-ref>
 logos-scaffold wallet default set --address <address-ref>
 logos-scaffold wallet -- <wallet-command...>
-logos-scaffold run [--profile <name>] [--reset | --no-reset] [--post-deploy <cmd>...] [--no-post-deploy] [--watch]
+logos-scaffold run [--post-deploy <cmd>...] [--no-post-deploy]
 logos-scaffold spel -- <spel-command...>
 logos-scaffold basecamp setup
 logos-scaffold basecamp modules [--path PATH]... [--flake REF]... [--show]
@@ -98,7 +98,7 @@ logos-scaffold help
 - `wallet topup` checks account state first (`wallet account get --account-id ...`), runs `wallet auth-transfer init --account-id ...` only when the destination is uninitialized, then performs Piñata faucet claim (`wallet pinata claim --to ...`). If address is omitted, scaffold uses project default wallet from `.scaffold/state/wallet.state`.
 - `wallet default set` stores a project-scoped default wallet address in `.scaffold/state/wallet.state`.
 - `wallet -- ...` forwards raw wallet CLI arguments to the project-local wallet binary while preserving project wallet environment.
-- `run` combines build, IDL build, localnet start, wallet topup, and deploy into a single command. If a `[run]` section with `post_deploy` is present in `scaffold.toml`, each hook is executed after deploy via `sh -c` (cwd = project root) with `SEQUENCER_URL`, `NSSA_WALLET_HOME_DIR`, `SCAFFOLD_PROJECT_ROOT`, `SCAFFOLD_IDL_DIR`, and the per-program `SCAFFOLD_PROGRAMS` / `SCAFFOLD_PROGRAM_ID_<name>` / `SCAFFOLD_GUEST_BIN_<name>` env vars. If a localnet is already running it is reused; otherwise it is started. `--reset` (or `[run].reset = true`) wipes rocksdb and the project wallet, restarts the sequencer, re-seeds the default wallet, and continues the pipeline — for fixture-based deterministic test loops that need a fresh chain per invocation, or as a manual recovery for a wedged project. `--profile <name>` selects a named profile from `[run.profiles.<name>]`; `[run].default_profile` sets a default. `--post-deploy <cmd>` (repeatable) overrides the resolved profile's hooks; `--no-post-deploy` skips them entirely.
+- `run` combines build, IDL build, localnet start, wallet topup, and deploy into a single command. If a `[run]` section with `post_deploy` is present in `scaffold.toml`, each hook is executed after deploy via `sh -c` (cwd = project root) with `SEQUENCER_URL`, `NSSA_WALLET_HOME_DIR`, `SCAFFOLD_PROJECT_ROOT`, and `SCAFFOLD_IDL_DIR` env vars; when the project has exactly one deployable program, `SCAFFOLD_PROGRAM_ID` and `SCAFFOLD_GUEST_BIN` are also set. If a localnet is already running it is reused; otherwise it is started. `--post-deploy <cmd>` (repeatable) overrides the configured hooks; `--no-post-deploy` skips them entirely.
 - `spel -- ...` forwards raw spel CLI arguments to the project-vendored `spel` binary so any spel subcommand (`inspect`, `pda`, `generate-idl`, …) runs against the project's pinned version without a global install.
 - `basecamp setup` pins basecamp + `lgpm` (read from `[repos.basecamp]` / `[repos.lgpm]` — both `build = "nix-flake"`), builds both (logged to `.scaffold/logs/<timestamp>-setup-*.log`), and seeds per-profile XDG directories for `alice` and `bob` under `.scaffold/basecamp/profiles/`. Runtime config (`port_base`, `port_stride`) is in `[basecamp]`.
 - `basecamp modules` is the sole writer of the captured module set, which lives in top-level `[modules.<name>]` sections (each with `flake` and `role = "project" | "dependency"`). Modules aren't basecamp's property — they're the project's Logos modules, which basecamp happens to be one consumer of. Zero-arg runs auto-discovery: walks project flakes (root `.#lgx` first, else immediate sub-flakes), derives a `module_name` per source (from `metadata.json.name` for local paths; heuristic from the github repo slug for remote refs, with a one-line assumption note you can correct in `scaffold.toml`), then resolves each declared dep name by: (1) already keyed in `[modules]`, (2) basecamp preinstall list, (3) the source's own `flake.lock`, (4) scaffold-default pin. Unresolved deps **fail fast** — no silent skip. `--flake <ref>` / `--path <file>` capture explicit project sources; `--show` prints the current set without mutating. Re-runs are idempotent: existing `[modules]` entries are preserved so hand-edits survive. Project contract: see [docs/basecamp-module-requirements.md](./docs/basecamp-module-requirements.md).
@@ -153,7 +153,7 @@ Existing fields are preserved verbatim.
 
 ### One-step build + deploy with `run`
 
-Or use `run` to do build → localnet → topup → deploy in one step:
+Or use `run` to do build → IDL → localnet → topup → deploy in one step:
 
 ```bash
 lgs new my-app
@@ -166,36 +166,11 @@ with [spel](https://github.com/logos-co/spel)), add a `[run]` section to
 `scaffold.toml`. `post_deploy` is a list of shell commands executed in order;
 the run aborts at the first non-zero exit:
 
-Single-program project (uses the `SCAFFOLD_PROGRAM_NAME` /
-`SCAFFOLD_GUEST_BIN` shortcuts described in the env table below):
-
 ```toml
 [run]
 post_deploy = [
-  "lgs spel -- --idl $SCAFFOLD_IDL_DIR/${SCAFFOLD_PROGRAM_NAME}.json -p $SCAFFOLD_GUEST_BIN init",
-  "lgs spel -- --idl $SCAFFOLD_IDL_DIR/${SCAFFOLD_PROGRAM_NAME}.json -p $SCAFFOLD_GUEST_BIN increment --by 5",
-]
-```
-
-Multi-program project (shortcuts are unset; reference each program by
-its source filename stem):
-
-```toml
-[run]
-post_deploy = [
-  # Initialize the counter program.
-  "lgs spel -- --idl $SCAFFOLD_IDL_DIR/counter.json -p $SCAFFOLD_GUEST_BIN_counter init",
-  # Initialize the greeter program with a message.
-  "lgs spel -- --idl $SCAFFOLD_IDL_DIR/greeter.json -p $SCAFFOLD_GUEST_BIN_greeter init --message hello",
-  # Iterate over every deployed program and print its image ID.
-  # Note: this loop assumes program filenames contain only [A-Za-z0-9_]
-  # — see the "Indexed env-var name rewriting" callout below.
-  '''
-  for prog in $SCAFFOLD_PROGRAMS; do
-    pid_var="SCAFFOLD_PROGRAM_ID_$prog"
-    echo "$prog -> ${!pid_var}"
-  done
-  ''',
+  "lgs spel -- --idl $SCAFFOLD_IDL_DIR/counter.json -p $SCAFFOLD_GUEST_BIN init",
+  "lgs spel -- --idl $SCAFFOLD_IDL_DIR/counter.json -p $SCAFFOLD_GUEST_BIN increment --by 5",
 ]
 ```
 
@@ -214,75 +189,12 @@ environment variables pre-set:
 | `NSSA_WALLET_HOME_DIR` | Absolute path to project wallet directory |
 | `SCAFFOLD_PROJECT_ROOT` | Absolute path to project root |
 | `SCAFFOLD_IDL_DIR` | Absolute path to IDL output directory |
-| `SCAFFOLD_PROGRAMS` | Space-separated list of deployable program names (raw filenames; see callout below) |
-| `SCAFFOLD_PROGRAM_ID_<name>` | risc0 image ID (hex) per program. Unset when `spel inspect` cannot extract it |
-| `SCAFFOLD_GUEST_BIN_<name>` | Absolute path to the guest `.bin` per program |
-| `SCAFFOLD_DEPLOY_SKIPPED_<name>` | `1` if the deploy step was short-circuited by the hash cache, else `0` |
-| `SCAFFOLD_PROGRAM_NAME` / `SCAFFOLD_PROGRAM_ID` / `SCAFFOLD_GUEST_BIN` / `SCAFFOLD_DEPLOY_SKIPPED` | Single-program shortcuts. Set only when exactly one program was deployed |
+| `SCAFFOLD_PROGRAM_ID` | risc0 image ID (hex) of the deployed program. Set only when the project has exactly one deployable program; unset if `spel inspect` cannot extract the ID |
+| `SCAFFOLD_GUEST_BIN` | Absolute path to the guest `.bin`. Set only when the project has exactly one deployable program |
 
-The single-program shortcuts (`SCAFFOLD_PROGRAM_NAME` / `_ID` / `_BIN` /
-`_DEPLOY_SKIPPED`) are unset for multi-program projects so hooks fail
-loudly rather than silently picking up a value from a stale config.
-
-##### Indexed env-var name rewriting
-
-The `<name>` in `SCAFFOLD_PROGRAM_ID_<name>` (and the `_BIN_<name>` /
-`_DEPLOY_SKIPPED_<name>` siblings) is the program's source filename stem
-(from `methods/guest/src/bin/<name>.rs`) with any character outside
-`[A-Za-z0-9_]` rewritten to `_`. POSIX env-var names cannot contain
-hyphens, dots, or slashes, so a program named `my-program.rs` becomes
-`SCAFFOLD_PROGRAM_ID_my_program` (lowercase preserved, only the
-hyphen rewritten).
-
-This means `$SCAFFOLD_PROGRAMS` and the indexed-var suffix do **not**
-round-trip identically when a name contains rewritten characters: the
-program list reports `my-program`, but the env var is keyed by
-`my_program`. Two safe patterns:
-
-- Reference programs by hardcoded filename in your hooks
-  (`$SCAFFOLD_GUEST_BIN_counter`, not a loop variable). Cleanest.
-- Or sanitize inside the loop before constructing the var name:
-
-  ```sh
-  for prog in $SCAFFOLD_PROGRAMS; do
-    suffix=$(echo "$prog" | tr -c '[:alnum:]_' '_')
-    pid_var="SCAFFOLD_PROGRAM_ID_$suffix"
-    echo "$prog -> ${!pid_var}"
-  done
-  ```
-
-To make the rewrite visible at runtime, `lgs run` prints a one-line
-`note:` listing the resolved suffix for any program whose name was
-rewritten, just before invoking the first hook. The simplest fix is
-usually to rename the file so its stem stays inside `[A-Za-z0-9_]`
-(cargo's `bin` convention discourages hyphens anyway).
-
-#### Named profiles
-
-For projects with multiple post-deploy workflows (dev iteration, e2e
-fixture replay, smoke verify, fuzz), define them as named profiles and
-select with `--profile`:
-
-```toml
-[run]
-default_profile = "dev"
-
-[run.profiles.dev]
-post_deploy = "scripts/post-deploy-dev.sh"
-
-[run.profiles.e2e]
-reset = true
-post_deploy = "scripts/e2e-runs.sh"
-```
-
-```bash
-lgs run                # uses default_profile = "dev"
-lgs run --profile e2e  # uses [run.profiles.e2e]
-```
-
-When `--profile` is not passed, scaffold picks `default_profile` if set,
-otherwise falls back to inline `[run]` keys (the legacy/unnamed slot).
-An unknown `--profile` name errors with the list of known profiles.
+`SCAFFOLD_PROGRAM_ID` and `SCAFFOLD_GUEST_BIN` are unset for
+multi-program projects so hooks fail loudly rather than silently
+picking up the wrong program.
 
 #### One-off override / skip
 
@@ -295,76 +207,7 @@ lgs run --no-post-deploy                                 # skip all hooks
 ```
 
 `--post-deploy` and `--no-post-deploy` conflict with each other and
-both override whatever the resolved profile defines.
-
-#### Deploy idempotence
-
-`run` skips the deploy step when every guest program's `.bin` plus its
-IDL JSON hashes (SHA-256, domain-separated) to the same value as the
-prior deploy. State lives at `.scaffold/state/run_deploy.json`. Adding
-or removing a program in `methods/guest/src/bin/`, or editing the IDL
-output for a program, invalidates the cache and forces a deploy.
-A `--reset` clears the state file as a side effect of the wipe. To
-force a fresh deploy without resetting the chain, delete the state
-file manually:
-
-```bash
-rm .scaffold/state/run_deploy.json
-lgs run
-```
-
-#### Watch mode
-
-For tight inner-loop work, `--watch` re-runs build → IDL → deploy → hooks
-on every file change under the project root (ignoring `.scaffold/`,
-`target/`, `.git/`, and the framework's IDL output directory). The
-initial run is the full pipeline; subsequent re-runs reuse the running
-localnet (reset is suppressed on re-runs). Hook failures don't end the
-loop — the watcher waits for the next change.
-
-```bash
-lgs run --watch                  # full pipeline, then iterate
-lgs run --profile dev --watch    # iterate against the dev profile
-```
-
-#### Reset
-
-`--reset` (or `[run].reset = true` / `[run.profiles.<name>].reset = true`)
-wipes rocksdb and the project wallet, restarts the sequencer, **re-seeds
-the default wallet from the preconfigured public account**, and
-continues the pipeline through topup → deploy → hooks. The post-reset
-state is byte-equivalent to a fresh `lgs setup`.
-
-Two equally-legitimate use cases:
-
-- **Fixture-based deterministic test suites** — fixed chain seeds produce
-  fixed PDA keys, so consecutive runs collide on duplicate writes without
-  reset. `reset = true` in such a profile is the *normal per-run
-  behavior*, not an escape hatch.
-- **Manual recovery** — "give me a fresh project state, regardless of
-  what happened in the previous run."
-
-```bash
-lgs run --reset
-```
-
-```toml
-[run.profiles.e2e]
-reset = true
-post_deploy = "scripts/e2e-run.sh"
-```
-
-The CLI flag overrides the config (`--no-reset` opts out of a
-config-true default).
-
-`lgs run --reset` is asymmetric with `lgs localnet reset` by design:
-
-| Surface | Wallet treatment |
-|---|---|
-| `lgs run --reset` | Always wipes + re-seeds default wallet (lifecycle reset for the deploy cycle) |
-| `lgs localnet reset` | Preserves wallet by default; `--reset-wallet` opts in to delete (surgical primitive for multi-account projects) |
-
-`setup` automatically seeds `.scaffold/state/wallet.state` with the first preconfigured public account when no default is present.
+both override whatever `[run].post_deploy` defines.
 
 Checkpoint commands:
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ logos-scaffold wallet topup [<address> | --address <address-ref>] [--dry-run]
 logos-scaffold wallet default set <address-ref>
 logos-scaffold wallet default set --address <address-ref>
 logos-scaffold wallet -- <wallet-command...>
+logos-scaffold run [--profile <name>] [--reset | --no-reset] [--post-deploy <cmd>...] [--no-post-deploy] [--watch]
 logos-scaffold spel -- <spel-command...>
 logos-scaffold basecamp setup
 logos-scaffold basecamp modules [--path PATH]... [--flake REF]... [--show]
@@ -97,6 +98,7 @@ logos-scaffold help
 - `wallet topup` checks account state first (`wallet account get --account-id ...`), runs `wallet auth-transfer init --account-id ...` only when the destination is uninitialized, then performs Piñata faucet claim (`wallet pinata claim --to ...`). If address is omitted, scaffold uses project default wallet from `.scaffold/state/wallet.state`.
 - `wallet default set` stores a project-scoped default wallet address in `.scaffold/state/wallet.state`.
 - `wallet -- ...` forwards raw wallet CLI arguments to the project-local wallet binary while preserving project wallet environment.
+- `run` combines build, IDL build, localnet start, wallet topup, and deploy into a single command. If a `[run]` section with `post_deploy` is present in `scaffold.toml`, each hook is executed after deploy via `sh -c` (cwd = project root) with `SEQUENCER_URL`, `NSSA_WALLET_HOME_DIR`, `SCAFFOLD_PROJECT_ROOT`, `SCAFFOLD_IDL_DIR`, and the per-program `SCAFFOLD_PROGRAMS` / `SCAFFOLD_PROGRAM_ID_<name>` / `SCAFFOLD_GUEST_BIN_<name>` env vars. If a localnet is already running it is reused; otherwise it is started. `--reset` (or `[run].reset = true`) wipes rocksdb and the project wallet, restarts the sequencer, re-seeds the default wallet, and continues the pipeline — for fixture-based deterministic test loops that need a fresh chain per invocation, or as a manual recovery for a wedged project. `--profile <name>` selects a named profile from `[run.profiles.<name>]`; `[run].default_profile` sets a default. `--post-deploy <cmd>` (repeatable) overrides the resolved profile's hooks; `--no-post-deploy` skips them entirely.
 - `spel -- ...` forwards raw spel CLI arguments to the project-vendored `spel` binary so any spel subcommand (`inspect`, `pda`, `generate-idl`, …) runs against the project's pinned version without a global install.
 - `basecamp setup` pins basecamp + `lgpm` (read from `[repos.basecamp]` / `[repos.lgpm]` — both `build = "nix-flake"`), builds both (logged to `.scaffold/logs/<timestamp>-setup-*.log`), and seeds per-profile XDG directories for `alice` and `bob` under `.scaffold/basecamp/profiles/`. Runtime config (`port_base`, `port_stride`) is in `[basecamp]`.
 - `basecamp modules` is the sole writer of the captured module set, which lives in top-level `[modules.<name>]` sections (each with `flake` and `role = "project" | "dependency"`). Modules aren't basecamp's property — they're the project's Logos modules, which basecamp happens to be one consumer of. Zero-arg runs auto-discovery: walks project flakes (root `.#lgx` first, else immediate sub-flakes), derives a `module_name` per source (from `metadata.json.name` for local paths; heuristic from the github repo slug for remote refs, with a one-line assumption note you can correct in `scaffold.toml`), then resolves each declared dep name by: (1) already keyed in `[modules]`, (2) basecamp preinstall list, (3) the source's own `flake.lock`, (4) scaffold-default pin. Unresolved deps **fail fast** — no silent skip. `--flake <ref>` / `--path <file>` capture explicit project sources; `--show` prints the current set without mutating. Re-runs are idempotent: existing `[modules]` entries are preserved so hand-edits survive. Project contract: see [docs/basecamp-module-requirements.md](./docs/basecamp-module-requirements.md).
@@ -148,6 +150,219 @@ lgs setup   # picks up the new section
 ```
 
 Existing fields are preserved verbatim.
+
+### One-step build + deploy with `run`
+
+Or use `run` to do build → localnet → topup → deploy in one step:
+
+```bash
+lgs new my-app
+cd my-app
+lgs run
+```
+
+To run one or more post-deploy hooks automatically (e.g. submit a transaction
+with [spel](https://github.com/logos-co/spel)), add a `[run]` section to
+`scaffold.toml`. `post_deploy` is a list of shell commands executed in order;
+the run aborts at the first non-zero exit:
+
+Single-program project (uses the `SCAFFOLD_PROGRAM_NAME` /
+`SCAFFOLD_GUEST_BIN` shortcuts described in the env table below):
+
+```toml
+[run]
+post_deploy = [
+  "lgs spel -- --idl $SCAFFOLD_IDL_DIR/${SCAFFOLD_PROGRAM_NAME}.json -p $SCAFFOLD_GUEST_BIN init",
+  "lgs spel -- --idl $SCAFFOLD_IDL_DIR/${SCAFFOLD_PROGRAM_NAME}.json -p $SCAFFOLD_GUEST_BIN increment --by 5",
+]
+```
+
+Multi-program project (shortcuts are unset; reference each program by
+its source filename stem):
+
+```toml
+[run]
+post_deploy = [
+  # Initialize the counter program.
+  "lgs spel -- --idl $SCAFFOLD_IDL_DIR/counter.json -p $SCAFFOLD_GUEST_BIN_counter init",
+  # Initialize the greeter program with a message.
+  "lgs spel -- --idl $SCAFFOLD_IDL_DIR/greeter.json -p $SCAFFOLD_GUEST_BIN_greeter init --message hello",
+  # Iterate over every deployed program and print its image ID.
+  # Note: this loop assumes program filenames contain only [A-Za-z0-9_]
+  # — see the "Indexed env-var name rewriting" callout below.
+  '''
+  for prog in $SCAFFOLD_PROGRAMS; do
+    pid_var="SCAFFOLD_PROGRAM_ID_$prog"
+    echo "$prog -> ${!pid_var}"
+  done
+  ''',
+]
+```
+
+The `lgs spel --` passthrough invokes the project-vendored `spel` binary
+so hooks pick up the same pinned version `deploy` used.
+
+A single command may also be written as a plain string for brevity:
+`post_deploy = "echo done"`.
+
+Each hook runs via `sh -c` with cwd set to the project root and these
+environment variables pre-set:
+
+| Variable | Value |
+|---|---|
+| `SEQUENCER_URL` | `http://127.0.0.1:<port>` (from `scaffold.toml`) |
+| `NSSA_WALLET_HOME_DIR` | Absolute path to project wallet directory |
+| `SCAFFOLD_PROJECT_ROOT` | Absolute path to project root |
+| `SCAFFOLD_IDL_DIR` | Absolute path to IDL output directory |
+| `SCAFFOLD_PROGRAMS` | Space-separated list of deployable program names (raw filenames; see callout below) |
+| `SCAFFOLD_PROGRAM_ID_<name>` | risc0 image ID (hex) per program. Unset when `spel inspect` cannot extract it |
+| `SCAFFOLD_GUEST_BIN_<name>` | Absolute path to the guest `.bin` per program |
+| `SCAFFOLD_DEPLOY_SKIPPED_<name>` | `1` if the deploy step was short-circuited by the hash cache, else `0` |
+| `SCAFFOLD_PROGRAM_NAME` / `SCAFFOLD_PROGRAM_ID` / `SCAFFOLD_GUEST_BIN` / `SCAFFOLD_DEPLOY_SKIPPED` | Single-program shortcuts. Set only when exactly one program was deployed |
+
+The single-program shortcuts (`SCAFFOLD_PROGRAM_NAME` / `_ID` / `_BIN` /
+`_DEPLOY_SKIPPED`) are unset for multi-program projects so hooks fail
+loudly rather than silently picking up a value from a stale config.
+
+##### Indexed env-var name rewriting
+
+The `<name>` in `SCAFFOLD_PROGRAM_ID_<name>` (and the `_BIN_<name>` /
+`_DEPLOY_SKIPPED_<name>` siblings) is the program's source filename stem
+(from `methods/guest/src/bin/<name>.rs`) with any character outside
+`[A-Za-z0-9_]` rewritten to `_`. POSIX env-var names cannot contain
+hyphens, dots, or slashes, so a program named `my-program.rs` becomes
+`SCAFFOLD_PROGRAM_ID_my_program` (lowercase preserved, only the
+hyphen rewritten).
+
+This means `$SCAFFOLD_PROGRAMS` and the indexed-var suffix do **not**
+round-trip identically when a name contains rewritten characters: the
+program list reports `my-program`, but the env var is keyed by
+`my_program`. Two safe patterns:
+
+- Reference programs by hardcoded filename in your hooks
+  (`$SCAFFOLD_GUEST_BIN_counter`, not a loop variable). Cleanest.
+- Or sanitize inside the loop before constructing the var name:
+
+  ```sh
+  for prog in $SCAFFOLD_PROGRAMS; do
+    suffix=$(echo "$prog" | tr -c '[:alnum:]_' '_')
+    pid_var="SCAFFOLD_PROGRAM_ID_$suffix"
+    echo "$prog -> ${!pid_var}"
+  done
+  ```
+
+To make the rewrite visible at runtime, `lgs run` prints a one-line
+`note:` listing the resolved suffix for any program whose name was
+rewritten, just before invoking the first hook. The simplest fix is
+usually to rename the file so its stem stays inside `[A-Za-z0-9_]`
+(cargo's `bin` convention discourages hyphens anyway).
+
+#### Named profiles
+
+For projects with multiple post-deploy workflows (dev iteration, e2e
+fixture replay, smoke verify, fuzz), define them as named profiles and
+select with `--profile`:
+
+```toml
+[run]
+default_profile = "dev"
+
+[run.profiles.dev]
+post_deploy = "scripts/post-deploy-dev.sh"
+
+[run.profiles.e2e]
+reset = true
+post_deploy = "scripts/e2e-runs.sh"
+```
+
+```bash
+lgs run                # uses default_profile = "dev"
+lgs run --profile e2e  # uses [run.profiles.e2e]
+```
+
+When `--profile` is not passed, scaffold picks `default_profile` if set,
+otherwise falls back to inline `[run]` keys (the legacy/unnamed slot).
+An unknown `--profile` name errors with the list of known profiles.
+
+#### One-off override / skip
+
+To run a different hook without editing `scaffold.toml`:
+
+```bash
+lgs run --post-deploy "scripts/smoke.sh"
+lgs run --post-deploy "step-a" --post-deploy "step-b"   # repeatable
+lgs run --no-post-deploy                                 # skip all hooks
+```
+
+`--post-deploy` and `--no-post-deploy` conflict with each other and
+both override whatever the resolved profile defines.
+
+#### Deploy idempotence
+
+`run` skips the deploy step when every guest program's `.bin` plus its
+IDL JSON hashes (SHA-256, domain-separated) to the same value as the
+prior deploy. State lives at `.scaffold/state/run_deploy.json`. Adding
+or removing a program in `methods/guest/src/bin/`, or editing the IDL
+output for a program, invalidates the cache and forces a deploy.
+A `--reset` clears the state file as a side effect of the wipe. To
+force a fresh deploy without resetting the chain, delete the state
+file manually:
+
+```bash
+rm .scaffold/state/run_deploy.json
+lgs run
+```
+
+#### Watch mode
+
+For tight inner-loop work, `--watch` re-runs build → IDL → deploy → hooks
+on every file change under the project root (ignoring `.scaffold/`,
+`target/`, `.git/`, and the framework's IDL output directory). The
+initial run is the full pipeline; subsequent re-runs reuse the running
+localnet (reset is suppressed on re-runs). Hook failures don't end the
+loop — the watcher waits for the next change.
+
+```bash
+lgs run --watch                  # full pipeline, then iterate
+lgs run --profile dev --watch    # iterate against the dev profile
+```
+
+#### Reset
+
+`--reset` (or `[run].reset = true` / `[run.profiles.<name>].reset = true`)
+wipes rocksdb and the project wallet, restarts the sequencer, **re-seeds
+the default wallet from the preconfigured public account**, and
+continues the pipeline through topup → deploy → hooks. The post-reset
+state is byte-equivalent to a fresh `lgs setup`.
+
+Two equally-legitimate use cases:
+
+- **Fixture-based deterministic test suites** — fixed chain seeds produce
+  fixed PDA keys, so consecutive runs collide on duplicate writes without
+  reset. `reset = true` in such a profile is the *normal per-run
+  behavior*, not an escape hatch.
+- **Manual recovery** — "give me a fresh project state, regardless of
+  what happened in the previous run."
+
+```bash
+lgs run --reset
+```
+
+```toml
+[run.profiles.e2e]
+reset = true
+post_deploy = "scripts/e2e-run.sh"
+```
+
+The CLI flag overrides the config (`--no-reset` opts out of a
+config-true default).
+
+`lgs run --reset` is asymmetric with `lgs localnet reset` by design:
+
+| Surface | Wallet treatment |
+|---|---|
+| `lgs run --reset` | Always wipes + re-seeds default wallet (lifecycle reset for the deploy cycle) |
+| `lgs localnet reset` | Preserves wallet by default; `--reset-wallet` opts in to delete (surgical primitive for multi-account projects) |
 
 `setup` automatically seeds `.scaffold/state/wallet.state` with the first preconfigured public account when no default is present.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,6 +15,7 @@ use crate::commands::init::cmd_init;
 use crate::commands::localnet::{cmd_localnet, LocalnetAction};
 use crate::commands::new::{cmd_new, NewCommand};
 use crate::commands::report::cmd_report;
+use crate::commands::run::{cmd_run, RunInvocation};
 use crate::commands::setup::cmd_setup;
 use crate::commands::spel::cmd_spel;
 use crate::commands::wallet::{cmd_wallet, WalletAction};
@@ -64,6 +65,8 @@ enum Commands {
     #[command(about = "Manage pre-seeded basecamp profiles for p2p dogfooding")]
     Basecamp(BasecampArgs),
     Doctor(DoctorArgs),
+    #[command(about = "Build, start localnet, top up wallet, deploy, and run post-deploy hook")]
+    Run(RunArgs),
     #[command(about = "Collect a sanitized diagnostics archive for issue reporting")]
     Report(ReportArgs),
     #[command(
@@ -205,6 +208,17 @@ struct ReportArgs {
     out: Option<PathBuf>,
     #[arg(long, default_value_t = 500)]
     tail: usize,
+}
+
+#[derive(Debug, clap::Args)]
+struct RunArgs {
+    /// Skip post-deploy hooks even if scaffold.toml configures them
+    #[arg(long)]
+    no_post_deploy: bool,
+    /// Override post-deploy hooks (repeatable). Replaces config-defined hooks
+    /// for this invocation. Conflicts with --no-post-deploy.
+    #[arg(long, value_name = "CMD", conflicts_with = "no_post_deploy")]
+    post_deploy: Vec<String>,
 }
 
 #[derive(Debug, clap::Args)]
@@ -502,6 +516,18 @@ pub(crate) fn run(args: Vec<String>) -> DynResult<()> {
             cmd_basecamp(action)
         }
         Some(Commands::Doctor(args)) => cmd_doctor(args.json),
+        Some(Commands::Run(args)) => {
+            let post_deploy = if args.no_post_deploy {
+                Some(Vec::new())
+            } else if !args.post_deploy.is_empty() {
+                Some(args.post_deploy)
+            } else {
+                None
+            };
+            cmd_run(RunInvocation {
+                post_deploy_override: post_deploy,
+            })
+        }
         Some(Commands::Report(args)) => cmd_report(args.out, args.tail),
         Some(Commands::Completions(args)) => {
             let shell = match args.shell {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -219,6 +219,11 @@ struct RunArgs {
     /// for this invocation. Conflicts with --no-post-deploy.
     #[arg(long, value_name = "CMD", conflicts_with = "no_post_deploy")]
     post_deploy: Vec<String>,
+    /// Seconds to wait for the sequencer to become ready when `run` has to
+    /// start localnet itself. Bump this if a cold first run (fresh clone,
+    /// cold caches) overshoots the default.
+    #[arg(long, value_name = "SECS")]
+    localnet_timeout: Option<u64>,
 }
 
 #[derive(Debug, clap::Args)]
@@ -526,6 +531,7 @@ pub(crate) fn run(args: Vec<String>) -> DynResult<()> {
             };
             cmd_run(RunInvocation {
                 post_deploy_override: post_deploy,
+                localnet_timeout_sec: args.localnet_timeout,
             })
         }
         Some(Commands::Report(args)) => cmd_report(args.out, args.tail),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,7 +19,7 @@ use crate::commands::run::{cmd_run, RunInvocation};
 use crate::commands::setup::cmd_setup;
 use crate::commands::spel::cmd_spel;
 use crate::commands::wallet::{cmd_wallet, WalletAction};
-use crate::constants::VERSION;
+use crate::constants::{DEFAULT_RUN_LOCALNET_TIMEOUT_SEC, VERSION};
 use crate::template::project::available_templates;
 use crate::DynResult;
 
@@ -36,6 +36,15 @@ static CREATE_ABOUT: LazyLock<String> = LazyLock::new(|| {
 static NEW_ABOUT: LazyLock<String> = LazyLock::new(|| {
     let templates = available_templates().join(", ");
     format!("Alias for `create` (templates: {templates})")
+});
+
+static RUN_LOCALNET_TIMEOUT_HELP: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "Seconds to wait for the sequencer to become ready when `run` has to \
+         start localnet itself (default: {DEFAULT_RUN_LOCALNET_TIMEOUT_SEC}). \
+         Bump this if a cold first run (fresh clone, cold caches) overshoots \
+         the default."
+    )
 });
 
 #[derive(Debug, Parser)]
@@ -219,10 +228,7 @@ struct RunArgs {
     /// for this invocation. Conflicts with --no-post-deploy.
     #[arg(long, value_name = "CMD", conflicts_with = "no_post_deploy")]
     post_deploy: Vec<String>,
-    /// Seconds to wait for the sequencer to become ready when `run` has to
-    /// start localnet itself. Bump this if a cold first run (fresh clone,
-    /// cold caches) overshoots the default.
-    #[arg(long, value_name = "SECS")]
+    #[arg(long, value_name = "SECS", help = RUN_LOCALNET_TIMEOUT_HELP.as_str())]
     localnet_timeout: Option<u64>,
 }
 

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -278,7 +278,7 @@ fn preflight_sequencer_reachability(sequencer_addr: &str) -> DynResult<()> {
     }
 }
 
-fn discover_deployable_programs(project_root: &Path) -> DynResult<Vec<String>> {
+pub(crate) fn discover_deployable_programs(project_root: &Path) -> DynResult<Vec<String>> {
     let programs_dir = project_root.join("methods/guest/src/bin");
     if !programs_dir.exists() {
         bail!(
@@ -430,7 +430,7 @@ const SPEL_INSPECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs
 /// missing, non-zero exit, output unparseable, timeout). Callers print an
 /// "unavailable" hint instead of failing the deploy — the deploy itself has
 /// already succeeded by the time this runs.
-fn extract_program_id(spel_bin: &Path, binary_path: &Path) -> Option<String> {
+pub(crate) fn extract_program_id(spel_bin: &Path, binary_path: &Path) -> Option<String> {
     use std::io::Read;
     use std::process::Stdio;
     use std::time::Instant;

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -14,7 +14,7 @@ use crate::constants::{
     SCAFFOLD_TOML_SCHEMA_VERSION,
 };
 use crate::migrate::migrate_to_v0_2_0;
-use crate::model::{Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig};
+use crate::model::{Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig, RunConfig};
 use crate::state::write_text;
 use crate::template::project::ensure_scaffold_in_gitignore;
 use crate::DynResult;
@@ -104,6 +104,7 @@ fn fresh_default_config() -> Config {
         localnet: LocalnetConfig::default(),
         modules: std::collections::BTreeMap::new(),
         basecamp: None,
+        run: RunConfig::default(),
     }
 }
 

--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -633,7 +633,7 @@ mod tests {
     use crate::commands::wallet_support::wallet_state_path;
     use crate::error::ResetError;
     use crate::model::{
-        Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig, Project, RepoRef,
+        Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig, Project, RepoRef, RunConfig,
     };
 
     fn make_test_project(temp: &tempfile::TempDir) -> (Project, PathBuf) {
@@ -672,6 +672,7 @@ mod tests {
             },
             modules: std::collections::BTreeMap::new(),
             basecamp: None,
+            run: RunConfig::default(),
         };
 
         let project = Project {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod init;
 pub(crate) mod localnet;
 pub(crate) mod new;
 pub(crate) mod report;
+pub(crate) mod run;
 pub(crate) mod self_test;
 pub(crate) mod setup;
 pub(crate) mod spel;

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -12,7 +12,7 @@ use crate::constants::{
     DEFAULT_FRAMEWORK_VERSION, DEFAULT_LEZ, DEFAULT_LGPM_PIN, DEFAULT_SPEL, FRAMEWORK_KIND_DEFAULT,
     FRAMEWORK_KIND_LEZ_FRAMEWORK, LEZ_SOURCE, SCAFFOLD_TOML_SCHEMA_VERSION,
 };
-use crate::model::{Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig};
+use crate::model::{Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig, RunConfig};
 use crate::project::default_cache_root;
 use crate::repo::{sync_repo_to_pin_at_path_with_opts, RepoSyncOptions};
 use crate::state::write_text;
@@ -132,6 +132,7 @@ pub(crate) fn cmd_new(cmd: NewCommand) -> DynResult<()> {
         localnet: LocalnetConfig::default(),
         modules: std::collections::BTreeMap::new(),
         basecamp: None,
+        run: RunConfig::default(),
     };
 
     let template_root = lez_repo_path.join("examples/program_deployment");

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::process::Command;
 
 use anyhow::{bail, Context};
@@ -10,7 +11,7 @@ use crate::commands::idl::build_idl_for_current_project;
 use crate::commands::localnet::{build_localnet_status_for_project, cmd_localnet, LocalnetAction};
 use crate::commands::wallet::{cmd_wallet_topup_inner, TopupOutcome};
 use crate::constants::SPEL_BIN_REL_PATH;
-use crate::model::LocalnetOwnership;
+use crate::model::{LocalnetOwnership, Project};
 use crate::project::{load_project, resolve_repo_path};
 use crate::DynResult;
 
@@ -32,7 +33,7 @@ pub(crate) fn cmd_run(inv: RunInvocation) -> DynResult<()> {
     run_pipeline_once(&project, &hooks)
 }
 
-fn run_pipeline_once(project: &crate::model::Project, hooks: &[String]) -> DynResult<()> {
+fn run_pipeline_once(project: &Project, hooks: &[String]) -> DynResult<()> {
     let has_hooks = !hooks.is_empty();
     // Steps: build, build idl, localnet, topup, deploy, [+1 if hooks]
     let total_steps: u32 = if has_hooks { 6 } else { 5 };
@@ -76,7 +77,7 @@ fn run_pipeline_once(project: &crate::model::Project, hooks: &[String]) -> DynRe
     Ok(())
 }
 
-fn ensure_localnet(project: &crate::model::Project) -> DynResult<()> {
+fn ensure_localnet(project: &Project) -> DynResult<()> {
     let status = build_localnet_status_for_project(project);
     match status.ownership {
         LocalnetOwnership::Managed if status.ready => {
@@ -102,7 +103,7 @@ fn ensure_localnet(project: &crate::model::Project) -> DynResult<()> {
     }
 }
 
-fn print_deploy_summary(project: &crate::model::Project) -> DynResult<()> {
+fn print_deploy_summary(project: &Project) -> DynResult<()> {
     let programs_dir = project.root.join("methods/guest/src/bin");
     if !programs_dir.exists() {
         return Ok(());
@@ -132,7 +133,7 @@ fn print_deploy_summary(project: &crate::model::Project) -> DynResult<()> {
     Ok(())
 }
 
-fn build_hook_command(project: &crate::model::Project, hook_command: &str) -> Command {
+fn build_hook_command(project: &Project, hook_command: &str) -> Command {
     let port = project.config.localnet.port;
     let sequencer_url = format!("http://127.0.0.1:{port}");
     let wallet_home = project
@@ -164,21 +165,18 @@ fn build_hook_command(project: &crate::model::Project, hook_command: &str) -> Co
     // hooks can call `spel` or the dogfood client without parsing the
     // deploy summary. Multi-program env fan-out arrives in a later branch
     // of this stack.
-    if let Some((name, binary_path)) = single_program_metadata(project) {
+    if let Some(binary_path) = single_program_binary(project) {
         if let Some(spel_bin) = resolve_spel_bin(project) {
             if let Some(id) = extract_program_id(&spel_bin, &binary_path) {
                 cmd.env("SCAFFOLD_PROGRAM_ID", id);
             }
         }
         cmd.env("SCAFFOLD_GUEST_BIN", &binary_path);
-        let _ = name; // currently unused; introduced when multi-program lands
     }
     cmd
 }
 
-fn single_program_metadata(
-    project: &crate::model::Project,
-) -> Option<(String, std::path::PathBuf)> {
+fn single_program_binary(project: &Project) -> Option<PathBuf> {
     let programs_dir = project.root.join("methods/guest/src/bin");
     if !programs_dir.exists() {
         return None;
@@ -189,16 +187,15 @@ fn single_program_metadata(
     }
     let binaries = discover_program_binaries(&project.root, &programs);
     let stem = programs.into_iter().next()?;
-    let bin = binaries.get(&stem).cloned()?;
-    Some((stem, bin))
+    binaries.get(&stem).cloned()
 }
 
-fn resolve_spel_bin(project: &crate::model::Project) -> Option<std::path::PathBuf> {
+fn resolve_spel_bin(project: &Project) -> Option<PathBuf> {
     let spel = resolve_repo_path(project, &project.config.spel, "spel").ok()?;
     Some(spel.join(SPEL_BIN_REL_PATH))
 }
 
-fn run_post_deploy_hook(project: &crate::model::Project, hook_command: &str) -> DynResult<()> {
+fn run_post_deploy_hook(project: &Project, hook_command: &str) -> DynResult<()> {
     let status = build_hook_command(project, hook_command)
         .status()
         .context("failed to execute post-deploy hook")?;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -12,7 +12,7 @@ use crate::commands::localnet::{build_localnet_status_for_project, cmd_localnet,
 use crate::commands::wallet::{cmd_wallet_topup_inner, TopupOutcome};
 use crate::constants::SPEL_BIN_REL_PATH;
 use crate::model::{LocalnetOwnership, Project};
-use crate::project::{load_project, resolve_repo_path};
+use crate::project::{load_project, resolve_repo_path, run_in_project_dir};
 use crate::DynResult;
 
 /// All knobs that control a `lgs run` invocation. Built by `cli.rs` from
@@ -30,7 +30,11 @@ pub(crate) fn cmd_run(inv: RunInvocation) -> DynResult<()> {
         .post_deploy_override
         .unwrap_or_else(|| project.config.run.post_deploy.clone());
 
-    run_pipeline_once(&project, &hooks)
+    // Anchor the pipeline at the discovered project root. Otherwise commands
+    // that resolve paths relative to cwd (`cmd_build_shortcut`,
+    // `build_idl_for_current_project`, etc.) would build/deploy from whichever
+    // subdirectory the user invoked `lgs run` in.
+    run_in_project_dir(Some(&project.root), || run_pipeline_once(&project, &hooks))
 }
 
 fn run_pipeline_once(project: &Project, hooks: &[String]) -> DynResult<()> {
@@ -65,9 +69,13 @@ fn run_pipeline_once(project: &Project, hooks: &[String]) -> DynResult<()> {
     if has_hooks {
         let n = hooks.len();
         println!("[6/{total_steps}] Running {n} post-deploy hook(s)...");
+        // Resolve the single-program shortcut metadata once: `extract_program_id`
+        // shells out to `spel inspect` with a per-call timeout, so doing it
+        // inside the loop would multiply latency by the hook count.
+        let single_program = resolve_single_program_metadata(project);
         for (i, hook) in hooks.iter().enumerate() {
             println!("===> post_deploy[{}/{n}]: {hook}", i + 1);
-            run_post_deploy_hook(project, hook)?;
+            run_post_deploy_hook(project, hook, single_program.as_ref())?;
             println!("<=== post_deploy[{}/{n}] OK", i + 1);
         }
     } else {
@@ -75,6 +83,23 @@ fn run_pipeline_once(project: &Project, hooks: &[String]) -> DynResult<()> {
     }
 
     Ok(())
+}
+
+/// Single-program shortcut metadata exposed to post-deploy hooks via env vars.
+/// Resolved once per `run` invocation and reused across hooks.
+struct SingleProgram {
+    binary_path: PathBuf,
+    program_id: Option<String>,
+}
+
+fn resolve_single_program_metadata(project: &Project) -> Option<SingleProgram> {
+    let binary_path = single_program_binary(project)?;
+    let program_id =
+        resolve_spel_bin(project).and_then(|spel_bin| extract_program_id(&spel_bin, &binary_path));
+    Some(SingleProgram {
+        binary_path,
+        program_id,
+    })
 }
 
 fn ensure_localnet(project: &Project) -> DynResult<()> {
@@ -133,7 +158,11 @@ fn print_deploy_summary(project: &Project) -> DynResult<()> {
     Ok(())
 }
 
-fn build_hook_command(project: &Project, hook_command: &str) -> Command {
+fn build_hook_command(
+    project: &Project,
+    hook_command: &str,
+    single_program: Option<&SingleProgram>,
+) -> Command {
     let port = project.config.localnet.port;
     let sequencer_url = format!("http://127.0.0.1:{port}");
     let wallet_home = project
@@ -163,15 +192,12 @@ fn build_hook_command(project: &Project, hook_command: &str) -> Command {
     // Single-program shortcut: when there's exactly one deployable program,
     // expose its program-id and guest-binary path as env vars so simple
     // hooks can call `spel` or the dogfood client without parsing the
-    // deploy summary. Multi-program env fan-out arrives in a later branch
-    // of this stack.
-    if let Some(binary_path) = single_program_binary(project) {
-        if let Some(spel_bin) = resolve_spel_bin(project) {
-            if let Some(id) = extract_program_id(&spel_bin, &binary_path) {
-                cmd.env("SCAFFOLD_PROGRAM_ID", id);
-            }
+    // deploy summary.
+    if let Some(sp) = single_program {
+        if let Some(id) = &sp.program_id {
+            cmd.env("SCAFFOLD_PROGRAM_ID", id);
         }
-        cmd.env("SCAFFOLD_GUEST_BIN", &binary_path);
+        cmd.env("SCAFFOLD_GUEST_BIN", &sp.binary_path);
     }
     cmd
 }
@@ -195,8 +221,12 @@ fn resolve_spel_bin(project: &Project) -> Option<PathBuf> {
     Some(spel.join(SPEL_BIN_REL_PATH))
 }
 
-fn run_post_deploy_hook(project: &Project, hook_command: &str) -> DynResult<()> {
-    let status = build_hook_command(project, hook_command)
+fn run_post_deploy_hook(
+    project: &Project,
+    hook_command: &str,
+    single_program: Option<&SingleProgram>,
+) -> DynResult<()> {
+    let status = build_hook_command(project, hook_command, single_program)
         .status()
         .context("failed to execute post-deploy hook")?;
 
@@ -263,7 +293,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$SEQUENCER_URL\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, None).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "http://127.0.0.1:3040");
@@ -276,7 +306,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$NSSA_WALLET_HOME_DIR\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, None).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert!(
@@ -292,7 +322,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$SCAFFOLD_PROJECT_ROOT\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, None).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         let canonical = temp
@@ -309,7 +339,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$SCAFFOLD_IDL_DIR\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, None).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert!(
@@ -326,7 +356,7 @@ mod tests {
         project.config.localnet.port = 9999;
 
         let hook = format!("echo \"$SEQUENCER_URL\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, None).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "http://127.0.0.1:9999");
@@ -337,7 +367,7 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let project = make_test_project(temp.path().to_path_buf());
 
-        let result = run_post_deploy_hook(&project, "exit 42");
+        let result = run_post_deploy_hook(&project, "exit 42", None);
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(
@@ -353,7 +383,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("pwd > '{}'", pwd_file.display());
-        run_post_deploy_hook(&project, &hook).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, None).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&pwd_file).expect("read pwd output");
         let canonical = temp
@@ -401,5 +431,118 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         print_deploy_summary(&project).expect("should succeed with missing dir");
+    }
+
+    #[test]
+    fn hook_receives_full_env_contract_in_one_invocation() {
+        // Integration-style assertion: every documented always-on env var
+        // reaches the hook in a single shell invocation, in the same form
+        // `cmd_run` would produce.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env_file = temp.path().join("env_out.txt");
+        let project = make_test_project(temp.path().to_path_buf());
+
+        let hook = format!(
+            "{{ \
+                echo \"SEQUENCER_URL=$SEQUENCER_URL\"; \
+                echo \"NSSA_WALLET_HOME_DIR=$NSSA_WALLET_HOME_DIR\"; \
+                echo \"SCAFFOLD_PROJECT_ROOT=$SCAFFOLD_PROJECT_ROOT\"; \
+                echo \"SCAFFOLD_IDL_DIR=$SCAFFOLD_IDL_DIR\"; \
+            }} > '{}'",
+            env_file.display()
+        );
+        run_post_deploy_hook(&project, &hook, None).expect("hook should succeed");
+
+        let content = std::fs::read_to_string(&env_file).expect("read env output");
+        let canonical = temp
+            .path()
+            .canonicalize()
+            .unwrap_or_else(|_| temp.path().to_path_buf());
+        let lines: Vec<&str> = content.lines().collect();
+
+        assert_eq!(lines[0], "SEQUENCER_URL=http://127.0.0.1:3040");
+        assert!(
+            lines[1].starts_with("NSSA_WALLET_HOME_DIR=") && lines[1].ends_with(".scaffold/wallet"),
+            "wallet home line was: {}",
+            lines[1]
+        );
+        assert_eq!(
+            lines[2],
+            format!("SCAFFOLD_PROJECT_ROOT={}", canonical.display())
+        );
+        assert!(
+            lines[3].starts_with("SCAFFOLD_IDL_DIR=") && lines[3].ends_with("/idl"),
+            "idl dir line was: {}",
+            lines[3]
+        );
+    }
+
+    #[test]
+    fn hook_receives_single_program_env_when_provided() {
+        // When `SingleProgram` is passed, `SCAFFOLD_PROGRAM_ID` and
+        // `SCAFFOLD_GUEST_BIN` reach the hook environment.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env_file = temp.path().join("env_out.txt");
+        let project = make_test_project(temp.path().to_path_buf());
+
+        let single = SingleProgram {
+            binary_path: temp.path().join("counter.bin"),
+            program_id: Some("deadbeef".to_string()),
+        };
+
+        let hook = format!(
+            "echo \"$SCAFFOLD_PROGRAM_ID|$SCAFFOLD_GUEST_BIN\" > '{}'",
+            env_file.display()
+        );
+        run_post_deploy_hook(&project, &hook, Some(&single)).expect("hook should succeed");
+
+        let content = std::fs::read_to_string(&env_file).expect("read env output");
+        let expected_bin = temp.path().join("counter.bin");
+        assert_eq!(
+            content.trim(),
+            format!("deadbeef|{}", expected_bin.display())
+        );
+    }
+
+    #[test]
+    fn hook_omits_program_id_env_when_extraction_failed() {
+        // When `extract_program_id` returns None, the env var must be unset
+        // rather than set to an empty string — a hook that tests `[ -z
+        // "$SCAFFOLD_PROGRAM_ID" ]` should see it as unset.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env_file = temp.path().join("env_out.txt");
+        let project = make_test_project(temp.path().to_path_buf());
+
+        let single = SingleProgram {
+            binary_path: temp.path().join("counter.bin"),
+            program_id: None,
+        };
+
+        let hook = format!(
+            "if [ -z \"${{SCAFFOLD_PROGRAM_ID+set}}\" ]; then echo unset; else echo set; fi > '{}'",
+            env_file.display()
+        );
+        run_post_deploy_hook(&project, &hook, Some(&single)).expect("hook should succeed");
+
+        let content = std::fs::read_to_string(&env_file).expect("read env output");
+        assert_eq!(content.trim(), "unset");
+    }
+
+    #[test]
+    fn hook_omits_single_program_env_when_metadata_absent() {
+        // Multi-program (or no-program) projects pass `None`, and the
+        // single-program shortcut env vars must not be set.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env_file = temp.path().join("env_out.txt");
+        let project = make_test_project(temp.path().to_path_buf());
+
+        let hook = format!(
+            "echo \"id=${{SCAFFOLD_PROGRAM_ID+set}}|bin=${{SCAFFOLD_GUEST_BIN+set}}\" > '{}'",
+            env_file.display()
+        );
+        run_post_deploy_hook(&project, &hook, None).expect("hook should succeed");
+
+        let content = std::fs::read_to_string(&env_file).expect("read env output");
+        assert_eq!(content.trim(), "id=|bin=");
     }
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -22,22 +22,37 @@ use crate::DynResult;
 #[derive(Clone, Debug, Default)]
 pub(crate) struct RunInvocation {
     pub(crate) post_deploy_override: Option<Vec<String>>,
+    pub(crate) localnet_timeout_sec: Option<u64>,
 }
+
+/// Default seconds to wait for the sequencer to become ready when `lgs run`
+/// has to start localnet itself. Cold first runs (fresh repo clone, cold
+/// nix/cargo caches) routinely overshoot the previous 20s ceiling.
+pub(crate) const DEFAULT_RUN_LOCALNET_TIMEOUT_SEC: u64 = 120;
 
 pub(crate) fn cmd_run(inv: RunInvocation) -> DynResult<()> {
     let project = load_project()?;
     let hooks = inv
         .post_deploy_override
         .unwrap_or_else(|| project.config.run.post_deploy.clone());
+    let localnet_timeout_sec = inv
+        .localnet_timeout_sec
+        .unwrap_or(DEFAULT_RUN_LOCALNET_TIMEOUT_SEC);
 
     // Anchor the pipeline at the discovered project root. Otherwise commands
     // that resolve paths relative to cwd (`cmd_build_shortcut`,
     // `build_idl_for_current_project`, etc.) would build/deploy from whichever
     // subdirectory the user invoked `lgs run` in.
-    run_in_project_dir(Some(&project.root), || run_pipeline_once(&project, &hooks))
+    run_in_project_dir(Some(&project.root), || {
+        run_pipeline_once(&project, &hooks, localnet_timeout_sec)
+    })
 }
 
-fn run_pipeline_once(project: &Project, hooks: &[String]) -> DynResult<()> {
+fn run_pipeline_once(
+    project: &Project,
+    hooks: &[String],
+    localnet_timeout_sec: u64,
+) -> DynResult<()> {
     let has_hooks = !hooks.is_empty();
     // Steps: build, build idl, localnet, topup, deploy, [+1 if hooks]
     let total_steps: u32 = if has_hooks { 6 } else { 5 };
@@ -52,7 +67,7 @@ fn run_pipeline_once(project: &Project, hooks: &[String]) -> DynResult<()> {
 
     // Step 3: Ensure localnet is running.
     println!("[3/{total_steps}] Ensuring localnet...");
-    ensure_localnet(project)?;
+    ensure_localnet(project, localnet_timeout_sec)?;
 
     // Step 4: Wallet topup
     println!("[4/{total_steps}] Topping up wallet...");
@@ -102,7 +117,7 @@ fn resolve_single_program_metadata(project: &Project) -> Option<SingleProgram> {
     })
 }
 
-fn ensure_localnet(project: &Project) -> DynResult<()> {
+fn ensure_localnet(project: &Project, timeout_sec: u64) -> DynResult<()> {
     let status = build_localnet_status_for_project(project);
     match status.ownership {
         LocalnetOwnership::Managed if status.ready => {
@@ -124,7 +139,7 @@ fn ensure_localnet(project: &Project) -> DynResult<()> {
                  Stop it first with `logos-scaffold localnet stop` (or `kill {pid_display}`)."
             );
         }
-        _ => cmd_localnet(LocalnetAction::Start { timeout_sec: 20 }),
+        _ => cmd_localnet(LocalnetAction::Start { timeout_sec }),
     }
 }
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -10,7 +10,7 @@ use crate::commands::deploy::{
 use crate::commands::idl::build_idl_for_current_project;
 use crate::commands::localnet::{build_localnet_status_for_project, cmd_localnet, LocalnetAction};
 use crate::commands::wallet::{cmd_wallet_topup_inner, TopupOutcome};
-use crate::constants::SPEL_BIN_REL_PATH;
+use crate::constants::{DEFAULT_RUN_LOCALNET_TIMEOUT_SEC, SPEL_BIN_REL_PATH};
 use crate::model::{LocalnetOwnership, Project};
 use crate::project::{load_project, resolve_repo_path, run_in_project_dir};
 use crate::DynResult;
@@ -24,11 +24,6 @@ pub(crate) struct RunInvocation {
     pub(crate) post_deploy_override: Option<Vec<String>>,
     pub(crate) localnet_timeout_sec: Option<u64>,
 }
-
-/// Default seconds to wait for the sequencer to become ready when `lgs run`
-/// has to start localnet itself. Cold first runs (fresh repo clone, cold
-/// nix/cargo caches) routinely overshoot the previous 20s ceiling.
-pub(crate) const DEFAULT_RUN_LOCALNET_TIMEOUT_SEC: u64 = 120;
 
 pub(crate) fn cmd_run(inv: RunInvocation) -> DynResult<()> {
     let project = load_project()?;
@@ -234,10 +229,7 @@ fn single_program_binary(project: &Project) -> DynResult<Option<PathBuf>> {
         return Ok(None);
     }
     let binaries = discover_program_binaries(&project.root, &programs);
-    let Some(stem) = programs.into_iter().next() else {
-        return Ok(None);
-    };
-    Ok(binaries.get(&stem).cloned())
+    Ok(binaries.get(&programs[0]).cloned())
 }
 
 fn resolve_spel_bin(project: &Project) -> Option<PathBuf> {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,0 +1,408 @@
+use std::process::Command;
+
+use anyhow::{bail, Context};
+
+use crate::commands::build::cmd_build_shortcut;
+use crate::commands::deploy::{
+    cmd_deploy, discover_deployable_programs, discover_program_binaries, extract_program_id,
+};
+use crate::commands::idl::build_idl_for_current_project;
+use crate::commands::localnet::{build_localnet_status_for_project, cmd_localnet, LocalnetAction};
+use crate::commands::wallet::{cmd_wallet_topup_inner, TopupOutcome};
+use crate::constants::SPEL_BIN_REL_PATH;
+use crate::model::LocalnetOwnership;
+use crate::project::{load_project, resolve_repo_path};
+use crate::DynResult;
+
+/// All knobs that control a `lgs run` invocation. Built by `cli.rs` from
+/// the parsed `RunArgs` (with conflicting-flag resolution into `Option<Vec<_>>`)
+/// and consumed by `cmd_run`. Grouping the fields together prevents the
+/// positional-swap class of bug.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct RunInvocation {
+    pub(crate) post_deploy_override: Option<Vec<String>>,
+}
+
+pub(crate) fn cmd_run(inv: RunInvocation) -> DynResult<()> {
+    let project = load_project()?;
+    let hooks = inv
+        .post_deploy_override
+        .unwrap_or_else(|| project.config.run.post_deploy.clone());
+
+    run_pipeline_once(&project, &hooks)
+}
+
+fn run_pipeline_once(project: &crate::model::Project, hooks: &[String]) -> DynResult<()> {
+    let has_hooks = !hooks.is_empty();
+    // Steps: build, build idl, localnet, topup, deploy, [+1 if hooks]
+    let total_steps: u32 = if has_hooks { 6 } else { 5 };
+
+    // Step 1: Build (chains setup internally)
+    println!("[1/{total_steps}] Building...");
+    cmd_build_shortcut(None)?;
+
+    // Step 2: Build IDL (no-op for non-lez-framework projects)
+    println!("[2/{total_steps}] Building IDL...");
+    build_idl_for_current_project()?;
+
+    // Step 3: Ensure localnet is running.
+    println!("[3/{total_steps}] Ensuring localnet...");
+    ensure_localnet(project)?;
+
+    // Step 4: Wallet topup
+    println!("[4/{total_steps}] Topping up wallet...");
+    let outcome = cmd_wallet_topup_inner(project, None, false)?;
+    if outcome == TopupOutcome::ConfirmationTimeout {
+        bail!("wallet topup confirmation timed out; aborting run to avoid deploying with uncertain funding.\nHint: retry `logos-scaffold run` or run `logos-scaffold wallet topup` manually.");
+    }
+
+    // Step 5: Deploy
+    println!("[5/{total_steps}] Deploying programs...");
+    cmd_deploy(None, None, false)?;
+
+    // Step 6: Post-deploy hooks (or summary)
+    if has_hooks {
+        let n = hooks.len();
+        println!("[6/{total_steps}] Running {n} post-deploy hook(s)...");
+        for (i, hook) in hooks.iter().enumerate() {
+            println!("===> post_deploy[{}/{n}]: {hook}", i + 1);
+            run_post_deploy_hook(project, hook)?;
+            println!("<=== post_deploy[{}/{n}] OK", i + 1);
+        }
+    } else {
+        print_deploy_summary(project)?;
+    }
+
+    Ok(())
+}
+
+fn ensure_localnet(project: &crate::model::Project) -> DynResult<()> {
+    let status = build_localnet_status_for_project(project);
+    match status.ownership {
+        LocalnetOwnership::Managed if status.ready => {
+            let pid_display = status
+                .tracked_pid
+                .map(|p| p.to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+            println!("      localnet already running (sequencer pid={pid_display})");
+            Ok(())
+        }
+        LocalnetOwnership::Foreign => {
+            let pid_display = status
+                .listener_pid
+                .map(|p| p.to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+            bail!(
+                "localnet port is in use by another process (pid={pid_display}).\n\
+                 This may be a sequencer from another project.\n\
+                 Stop it first with `logos-scaffold localnet stop` (or `kill {pid_display}`)."
+            );
+        }
+        _ => cmd_localnet(LocalnetAction::Start { timeout_sec: 20 }),
+    }
+}
+
+fn print_deploy_summary(project: &crate::model::Project) -> DynResult<()> {
+    let programs_dir = project.root.join("methods/guest/src/bin");
+    if !programs_dir.exists() {
+        return Ok(());
+    }
+
+    let programs = discover_deployable_programs(&project.root)?;
+    if programs.is_empty() {
+        println!();
+        println!("No deployable programs found in {}", programs_dir.display());
+        return Ok(());
+    }
+    let binaries = discover_program_binaries(&project.root, &programs);
+
+    println!();
+    println!("Deployed programs:");
+    for stem in &programs {
+        if let Some(binary_path) = binaries.get(stem) {
+            println!("  {stem}");
+            println!("    Binary: {}", binary_path.display());
+        }
+    }
+
+    let port = project.config.localnet.port;
+    println!();
+    println!("Sequencer: http://127.0.0.1:{port}");
+
+    Ok(())
+}
+
+fn build_hook_command(project: &crate::model::Project, hook_command: &str) -> Command {
+    let port = project.config.localnet.port;
+    let sequencer_url = format!("http://127.0.0.1:{port}");
+    let wallet_home = project
+        .root
+        .join(&project.config.wallet_home_dir)
+        .canonicalize()
+        .unwrap_or_else(|_| project.root.join(&project.config.wallet_home_dir));
+    let project_root = project
+        .root
+        .canonicalize()
+        .unwrap_or_else(|_| project.root.clone());
+    let idl_dir = project
+        .root
+        .join(&project.config.framework.idl.path)
+        .canonicalize()
+        .unwrap_or_else(|_| project.root.join(&project.config.framework.idl.path));
+
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c")
+        .arg(hook_command)
+        .env("SEQUENCER_URL", &sequencer_url)
+        .env("NSSA_WALLET_HOME_DIR", &wallet_home)
+        .env("SCAFFOLD_PROJECT_ROOT", &project_root)
+        .env("SCAFFOLD_IDL_DIR", &idl_dir)
+        .current_dir(&project.root);
+
+    // Single-program shortcut: when there's exactly one deployable program,
+    // expose its program-id and guest-binary path as env vars so simple
+    // hooks can call `spel` or the dogfood client without parsing the
+    // deploy summary. Multi-program env fan-out arrives in a later branch
+    // of this stack.
+    if let Some((name, binary_path)) = single_program_metadata(project) {
+        if let Some(spel_bin) = resolve_spel_bin(project) {
+            if let Some(id) = extract_program_id(&spel_bin, &binary_path) {
+                cmd.env("SCAFFOLD_PROGRAM_ID", id);
+            }
+        }
+        cmd.env("SCAFFOLD_GUEST_BIN", &binary_path);
+        let _ = name; // currently unused; introduced when multi-program lands
+    }
+    cmd
+}
+
+fn single_program_metadata(
+    project: &crate::model::Project,
+) -> Option<(String, std::path::PathBuf)> {
+    let programs_dir = project.root.join("methods/guest/src/bin");
+    if !programs_dir.exists() {
+        return None;
+    }
+    let programs = discover_deployable_programs(&project.root).ok()?;
+    if programs.len() != 1 {
+        return None;
+    }
+    let binaries = discover_program_binaries(&project.root, &programs);
+    let stem = programs.into_iter().next()?;
+    let bin = binaries.get(&stem).cloned()?;
+    Some((stem, bin))
+}
+
+fn resolve_spel_bin(project: &crate::model::Project) -> Option<std::path::PathBuf> {
+    let spel = resolve_repo_path(project, &project.config.spel, "spel").ok()?;
+    Some(spel.join(SPEL_BIN_REL_PATH))
+}
+
+fn run_post_deploy_hook(project: &crate::model::Project, hook_command: &str) -> DynResult<()> {
+    let status = build_hook_command(project, hook_command)
+        .status()
+        .context("failed to execute post-deploy hook")?;
+
+    if !status.success() {
+        let code = status.code().unwrap_or(1);
+        bail!("post-deploy hook exited with status {code}");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{
+        Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig, Project, RepoRef, RunConfig,
+    };
+    use std::path::PathBuf;
+
+    fn make_test_project(root: PathBuf) -> Project {
+        Project {
+            root,
+            config: Config {
+                version: "0.2.0".to_string(),
+                cache_root: ".scaffold/cache".to_string(),
+                lez: RepoRef {
+                    source: "lez".to_string(),
+                    path: "lez".to_string(),
+                    pin: "abc123".to_string(),
+                    ..Default::default()
+                },
+                spel: RepoRef {
+                    source: "spel".to_string(),
+                    path: "spel".to_string(),
+                    pin: "def456".to_string(),
+                    ..Default::default()
+                },
+                basecamp_repo: None,
+                lgpm_repo: None,
+                wallet_home_dir: ".scaffold/wallet".to_string(),
+                framework: FrameworkConfig {
+                    kind: "default".to_string(),
+                    version: "0.1.0".to_string(),
+                    idl: FrameworkIdlConfig {
+                        spec: "lssa-idl/0.1.0".to_string(),
+                        path: "idl".to_string(),
+                    },
+                },
+                localnet: LocalnetConfig {
+                    port: 3040,
+                    risc0_dev_mode: true,
+                },
+                modules: std::collections::BTreeMap::new(),
+                run: RunConfig::default(),
+                basecamp: None,
+            },
+        }
+    }
+
+    #[test]
+    fn hook_receives_sequencer_url_env() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env_file = temp.path().join("env_out.txt");
+        let project = make_test_project(temp.path().to_path_buf());
+
+        let hook = format!("echo \"$SEQUENCER_URL\" > '{}'", env_file.display());
+        run_post_deploy_hook(&project, &hook).expect("hook should succeed");
+
+        let content = std::fs::read_to_string(&env_file).expect("read env output");
+        assert_eq!(content.trim(), "http://127.0.0.1:3040");
+    }
+
+    #[test]
+    fn hook_receives_wallet_home_dir_env() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env_file = temp.path().join("env_out.txt");
+        let project = make_test_project(temp.path().to_path_buf());
+
+        let hook = format!("echo \"$NSSA_WALLET_HOME_DIR\" > '{}'", env_file.display());
+        run_post_deploy_hook(&project, &hook).expect("hook should succeed");
+
+        let content = std::fs::read_to_string(&env_file).expect("read env output");
+        assert!(
+            content.trim().ends_with(".scaffold/wallet"),
+            "expected wallet home to end with .scaffold/wallet, got: {content}"
+        );
+    }
+
+    #[test]
+    fn hook_receives_project_root_env() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env_file = temp.path().join("env_out.txt");
+        let project = make_test_project(temp.path().to_path_buf());
+
+        let hook = format!("echo \"$SCAFFOLD_PROJECT_ROOT\" > '{}'", env_file.display());
+        run_post_deploy_hook(&project, &hook).expect("hook should succeed");
+
+        let content = std::fs::read_to_string(&env_file).expect("read env output");
+        let canonical = temp
+            .path()
+            .canonicalize()
+            .unwrap_or_else(|_| temp.path().to_path_buf());
+        assert_eq!(content.trim(), canonical.display().to_string());
+    }
+
+    #[test]
+    fn hook_receives_idl_dir_env() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env_file = temp.path().join("env_out.txt");
+        let project = make_test_project(temp.path().to_path_buf());
+
+        let hook = format!("echo \"$SCAFFOLD_IDL_DIR\" > '{}'", env_file.display());
+        run_post_deploy_hook(&project, &hook).expect("hook should succeed");
+
+        let content = std::fs::read_to_string(&env_file).expect("read env output");
+        assert!(
+            content.trim().ends_with("/idl"),
+            "expected IDL dir to end with /idl, got: {content}"
+        );
+    }
+
+    #[test]
+    fn hook_uses_custom_port() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env_file = temp.path().join("env_out.txt");
+        let mut project = make_test_project(temp.path().to_path_buf());
+        project.config.localnet.port = 9999;
+
+        let hook = format!("echo \"$SEQUENCER_URL\" > '{}'", env_file.display());
+        run_post_deploy_hook(&project, &hook).expect("hook should succeed");
+
+        let content = std::fs::read_to_string(&env_file).expect("read env output");
+        assert_eq!(content.trim(), "http://127.0.0.1:9999");
+    }
+
+    #[test]
+    fn hook_failure_propagates_as_error() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = make_test_project(temp.path().to_path_buf());
+
+        let result = run_post_deploy_hook(&project, "exit 42");
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("42"),
+            "expected exit code 42 in error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn hook_runs_in_project_root_directory() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let pwd_file = temp.path().join("pwd_out.txt");
+        let project = make_test_project(temp.path().to_path_buf());
+
+        let hook = format!("pwd > '{}'", pwd_file.display());
+        run_post_deploy_hook(&project, &hook).expect("hook should succeed");
+
+        let content = std::fs::read_to_string(&pwd_file).expect("read pwd output");
+        let canonical = temp
+            .path()
+            .canonicalize()
+            .unwrap_or_else(|_| temp.path().to_path_buf());
+        assert_eq!(content.trim(), canonical.display().to_string());
+    }
+
+    #[test]
+    fn print_deploy_summary_shows_programs() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = make_test_project(temp.path().to_path_buf());
+
+        let programs_dir = temp.path().join("methods/guest/src/bin");
+        std::fs::create_dir_all(&programs_dir).expect("create programs dir");
+        std::fs::write(programs_dir.join("counter.rs"), "fn main() {}").expect("write source");
+
+        // Mirror the layout `discover_program_binaries` walks for: a
+        // `riscv32im*/release/` segment under one of the search roots.
+        let binary_dir = temp
+            .path()
+            .join("target/riscv-guest/methods/programs/riscv32im-risc0-zkvm-elf/release");
+        std::fs::create_dir_all(&binary_dir).expect("create binary dir");
+        std::fs::write(binary_dir.join("counter.bin"), b"fake binary").expect("write binary");
+
+        print_deploy_summary(&project).expect("should succeed");
+    }
+
+    #[test]
+    fn print_deploy_summary_skips_non_rs_files() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = make_test_project(temp.path().to_path_buf());
+
+        let programs_dir = temp.path().join("methods/guest/src/bin");
+        std::fs::create_dir_all(&programs_dir).expect("create programs dir");
+        std::fs::write(programs_dir.join("README.md"), "# readme").expect("write non-rs file");
+
+        print_deploy_summary(&project).expect("should succeed with no .rs files");
+    }
+
+    #[test]
+    fn print_deploy_summary_returns_ok_when_no_programs_dir() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = make_test_project(temp.path().to_path_buf());
+
+        print_deploy_summary(&project).expect("should succeed with missing dir");
+    }
+}

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -87,7 +87,7 @@ fn run_pipeline_once(
         // Resolve the single-program shortcut metadata once: `extract_program_id`
         // shells out to `spel inspect` with a per-call timeout, so doing it
         // inside the loop would multiply latency by the hook count.
-        let single_program = resolve_single_program_metadata(project);
+        let single_program = resolve_single_program_metadata(project)?;
         for (i, hook) in hooks.iter().enumerate() {
             println!("===> post_deploy[{}/{n}]: {hook}", i + 1);
             run_post_deploy_hook(project, hook, single_program.as_ref())?;
@@ -107,14 +107,16 @@ struct SingleProgram {
     program_id: Option<String>,
 }
 
-fn resolve_single_program_metadata(project: &Project) -> Option<SingleProgram> {
-    let binary_path = single_program_binary(project)?;
+fn resolve_single_program_metadata(project: &Project) -> DynResult<Option<SingleProgram>> {
+    let Some(binary_path) = single_program_binary(project)? else {
+        return Ok(None);
+    };
     let program_id =
         resolve_spel_bin(project).and_then(|spel_bin| extract_program_id(&spel_bin, &binary_path));
-    Some(SingleProgram {
+    Ok(Some(SingleProgram {
         binary_path,
         program_id,
-    })
+    }))
 }
 
 fn ensure_localnet(project: &Project, timeout_sec: u64) -> DynResult<()> {
@@ -217,18 +219,25 @@ fn build_hook_command(
     cmd
 }
 
-fn single_program_binary(project: &Project) -> Option<PathBuf> {
+fn single_program_binary(project: &Project) -> DynResult<Option<PathBuf>> {
     let programs_dir = project.root.join("methods/guest/src/bin");
     if !programs_dir.exists() {
-        return None;
+        return Ok(None);
     }
-    let programs = discover_deployable_programs(&project.root).ok()?;
+    // Propagate I/O failures rather than treating them as "no programs":
+    // an unreadable bin dir is a real error, and silently dropping it
+    // strips the SCAFFOLD_GUEST_BIN env var from post-deploy hooks
+    // without ever surfacing the cause.
+    let programs = discover_deployable_programs(&project.root)
+        .context("failed to discover deployable programs for run")?;
     if programs.len() != 1 {
-        return None;
+        return Ok(None);
     }
     let binaries = discover_program_binaries(&project.root, &programs);
-    let stem = programs.into_iter().next()?;
-    binaries.get(&stem).cloned()
+    let Some(stem) = programs.into_iter().next() else {
+        return Ok(None);
+    };
+    Ok(binaries.get(&stem).cloned())
 }
 
 fn resolve_spel_bin(project: &Project) -> Option<PathBuf> {

--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -13,6 +13,16 @@ use super::wallet_support::{
     summarize_command_failure, wallet_password, wallet_state_path, write_default_wallet_address,
 };
 
+/// Result of a wallet topup attempt. `cmd_run` distinguishes the
+/// confirmation-timeout case so the pipeline can bail before deploy
+/// rather than continue with uncertain funding. Standalone `wallet topup`
+/// treats both as success (matching prior behavior).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TopupOutcome {
+    Success,
+    ConfirmationTimeout,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) enum WalletAction {
     List {
@@ -92,6 +102,15 @@ fn cmd_wallet_topup(
     address: Option<String>,
     dry_run: bool,
 ) -> DynResult<()> {
+    let _ = cmd_wallet_topup_inner(project, address, dry_run)?;
+    Ok(())
+}
+
+pub(crate) fn cmd_wallet_topup_inner(
+    project: &crate::model::Project,
+    address: Option<String>,
+    dry_run: bool,
+) -> DynResult<TopupOutcome> {
     let wallet = load_wallet_runtime(project)?;
     let default_address = read_default_wallet_address(&project.root)?;
     let resolved_to = resolve_wallet_address(address.as_deref(), default_address.as_deref())?;
@@ -139,7 +158,7 @@ fn cmd_wallet_topup(
         println!("planned wallet: {resolved_to}");
         println!("planned method: pinata faucet claim");
         println!("planned network: local sequencer ({sequencer_addr})");
-        return Ok(());
+        return Ok(TopupOutcome::Success);
     }
 
     let preflight_output = run_with_stdin(preflight_command, password_input.clone())
@@ -207,7 +226,7 @@ fn cmd_wallet_topup(
             if let Some(tx) = extract_tx_identifier(&output.stdout, &output.stderr) {
                 println!("  Tx: {tx}");
             }
-            return Ok(());
+            return Ok(TopupOutcome::ConfirmationTimeout);
         }
         bail!(
             "wallet topup failed: {summary}\nHint: run `logos-scaffold wallet list` to inspect addresses, then retry with `--address` or set a default wallet."
@@ -222,7 +241,7 @@ fn cmd_wallet_topup(
         println!("  Tx: {tx}");
     }
 
-    Ok(())
+    Ok(TopupOutcome::Success)
 }
 
 fn cmd_wallet_default_set(project: &crate::model::Project, address: &str) -> DynResult<()> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,7 +29,7 @@ use crate::constants::{
 };
 use crate::model::{
     BasecampConfig, Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig, ModuleEntry,
-    ModuleRole, RepoBuild, RepoRef,
+    ModuleRole, RepoBuild, RepoRef, RunConfig,
 };
 use crate::DynResult;
 
@@ -68,6 +68,7 @@ pub(crate) fn parse_config(text: &str) -> DynResult<Config> {
 
     let modules = parse_modules(&doc)?;
     let basecamp = parse_basecamp_runtime(&doc)?;
+    let run = parse_run(&doc)?;
     let framework = parse_framework(&doc);
     let localnet = parse_localnet(&doc)?;
     let wallet_home_dir = doc
@@ -88,7 +89,43 @@ pub(crate) fn parse_config(text: &str) -> DynResult<Config> {
         localnet,
         modules,
         basecamp,
+        run,
     })
+}
+
+/// Parse the `[run]` section. Branch-1 surface is the inline `post_deploy`
+/// only — string (single hook) or array (multiple). `[run.profiles.*]`,
+/// `default_profile`, and `reset` arrive in later branches.
+fn parse_run(doc: &DocumentMut) -> DynResult<RunConfig> {
+    let Some(run_table) = doc.get("run").and_then(Item::as_table) else {
+        return Ok(RunConfig::default());
+    };
+    let post_deploy = parse_post_deploy(run_table.get("post_deploy"))?;
+    Ok(RunConfig { post_deploy })
+}
+
+fn parse_post_deploy(item: Option<&Item>) -> DynResult<Vec<String>> {
+    let Some(item) = item else {
+        return Ok(Vec::new());
+    };
+    if let Some(s) = item.as_str() {
+        return Ok(if s.is_empty() {
+            Vec::new()
+        } else {
+            vec![s.to_string()]
+        });
+    }
+    if let Some(arr) = item.as_array() {
+        let mut out = Vec::with_capacity(arr.len());
+        for v in arr.iter() {
+            let s = v.as_str().ok_or_else(|| {
+                anyhow!("invalid scaffold.toml: post_deploy entries must be strings")
+            })?;
+            out.push(s.to_string());
+        }
+        return Ok(out);
+    }
+    bail!("invalid scaffold.toml: post_deploy must be a string or array of strings")
 }
 
 /// Reject pre-0.2.0 schemas with a targeted error naming the section that's
@@ -387,7 +424,35 @@ pub(crate) fn serialize_config(cfg: &Config) -> DynResult<String> {
         basecamp_table["port_stride"] = value(i64::from(bc.port_stride));
     }
 
+    // [run] — only emit when non-default to keep fresh scaffold.toml minimal.
+    write_run_config(&mut doc, &cfg.run)?;
+
     Ok(doc.to_string())
+}
+
+fn write_run_config(doc: &mut DocumentMut, run: &RunConfig) -> DynResult<()> {
+    if run.post_deploy.is_empty() {
+        return Ok(());
+    }
+    for hook in &run.post_deploy {
+        check_toml_value("run.post_deploy", hook)?;
+    }
+    let run_item = doc.entry("run").or_insert(Item::Table(Table::new()));
+    let run_table = run_item.as_table_mut().expect("run table");
+    run_table["post_deploy"] = post_deploy_value(&run.post_deploy);
+    Ok(())
+}
+
+fn post_deploy_value(hooks: &[String]) -> Item {
+    if hooks.len() == 1 {
+        value(&hooks[0])
+    } else {
+        let mut arr = toml_edit::Array::new();
+        for h in hooks {
+            arr.push(h.as_str());
+        }
+        value(arr)
+    }
 }
 
 fn write_repo_ref(doc: &mut DocumentMut, name: &str, repo: &RepoRef) -> DynResult<()> {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -55,6 +55,11 @@ pub(crate) const METHODS_DIR: &str = "methods";
 pub(crate) const SEQUENCER_CONFIG_REL_PATH: &str =
     "sequencer/service/configs/debug/sequencer_config.json";
 pub(crate) const SPEL_BIN_REL_PATH: &str = "target/release/spel";
+/// Default seconds to wait for the sequencer to become ready when `lgs run`
+/// has to start localnet itself. Cold first runs (fresh repo clone, cold
+/// nix/cargo caches) routinely overshoot the previous 20s ceiling. Override
+/// per invocation with `lgs run --localnet-timeout <SECS>`.
+pub(crate) const DEFAULT_RUN_LOCALNET_TIMEOUT_SEC: u64 = 120;
 /// Default `source` for `[repos.basecamp]`. Built via `nix build .#app`,
 /// hence `BASECAMP_ATTR = "app"`.
 pub(crate) const BASECAMP_SOURCE: &str = "https://github.com/logos-co/logos-basecamp.git";

--- a/src/model.rs
+++ b/src/model.rs
@@ -84,6 +84,8 @@ pub(crate) struct Config {
     /// `[basecamp]` — runtime config only (port_base, port_stride). Pin and
     /// source moved to `[repos.basecamp]`; modules moved to `[modules.*]`.
     pub(crate) basecamp: Option<BasecampConfig>,
+    /// `[run]` — `lgs run` pipeline config (post-deploy hooks).
+    pub(crate) run: RunConfig,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -257,4 +259,14 @@ pub(crate) struct FrameworkConfig {
 pub(crate) struct FrameworkIdlConfig {
     pub(crate) spec: String,
     pub(crate) path: String,
+}
+
+/// `[run]` — config for the `lgs run` pipeline. Branch-1 surface is the
+/// minimal inline `post_deploy` hook(s); profile/reset support arrives in
+/// later branches of the run-command stack.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct RunConfig {
+    /// Inline `[run].post_deploy` — string (single hook) or array (multiple).
+    /// Empty when not configured.
+    pub(crate) post_deploy: Vec<String>,
 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -224,6 +224,7 @@ mod tests {
                 localnet: LocalnetConfig::default(),
                 modules: std::collections::BTreeMap::new(),
                 basecamp: None,
+                run: crate::model::RunConfig::default(),
             },
         }
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3569,6 +3569,45 @@ fn run_with_multiple_post_deploy_hooks_uses_array_form() {
         .stdout(predicate::str::contains("[1/6] Building..."));
 }
 
+#[test]
+fn run_no_post_deploy_flag_skips_configured_hooks() {
+    // --no-post-deploy must collapse total_steps back to 5 even when
+    // scaffold.toml configures hooks. The build still fails first, but the
+    // step counter in stdout proves the override was honored.
+    let temp = tempdir().expect("tempdir");
+    setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));
+    append_run_config(temp.path(), &["echo configured"]);
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .arg("run")
+        .arg("--no-post-deploy")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("[1/5] Building..."));
+}
+
+#[test]
+fn run_post_deploy_flag_overrides_configured_hooks() {
+    // --post-deploy replaces config hooks. With one config hook ([1/6]) and
+    // two flag overrides, the resulting step count stays at /6 — proving
+    // that the flag took effect and config wasn't merged on top.
+    let temp = tempdir().expect("tempdir");
+    setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));
+    append_run_config(temp.path(), &["echo configured"]);
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .arg("run")
+        .arg("--post-deploy")
+        .arg("echo override-a")
+        .arg("--post-deploy")
+        .arg("echo override-b")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("[1/6] Building..."));
+}
+
 fn append_run_config(project_root: &Path, post_deploy: &[&str]) {
     let toml_path = project_root.join("scaffold.toml");
     let mut content = fs::read_to_string(&toml_path).expect("read scaffold.toml");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3484,3 +3484,95 @@ fn doctor_json_hard_fails_with_clean_stdout_on_pre_v0_2_0_scaffold_toml() {
         "stderr must point at `init`; got:\n{stderr}"
     );
 }
+
+// ─── run command tests ───────────────────────────────────────────────────────
+
+#[test]
+fn run_help_lists_command_summary() {
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .arg("run")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Build, start localnet, top up wallet, deploy, and run post-deploy hook",
+        ));
+}
+
+#[test]
+fn run_outside_project_fails_with_project_scoped_message() {
+    let temp = tempdir().expect("tempdir");
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .arg("run")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Not a logos-scaffold project"));
+}
+
+#[test]
+fn run_rejects_both_post_deploy_flags() {
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .arg("run")
+        .arg("--post-deploy")
+        .arg("echo override")
+        .arg("--no-post-deploy")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn run_fails_at_build_step_in_mock_project() {
+    // The run command calls cmd_build_shortcut which runs cargo build --workspace.
+    // In a mock project without a real Cargo workspace, this fails at step 1.
+    // This tests that the pipeline starts and fails fast.
+    let temp = tempdir().expect("tempdir");
+    setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .arg("run")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("[1/5] Building..."));
+}
+
+#[test]
+fn run_with_post_deploy_hook_shows_6_steps_in_output() {
+    // When a post_deploy hook is configured, the step counter shows /6.
+    let temp = tempdir().expect("tempdir");
+    setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));
+    append_run_config(temp.path(), &["echo hello"]);
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .arg("run")
+        .assert()
+        .failure() // still fails at build
+        .stdout(predicate::str::contains("[1/6] Building..."));
+}
+
+#[test]
+fn run_with_multiple_post_deploy_hooks_uses_array_form() {
+    // Multiple hooks are configured as a TOML inline array; pipeline still has 6 steps.
+    let temp = tempdir().expect("tempdir");
+    setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));
+    append_run_config(temp.path(), &["echo one", "echo two"]);
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .arg("run")
+        .assert()
+        .failure() // still fails at build
+        .stdout(predicate::str::contains("[1/6] Building..."));
+}
+
+fn append_run_config(project_root: &Path, post_deploy: &[&str]) {
+    let toml_path = project_root.join("scaffold.toml");
+    let mut content = fs::read_to_string(&toml_path).expect("read scaffold.toml");
+    let quoted: Vec<String> = post_deploy.iter().map(|c| format!("\"{c}\"")).collect();
+    content.push_str(&format!("\n[run]\npost_deploy = [{}]\n", quoted.join(", ")));
+    fs::write(toml_path, content).expect("write scaffold.toml");
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3524,6 +3524,27 @@ fn run_rejects_both_post_deploy_flags() {
 }
 
 #[test]
+fn run_help_advertises_localnet_timeout_flag() {
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .arg("run")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--localnet-timeout"));
+}
+
+#[test]
+fn run_rejects_non_numeric_localnet_timeout() {
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .arg("run")
+        .arg("--localnet-timeout")
+        .arg("abc")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value"));
+}
+
+#[test]
 fn run_fails_at_build_step_in_mock_project() {
     // The run command calls cmd_build_shortcut which runs cargo build --workspace.
     // In a mock project without a real Cargo workspace, this fails at step 1.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3530,7 +3530,8 @@ fn run_help_advertises_localnet_timeout_flag() {
         .arg("--help")
         .assert()
         .success()
-        .stdout(predicate::str::contains("--localnet-timeout"));
+        .stdout(predicate::str::contains("--localnet-timeout"))
+        .stdout(predicate::str::contains("default: 120"));
 }
 
 #[test]


### PR DESCRIPTION
Introduces the `logos-scaffold run` (alias `lgs run`) command that drives the standard project lifecycle in one shot: build → build IDL → ensure localnet → wallet topup → deploy → optional post-deploy hook. Configuration surface for this slice is the minimal inline `[run].post_deploy` (string or array). CLI flags: `--post-deploy <CMD>` (repeatable, replaces config) and `--no-post-deploy` (skip even if configured). Hook env contract is the single-program shortcut (`SEQUENCER_URL`, `NSSA_WALLET_HOME_DIR`, `SCAFFOLD_PROJECT_ROOT`, `SCAFFOLD_IDL_DIR`, `SCAFFOLD_PROGRAM_ID`, `SCAFFOLD_GUEST_BIN`).

## Stack

This is part 1 of a 5-PR stack that splits PR #66:

1. **feat/run-mvp ← this PR** — pipeline core, post-deploy hook, single-program env
2. feat/run-deploy-cache (depends on 1) — skip deploy when guest .bin + IDL hashes are unchanged
3. feat/run-multiprogram-env (depends on 2) — `SCAFFOLD_PROGRAMS`, `SCAFFOLD_PROGRAM_ID_<n>`, …
4. feat/run-reset-and-profiles (depends on 3) — `--reset` wipe-and-reseed and named `[run.profiles.*]`
5. feat/run-watch (depends on 4) — `--watch` re-runs pipeline on file changes

Each PR's base is the previous PR's branch; merge in order.

## Replaces part of

#66 — PR #66 will be retired by editing its description once this stack lands.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo check --all-targets`
- [x] `cargo test --all-targets` (passes locally; new tests: `run_help_lists_command_summary`, `run_outside_project_fails_with_project_scoped_message`, `run_rejects_both_post_deploy_flags`, `run_with_post_deploy_hook_shows_6_steps_in_output`, `run_with_multiple_post_deploy_hooks_uses_array_form`, `run_fails_at_build_step_in_mock_project`, plus 10 unit tests in `commands::run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>