### PR TITLE
feat(run): cache deploy by guest binary + IDL hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +226,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,10 +244,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -319,6 +357,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -596,6 +644,7 @@ dependencies = [
  "predicates",
  "serde",
  "serde_json",
+ "sha2",
  "tar",
  "tempfile",
  "thiserror",
@@ -903,6 +952,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,6 +1120,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,6 +1190,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ indicatif = "0.17"
 flate2 = "1.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.140"
+sha2 = "0.10"
 tar = "0.4.44"
 tempfile = "3.18.0"
 thiserror = "2.0"

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod localnet;
 pub(crate) mod new;
 pub(crate) mod report;
 pub(crate) mod run;
+pub(crate) mod run_state;
 pub(crate) mod self_test;
 pub(crate) mod setup;
 pub(crate) mod spel;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -9,6 +9,9 @@ use crate::commands::deploy::{
 };
 use crate::commands::idl::build_idl_for_current_project;
 use crate::commands::localnet::{build_localnet_status_for_project, cmd_localnet, LocalnetAction};
+use crate::commands::run_state::{
+    compute_program_hashes, deploy_can_be_skipped, load_state, save_state, RunDeployState,
+};
 use crate::commands::wallet::{cmd_wallet_topup_inner, TopupOutcome};
 use crate::constants::SPEL_BIN_REL_PATH;
 use crate::model::{LocalnetOwnership, Project};
@@ -57,9 +60,31 @@ fn run_pipeline_once(project: &Project, hooks: &[String]) -> DynResult<()> {
         bail!("wallet topup confirmation timed out; aborting run to avoid deploying with uncertain funding.\nHint: retry `logos-scaffold run` or run `logos-scaffold wallet topup` manually.");
     }
 
-    // Step 5: Deploy
-    println!("[5/{total_steps}] Deploying programs...");
-    cmd_deploy(None, None, false)?;
+    // Step 5: Deploy (idempotent: skip when guest .bin + IDL hashes both
+    // match the prior deploy. IDL is folded in so an ABI-only edit forces
+    // a re-deploy even if the binary is byte-identical). To force a
+    // re-deploy, delete `.scaffold/state/run_deploy.json` manually
+    // (a `--reset` switch arrives in a later branch of this stack).
+    let current_hashes = compute_program_hashes(project)?;
+    let prior = load_state(project);
+    let skipped = if deploy_can_be_skipped(&current_hashes, &prior.program_hashes) {
+        println!(
+            "[5/{total_steps}] Deploy skipped (guest binaries + IDL unchanged; delete `.scaffold/state/run_deploy.json` to force a re-deploy)"
+        );
+        true
+    } else {
+        println!("[5/{total_steps}] Deploying programs...");
+        cmd_deploy(None, None, false)?;
+        if !current_hashes.is_empty() {
+            save_state(
+                project,
+                &RunDeployState {
+                    program_hashes: current_hashes,
+                },
+            )?;
+        }
+        false
+    };
 
     // Step 6: Post-deploy hooks (or summary)
     if has_hooks {
@@ -67,7 +92,7 @@ fn run_pipeline_once(project: &Project, hooks: &[String]) -> DynResult<()> {
         println!("[6/{total_steps}] Running {n} post-deploy hook(s)...");
         for (i, hook) in hooks.iter().enumerate() {
             println!("===> post_deploy[{}/{n}]: {hook}", i + 1);
-            run_post_deploy_hook(project, hook)?;
+            run_post_deploy_hook(project, hook, skipped)?;
             println!("<=== post_deploy[{}/{n}] OK", i + 1);
         }
     } else {
@@ -133,7 +158,7 @@ fn print_deploy_summary(project: &Project) -> DynResult<()> {
     Ok(())
 }
 
-fn build_hook_command(project: &Project, hook_command: &str) -> Command {
+fn build_hook_command(project: &Project, hook_command: &str, deploy_skipped: bool) -> Command {
     let port = project.config.localnet.port;
     let sequencer_url = format!("http://127.0.0.1:{port}");
     let wallet_home = project
@@ -172,6 +197,10 @@ fn build_hook_command(project: &Project, hook_command: &str) -> Command {
             }
         }
         cmd.env("SCAFFOLD_GUEST_BIN", &binary_path);
+        cmd.env(
+            "SCAFFOLD_DEPLOY_SKIPPED",
+            if deploy_skipped { "1" } else { "0" },
+        );
     }
     cmd
 }
@@ -195,8 +224,12 @@ fn resolve_spel_bin(project: &Project) -> Option<PathBuf> {
     Some(spel.join(SPEL_BIN_REL_PATH))
 }
 
-fn run_post_deploy_hook(project: &Project, hook_command: &str) -> DynResult<()> {
-    let status = build_hook_command(project, hook_command)
+fn run_post_deploy_hook(
+    project: &Project,
+    hook_command: &str,
+    deploy_skipped: bool,
+) -> DynResult<()> {
+    let status = build_hook_command(project, hook_command, deploy_skipped)
         .status()
         .context("failed to execute post-deploy hook")?;
 
@@ -263,7 +296,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$SEQUENCER_URL\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, false).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "http://127.0.0.1:3040");
@@ -276,7 +309,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$NSSA_WALLET_HOME_DIR\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, false).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert!(
@@ -292,7 +325,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$SCAFFOLD_PROJECT_ROOT\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, false).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         let canonical = temp
@@ -309,7 +342,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$SCAFFOLD_IDL_DIR\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, false).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert!(
@@ -326,7 +359,7 @@ mod tests {
         project.config.localnet.port = 9999;
 
         let hook = format!("echo \"$SEQUENCER_URL\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, false).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "http://127.0.0.1:9999");
@@ -337,7 +370,7 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let project = make_test_project(temp.path().to_path_buf());
 
-        let result = run_post_deploy_hook(&project, "exit 42");
+        let result = run_post_deploy_hook(&project, "exit 42", false);
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(
@@ -353,7 +386,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("pwd > '{}'", pwd_file.display());
-        run_post_deploy_hook(&project, &hook).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, false).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&pwd_file).expect("read pwd output");
         let canonical = temp

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -10,7 +10,8 @@ use crate::commands::deploy::{
 use crate::commands::idl::build_idl_for_current_project;
 use crate::commands::localnet::{build_localnet_status_for_project, cmd_localnet, LocalnetAction};
 use crate::commands::run_state::{
-    compute_program_hashes, deploy_can_be_skipped, load_state, save_state, RunDeployState,
+    compute_program_hashes, current_localnet_pid, deploy_can_be_skipped, load_state, save_state,
+    RunDeployState,
 };
 use crate::commands::wallet::{cmd_wallet_topup_inner, TopupOutcome};
 use crate::constants::{DEFAULT_RUN_LOCALNET_TIMEOUT_SEC, SPEL_BIN_REL_PATH};
@@ -74,29 +75,32 @@ fn run_pipeline_once(
         bail!("wallet topup confirmation timed out; aborting run to avoid deploying with uncertain funding.\nHint: retry `logos-scaffold run` or run `logos-scaffold wallet topup` manually.");
     }
 
-    // Step 5: Deploy (idempotent: skip when guest .bin + IDL hashes both
-    // match the prior deploy. IDL is folded in so an ABI-only edit forces
-    // a re-deploy even if the binary is byte-identical). To force a
-    // re-deploy, delete `.scaffold/state/run_deploy.json` manually
-    // (a `--reset` switch arrives in a later branch of this stack).
+    // Step 5: Deploy (idempotent: skip when guest .bin + IDL + deploy
+    // config hashes match the prior deploy AND the sequencer is the same
+    // instance that received it. A `lgs localnet stop && start` cycle
+    // changes the sequencer PID and wipes on-chain state, so PID equality
+    // is the gate that prevents stale-deploy false positives. To force a
+    // re-deploy without restarting localnet, delete
+    // `.scaffold/state/run_deploy.json` manually (a `--reset` switch
+    // arrives in a later branch of this stack).
     let current_hashes = compute_program_hashes(project)?;
+    let current_pid = current_localnet_pid(project);
     let prior = load_state(project);
-    let deploy_skipped = if deploy_can_be_skipped(&current_hashes, &prior.program_hashes) {
+    let deploy_skipped = if deploy_can_be_skipped(&current_hashes, current_pid, &prior) {
         println!(
-            "[5/{total_steps}] Deploy skipped (guest binaries + IDL unchanged; delete `.scaffold/state/run_deploy.json` to force a re-deploy)"
+            "[5/{total_steps}] Deploy skipped (guest binaries + IDL + config + sequencer unchanged; delete `.scaffold/state/run_deploy.json` to force a re-deploy)"
         );
         true
     } else {
         println!("[5/{total_steps}] Deploying programs...");
         cmd_deploy(None, None, false)?;
-        if !current_hashes.is_empty() {
-            save_state(
-                project,
-                &RunDeployState {
-                    program_hashes: current_hashes,
-                },
-            )?;
-        }
+        save_state(
+            project,
+            &RunDeployState {
+                program_hashes: current_hashes,
+                localnet_pid: current_pid,
+            },
+        )?;
         false
     };
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -229,6 +229,13 @@ fn build_hook_command(
         .env("NSSA_WALLET_HOME_DIR", &wallet_home)
         .env("SCAFFOLD_PROJECT_ROOT", &project_root)
         .env("SCAFFOLD_IDL_DIR", &idl_dir)
+        // Always-on: deploy-skip state is run-level (it's the same for
+        // every program in this invocation), so multi-program hooks need
+        // it just as much as single-program ones.
+        .env(
+            "SCAFFOLD_DEPLOY_SKIPPED",
+            if deploy_skipped { "1" } else { "0" },
+        )
         .current_dir(&project.root);
 
     // Single-program shortcut: when there's exactly one deployable program,
@@ -240,10 +247,6 @@ fn build_hook_command(
             cmd.env("SCAFFOLD_PROGRAM_ID", id);
         }
         cmd.env("SCAFFOLD_GUEST_BIN", &sp.binary_path);
-        cmd.env(
-            "SCAFFOLD_DEPLOY_SKIPPED",
-            if deploy_skipped { "1" } else { "0" },
-        );
     }
     cmd
 }
@@ -595,5 +598,42 @@ mod tests {
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "id=|bin=");
+    }
+
+    #[test]
+    fn hook_receives_deploy_skipped_env_without_single_program() {
+        // `SCAFFOLD_DEPLOY_SKIPPED` is run-level state and must reach the
+        // hook even when there's no single-program shortcut to ride on
+        // (i.e. multi-program projects). Pre-fix, the env var was only
+        // exported inside the `if let Some(single_program)` block, so
+        // multi-program hooks never saw it.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env_file = temp.path().join("env_out.txt");
+        let project = make_test_project(temp.path().to_path_buf());
+
+        let hook = format!(
+            "echo \"$SCAFFOLD_DEPLOY_SKIPPED\" > '{}'",
+            env_file.display()
+        );
+        run_post_deploy_hook(&project, &hook, None, true).expect("hook should succeed");
+
+        let content = std::fs::read_to_string(&env_file).expect("read env output");
+        assert_eq!(content.trim(), "1");
+    }
+
+    #[test]
+    fn hook_receives_deploy_skipped_zero_when_deploy_ran() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env_file = temp.path().join("env_out.txt");
+        let project = make_test_project(temp.path().to_path_buf());
+
+        let hook = format!(
+            "echo \"$SCAFFOLD_DEPLOY_SKIPPED\" > '{}'",
+            env_file.display()
+        );
+        run_post_deploy_hook(&project, &hook, None, false).expect("hook should succeed");
+
+        let content = std::fs::read_to_string(&env_file).expect("read env output");
+        assert_eq!(content.trim(), "0");
     }
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -9,6 +9,9 @@ use crate::commands::deploy::{
 };
 use crate::commands::idl::build_idl_for_current_project;
 use crate::commands::localnet::{build_localnet_status_for_project, cmd_localnet, LocalnetAction};
+use crate::commands::run_state::{
+    compute_program_hashes, deploy_can_be_skipped, load_state, save_state, RunDeployState,
+};
 use crate::commands::wallet::{cmd_wallet_topup_inner, TopupOutcome};
 use crate::constants::{DEFAULT_RUN_LOCALNET_TIMEOUT_SEC, SPEL_BIN_REL_PATH};
 use crate::model::{LocalnetOwnership, Project};
@@ -71,9 +74,31 @@ fn run_pipeline_once(
         bail!("wallet topup confirmation timed out; aborting run to avoid deploying with uncertain funding.\nHint: retry `logos-scaffold run` or run `logos-scaffold wallet topup` manually.");
     }
 
-    // Step 5: Deploy
-    println!("[5/{total_steps}] Deploying programs...");
-    cmd_deploy(None, None, false)?;
+    // Step 5: Deploy (idempotent: skip when guest .bin + IDL hashes both
+    // match the prior deploy. IDL is folded in so an ABI-only edit forces
+    // a re-deploy even if the binary is byte-identical). To force a
+    // re-deploy, delete `.scaffold/state/run_deploy.json` manually
+    // (a `--reset` switch arrives in a later branch of this stack).
+    let current_hashes = compute_program_hashes(project)?;
+    let prior = load_state(project);
+    let deploy_skipped = if deploy_can_be_skipped(&current_hashes, &prior.program_hashes) {
+        println!(
+            "[5/{total_steps}] Deploy skipped (guest binaries + IDL unchanged; delete `.scaffold/state/run_deploy.json` to force a re-deploy)"
+        );
+        true
+    } else {
+        println!("[5/{total_steps}] Deploying programs...");
+        cmd_deploy(None, None, false)?;
+        if !current_hashes.is_empty() {
+            save_state(
+                project,
+                &RunDeployState {
+                    program_hashes: current_hashes,
+                },
+            )?;
+        }
+        false
+    };
 
     // Step 6: Post-deploy hooks (or summary)
     if has_hooks {
@@ -85,7 +110,7 @@ fn run_pipeline_once(
         let single_program = resolve_single_program_metadata(project)?;
         for (i, hook) in hooks.iter().enumerate() {
             println!("===> post_deploy[{}/{n}]: {hook}", i + 1);
-            run_post_deploy_hook(project, hook, single_program.as_ref())?;
+            run_post_deploy_hook(project, hook, single_program.as_ref(), deploy_skipped)?;
             println!("<=== post_deploy[{}/{n}] OK", i + 1);
         }
     } else {
@@ -174,6 +199,7 @@ fn build_hook_command(
     project: &Project,
     hook_command: &str,
     single_program: Option<&SingleProgram>,
+    deploy_skipped: bool,
 ) -> Command {
     let port = project.config.localnet.port;
     let sequencer_url = format!("http://127.0.0.1:{port}");
@@ -210,6 +236,10 @@ fn build_hook_command(
             cmd.env("SCAFFOLD_PROGRAM_ID", id);
         }
         cmd.env("SCAFFOLD_GUEST_BIN", &sp.binary_path);
+        cmd.env(
+            "SCAFFOLD_DEPLOY_SKIPPED",
+            if deploy_skipped { "1" } else { "0" },
+        );
     }
     cmd
 }
@@ -241,8 +271,9 @@ fn run_post_deploy_hook(
     project: &Project,
     hook_command: &str,
     single_program: Option<&SingleProgram>,
+    deploy_skipped: bool,
 ) -> DynResult<()> {
-    let status = build_hook_command(project, hook_command, single_program)
+    let status = build_hook_command(project, hook_command, single_program, deploy_skipped)
         .status()
         .context("failed to execute post-deploy hook")?;
 
@@ -309,7 +340,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$SEQUENCER_URL\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, None).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, None, false).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "http://127.0.0.1:3040");
@@ -322,7 +353,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$NSSA_WALLET_HOME_DIR\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, None).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, None, false).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert!(
@@ -338,7 +369,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$SCAFFOLD_PROJECT_ROOT\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, None).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, None, false).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         let canonical = temp
@@ -355,7 +386,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$SCAFFOLD_IDL_DIR\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, None).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, None, false).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert!(
@@ -372,7 +403,7 @@ mod tests {
         project.config.localnet.port = 9999;
 
         let hook = format!("echo \"$SEQUENCER_URL\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, None).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, None, false).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "http://127.0.0.1:9999");
@@ -383,7 +414,7 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let project = make_test_project(temp.path().to_path_buf());
 
-        let result = run_post_deploy_hook(&project, "exit 42", None);
+        let result = run_post_deploy_hook(&project, "exit 42", None, false);
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(
@@ -399,7 +430,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("pwd > '{}'", pwd_file.display());
-        run_post_deploy_hook(&project, &hook, None).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, None, false).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&pwd_file).expect("read pwd output");
         let canonical = temp
@@ -467,7 +498,7 @@ mod tests {
             }} > '{}'",
             env_file.display()
         );
-        run_post_deploy_hook(&project, &hook, None).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, None, false).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         let canonical = temp
@@ -510,7 +541,7 @@ mod tests {
             "echo \"$SCAFFOLD_PROGRAM_ID|$SCAFFOLD_GUEST_BIN\" > '{}'",
             env_file.display()
         );
-        run_post_deploy_hook(&project, &hook, Some(&single)).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, Some(&single), false).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         let expected_bin = temp.path().join("counter.bin");
@@ -538,7 +569,7 @@ mod tests {
             "if [ -z \"${{SCAFFOLD_PROGRAM_ID+set}}\" ]; then echo unset; else echo set; fi > '{}'",
             env_file.display()
         );
-        run_post_deploy_hook(&project, &hook, Some(&single)).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, Some(&single), false).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "unset");
@@ -556,7 +587,7 @@ mod tests {
             "echo \"id=${{SCAFFOLD_PROGRAM_ID+set}}|bin=${{SCAFFOLD_GUEST_BIN+set}}\" > '{}'",
             env_file.display()
         );
-        run_post_deploy_hook(&project, &hook, None).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, None, false).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "id=|bin=");

--- a/src/commands/run_state.rs
+++ b/src/commands/run_state.rs
@@ -1,0 +1,166 @@
+//! Persisted run state used by `cmd_run` for deploy idempotence.
+//!
+//! The state file at `.scaffold/state/run_deploy.json` records the SHA-256
+//! of every guest `.bin` (folded together with its IDL JSON) that was
+//! last deployed. Before re-deploying, `cmd_run` compares the current
+//! hashes against the stored ones and skips the deploy step when they
+//! match. To force a fresh deploy, use `lgs run --reset` (which clears
+//! this file as a side effect of the wipe) or delete the file manually.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::commands::deploy::{discover_deployable_programs, discover_program_binaries};
+use crate::model::Project;
+use crate::DynResult;
+
+const RUN_DEPLOY_STATE_REL: &str = ".scaffold/state/run_deploy.json";
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub(crate) struct RunDeployState {
+    pub(crate) program_hashes: BTreeMap<String, String>,
+}
+
+pub(crate) fn compute_program_hashes(project: &Project) -> DynResult<BTreeMap<String, String>> {
+    let mut out = BTreeMap::new();
+    let programs_dir = project.root.join("methods/guest/src/bin");
+    if !programs_dir.exists() {
+        return Ok(out);
+    }
+    let programs = discover_deployable_programs(&project.root)?;
+    let binaries = discover_program_binaries(&project.root, &programs);
+    let idl_dir = project.root.join(&project.config.framework.idl.path);
+    for (stem, bin_path) in binaries {
+        let mut hasher = Sha256::new();
+        let bin_bytes = std::fs::read(&bin_path)
+            .with_context(|| format!("read {} for hashing", bin_path.display()))?;
+        hasher.update(&bin_bytes);
+        // Fold the corresponding IDL JSON (if any) into the program's
+        // hash so that an ABI-only edit invalidates the cached deploy
+        // even when the compiled binary is byte-identical. Missing IDL
+        // is hashed as the empty string — consistent across runs for
+        // non-lez-framework projects.
+        let idl_path = idl_dir.join(format!("{stem}.json"));
+        if idl_path.exists() {
+            let idl_bytes = std::fs::read(&idl_path)
+                .with_context(|| format!("read {} for hashing", idl_path.display()))?;
+            hasher.update(b"\x00idl\x00");
+            hasher.update(&idl_bytes);
+        }
+        out.insert(stem, hex_encode(&hasher.finalize()));
+    }
+    Ok(out)
+}
+
+pub(crate) fn load_state(project: &Project) -> RunDeployState {
+    let path = state_path(&project.root);
+    let Ok(bytes) = std::fs::read(&path) else {
+        return RunDeployState::default();
+    };
+    match serde_json::from_slice(&bytes) {
+        Ok(state) => state,
+        Err(err) => {
+            // Surface cache corruption rather than silently re-deploying. A
+            // truncated `run_deploy.json` from a SIGINT mid-write would
+            // otherwise force every subsequent run to do a real deploy
+            // with no signal that the cache was discarded.
+            eprintln!(
+                "warning: ignoring malformed deploy cache at {} ({err}); next deploy will re-run",
+                path.display()
+            );
+            RunDeployState::default()
+        }
+    }
+}
+
+pub(crate) fn save_state(project: &Project, state: &RunDeployState) -> DynResult<()> {
+    let path = state_path(&project.root);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    let bytes = serde_json::to_vec_pretty(state).context("serialize run_deploy.json")?;
+    // Atomic write: stage to a sibling tempfile, then rename. A SIGINT
+    // between write and rename leaves the prior cache intact rather than
+    // truncating it. Same parent dir so rename(2) stays atomic across the
+    // same filesystem.
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, &bytes).with_context(|| format!("write {}", tmp.display()))?;
+    std::fs::rename(&tmp, &path)
+        .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))
+}
+
+/// `Some(true)` → all known programs hashed and match prior; safe to skip.
+/// `Some(false)` → at least one differs / new / removed; must deploy.
+/// Empty `current` is treated as "must deploy" (nothing built yet).
+pub(crate) fn deploy_can_be_skipped(
+    current: &BTreeMap<String, String>,
+    prior: &BTreeMap<String, String>,
+) -> bool {
+    if current.is_empty() || prior.is_empty() {
+        return false;
+    }
+    current == prior
+}
+
+fn state_path(project_root: &Path) -> std::path::PathBuf {
+    project_root.join(RUN_DEPLOY_STATE_REL)
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deploy_skipped_when_hashes_match() {
+        let mut a = BTreeMap::new();
+        a.insert("hello".to_string(), "deadbeef".to_string());
+        let b = a.clone();
+        assert!(deploy_can_be_skipped(&a, &b));
+    }
+
+    #[test]
+    fn deploy_not_skipped_when_hash_differs() {
+        let mut a = BTreeMap::new();
+        a.insert("hello".to_string(), "deadbeef".to_string());
+        let mut b = BTreeMap::new();
+        b.insert("hello".to_string(), "cafebabe".to_string());
+        assert!(!deploy_can_be_skipped(&a, &b));
+    }
+
+    #[test]
+    fn deploy_not_skipped_when_new_program_added() {
+        let mut a = BTreeMap::new();
+        a.insert("hello".to_string(), "h1".to_string());
+        a.insert("counter".to_string(), "h2".to_string());
+        let mut b = BTreeMap::new();
+        b.insert("hello".to_string(), "h1".to_string());
+        assert!(!deploy_can_be_skipped(&a, &b));
+    }
+
+    #[test]
+    fn deploy_not_skipped_when_either_empty() {
+        let a: BTreeMap<String, String> = BTreeMap::new();
+        let mut b = BTreeMap::new();
+        b.insert("hello".to_string(), "h1".to_string());
+        assert!(!deploy_can_be_skipped(&a, &b));
+        assert!(!deploy_can_be_skipped(&b, &a));
+    }
+
+    #[test]
+    fn hex_encode_is_lowercase_padded() {
+        assert_eq!(hex_encode(&[0x0a, 0xff, 0x00]), "0aff00");
+    }
+}

--- a/src/commands/run_state.rs
+++ b/src/commands/run_state.rs
@@ -1,11 +1,16 @@
 //! Persisted run state used by `cmd_run` for deploy idempotence.
 //!
 //! The state file at `.scaffold/state/run_deploy.json` records the SHA-256
-//! of every guest `.bin` (folded together with its IDL JSON) that was
-//! last deployed. Before re-deploying, `cmd_run` compares the current
-//! hashes against the stored ones and skips the deploy step when they
-//! match. To force a fresh deploy, use `lgs run --reset` (which clears
-//! this file as a side effect of the wipe) or delete the file manually.
+//! of every guest `.bin` (folded together with its IDL JSON and a small
+//! deploy-config digest) that was last deployed, plus the sequencer PID
+//! that received the deploy. Before re-deploying, `cmd_run` compares the
+//! current hashes against the stored ones and skips the deploy step when
+//! they match AND the sequencer is the same instance. A `lgs localnet
+//! stop && start` cycle changes the PID, which invalidates the cache so
+//! the next run actually re-deploys against the empty chain. To force a
+//! fresh deploy without restarting localnet, use `lgs run --reset` (which
+//! clears this file as a side effect of the wipe) or delete the file
+//! manually.
 
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -15,45 +20,98 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::commands::deploy::{discover_deployable_programs, discover_program_binaries};
+use crate::constants::FRAMEWORK_KIND_LEZ_FRAMEWORK;
 use crate::model::Project;
+use crate::state::read_localnet_state;
 use crate::DynResult;
 
 const RUN_DEPLOY_STATE_REL: &str = ".scaffold/state/run_deploy.json";
+const LOCALNET_STATE_REL: &str = ".scaffold/state/localnet.state";
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub(crate) struct RunDeployState {
     pub(crate) program_hashes: BTreeMap<String, String>,
+    /// Sequencer PID at deploy time. A stop+start cycle changes the PID
+    /// (and wipes on-chain state along with it), so a mismatch here means
+    /// the cached deploy is stale even when the binaries haven't changed.
+    /// `None` for legacy state files written before this field existed —
+    /// treated as unknown and forces a re-deploy.
+    #[serde(default)]
+    pub(crate) localnet_pid: Option<u32>,
+}
+
+/// Read the current sequencer PID from `.scaffold/state/localnet.state`.
+/// `None` when the state file is absent or unparseable — callers should
+/// treat that as "no localnet identity available", which forces a deploy.
+pub(crate) fn current_localnet_pid(project: &Project) -> Option<u32> {
+    let path = project.root.join(LOCALNET_STATE_REL);
+    read_localnet_state(&path)
+        .ok()
+        .and_then(|s| s.sequencer_pid)
 }
 
 pub(crate) fn compute_program_hashes(project: &Project) -> DynResult<BTreeMap<String, String>> {
     let mut out = BTreeMap::new();
-    let programs_dir = project.root.join("methods/guest/src/bin");
-    if !programs_dir.exists() {
+    // `discover_deployable_programs` returns an empty Vec when the bin dir
+    // is missing, so we don't need to pre-check. Surfacing its errors
+    // (unreadable dir, etc.) is preferable to silently treating them as
+    // "no programs to hash".
+    let programs = discover_deployable_programs(&project.root)?;
+    if programs.is_empty() {
         return Ok(out);
     }
-    let programs = discover_deployable_programs(&project.root)?;
     let binaries = discover_program_binaries(&project.root, &programs);
     let idl_dir = project.root.join(&project.config.framework.idl.path);
+    let cfg_digest = config_digest(project);
+    let is_lez_framework = project.config.framework.kind == FRAMEWORK_KIND_LEZ_FRAMEWORK;
+
     for (stem, bin_path) in binaries {
         let mut hasher = Sha256::new();
         let bin_bytes = std::fs::read(&bin_path)
             .with_context(|| format!("read {} for hashing", bin_path.display()))?;
         hasher.update(&bin_bytes);
+        // Fold a small canonical digest of deploy-affecting config so the
+        // cache invalidates when the user switches sequencer port, wallet
+        // home, or IDL path without doing a `--reset`. Without this, a
+        // run pointed at a different localnet would silently skip deploy
+        // and leave the new target empty.
+        hasher.update(b"\x00cfg\x00");
+        hasher.update(cfg_digest.as_bytes());
         // Fold the corresponding IDL JSON (if any) into the program's
         // hash so that an ABI-only edit invalidates the cached deploy
-        // even when the compiled binary is byte-identical. Missing IDL
-        // is hashed as the empty string — consistent across runs for
-        // non-lez-framework projects.
+        // even when the compiled binary is byte-identical.
         let idl_path = idl_dir.join(format!("{stem}.json"));
         if idl_path.exists() {
             let idl_bytes = std::fs::read(&idl_path)
                 .with_context(|| format!("read {} for hashing", idl_path.display()))?;
             hasher.update(b"\x00idl\x00");
             hasher.update(&idl_bytes);
+        } else if is_lez_framework {
+            // For lez-framework projects, the IDL file is a documented
+            // build artifact (`<stem>.json` produced by `build idl`).
+            // Missing it would mean we cache a partial digest and silently
+            // skip deploys after later ABI-only edits. Bail loudly.
+            anyhow::bail!(
+                "expected IDL file {} for program `{stem}` is missing; \
+                 run `lgs build idl` first or delete {} to bypass the deploy cache",
+                idl_path.display(),
+                project.root.join(RUN_DEPLOY_STATE_REL).display()
+            );
         }
         out.insert(stem, hex_encode(&hasher.finalize()));
     }
     Ok(out)
+}
+
+/// Canonical, stable digest of the deploy-affecting bits of scaffold.toml.
+/// Pinned to a small explicit set rather than serializing the whole config
+/// so unrelated config edits don't bust the cache.
+fn config_digest(project: &Project) -> String {
+    let cfg = &project.config;
+    format!(
+        "port={}|wallet={}|idl={}",
+        cfg.localnet.port, cfg.wallet_home_dir, cfg.framework.idl.path
+    )
 }
 
 pub(crate) fn load_state(project: &Project) -> RunDeployState {
@@ -87,23 +145,37 @@ pub(crate) fn save_state(project: &Project, state: &RunDeployState) -> DynResult
     // between write and rename leaves the prior cache intact rather than
     // truncating it. Same parent dir so rename(2) stays atomic across the
     // same filesystem.
-    let tmp = path.with_extension("json.tmp");
+    let tmp_name = match path.file_name().and_then(|n| n.to_str()) {
+        Some(n) => format!("{n}.tmp"),
+        None => return Err(anyhow::anyhow!("invalid state path: {}", path.display())),
+    };
+    let tmp = path.with_file_name(tmp_name);
     std::fs::write(&tmp, &bytes).with_context(|| format!("write {}", tmp.display()))?;
     std::fs::rename(&tmp, &path)
         .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))
 }
 
-/// `Some(true)` → all known programs hashed and match prior; safe to skip.
-/// `Some(false)` → at least one differs / new / removed; must deploy.
-/// Empty `current` is treated as "must deploy" (nothing built yet).
+/// `true` → all known programs hashed, hashes match prior, AND the
+/// sequencer PID matches the one that received the prior deploy. A `false`
+/// here can mean any of: nothing built, prior cache absent, hash mismatch,
+/// or sequencer was restarted (which wiped on-chain state).
 pub(crate) fn deploy_can_be_skipped(
     current: &BTreeMap<String, String>,
-    prior: &BTreeMap<String, String>,
+    current_pid: Option<u32>,
+    prior: &RunDeployState,
 ) -> bool {
-    if current.is_empty() || prior.is_empty() {
+    if current.is_empty() || prior.program_hashes.is_empty() {
         return false;
     }
-    current == prior
+    if current != &prior.program_hashes {
+        return false;
+    }
+    // Both PIDs must be present and equal — `None` on either side means
+    // we can't prove the sequencer is the same instance, so re-deploy.
+    match (current_pid, prior.localnet_pid) {
+        (Some(a), Some(b)) => a == b,
+        _ => false,
+    }
 }
 
 fn state_path(project_root: &Path) -> std::path::PathBuf {
@@ -123,44 +195,161 @@ fn hex_encode(bytes: &[u8]) -> String {
 mod tests {
     use super::*;
 
+    fn state_with(hashes: &[(&str, &str)], pid: Option<u32>) -> RunDeployState {
+        RunDeployState {
+            program_hashes: hashes
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            localnet_pid: pid,
+        }
+    }
+
     #[test]
-    fn deploy_skipped_when_hashes_match() {
-        let mut a = BTreeMap::new();
-        a.insert("hello".to_string(), "deadbeef".to_string());
-        let b = a.clone();
-        assert!(deploy_can_be_skipped(&a, &b));
+    fn deploy_skipped_when_hashes_and_pid_match() {
+        let current: BTreeMap<String, String> =
+            [("hello".to_string(), "deadbeef".to_string())].into();
+        let prior = state_with(&[("hello", "deadbeef")], Some(42));
+        assert!(deploy_can_be_skipped(&current, Some(42), &prior));
+    }
+
+    #[test]
+    fn deploy_not_skipped_when_pid_differs() {
+        let current: BTreeMap<String, String> =
+            [("hello".to_string(), "deadbeef".to_string())].into();
+        let prior = state_with(&[("hello", "deadbeef")], Some(42));
+        assert!(!deploy_can_be_skipped(&current, Some(99), &prior));
+    }
+
+    #[test]
+    fn deploy_not_skipped_when_pid_unknown_on_either_side() {
+        let current: BTreeMap<String, String> =
+            [("hello".to_string(), "deadbeef".to_string())].into();
+        let with_pid = state_with(&[("hello", "deadbeef")], Some(42));
+        let no_pid = state_with(&[("hello", "deadbeef")], None);
+        assert!(!deploy_can_be_skipped(&current, None, &with_pid));
+        assert!(!deploy_can_be_skipped(&current, Some(42), &no_pid));
     }
 
     #[test]
     fn deploy_not_skipped_when_hash_differs() {
-        let mut a = BTreeMap::new();
-        a.insert("hello".to_string(), "deadbeef".to_string());
-        let mut b = BTreeMap::new();
-        b.insert("hello".to_string(), "cafebabe".to_string());
-        assert!(!deploy_can_be_skipped(&a, &b));
+        let current: BTreeMap<String, String> =
+            [("hello".to_string(), "deadbeef".to_string())].into();
+        let prior = state_with(&[("hello", "cafebabe")], Some(42));
+        assert!(!deploy_can_be_skipped(&current, Some(42), &prior));
     }
 
     #[test]
     fn deploy_not_skipped_when_new_program_added() {
-        let mut a = BTreeMap::new();
-        a.insert("hello".to_string(), "h1".to_string());
-        a.insert("counter".to_string(), "h2".to_string());
-        let mut b = BTreeMap::new();
-        b.insert("hello".to_string(), "h1".to_string());
-        assert!(!deploy_can_be_skipped(&a, &b));
+        let current: BTreeMap<String, String> = [
+            ("hello".to_string(), "h1".to_string()),
+            ("counter".to_string(), "h2".to_string()),
+        ]
+        .into();
+        let prior = state_with(&[("hello", "h1")], Some(42));
+        assert!(!deploy_can_be_skipped(&current, Some(42), &prior));
     }
 
     #[test]
     fn deploy_not_skipped_when_either_empty() {
-        let a: BTreeMap<String, String> = BTreeMap::new();
-        let mut b = BTreeMap::new();
-        b.insert("hello".to_string(), "h1".to_string());
-        assert!(!deploy_can_be_skipped(&a, &b));
-        assert!(!deploy_can_be_skipped(&b, &a));
+        let empty: BTreeMap<String, String> = BTreeMap::new();
+        let nonempty: BTreeMap<String, String> = [("hello".to_string(), "h1".to_string())].into();
+        let prior_with = state_with(&[("hello", "h1")], Some(42));
+        let prior_empty = state_with(&[], Some(42));
+        assert!(!deploy_can_be_skipped(&empty, Some(42), &prior_with));
+        assert!(!deploy_can_be_skipped(&nonempty, Some(42), &prior_empty));
     }
 
     #[test]
     fn hex_encode_is_lowercase_padded() {
         assert_eq!(hex_encode(&[0x0a, 0xff, 0x00]), "0aff00");
+    }
+
+    #[test]
+    fn save_then_load_round_trips_state() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = make_test_project(temp.path().to_path_buf());
+        let state = state_with(&[("hello", "deadbeef")], Some(1234));
+        save_state(&project, &state).expect("save");
+        let loaded = load_state(&project);
+        assert_eq!(loaded.program_hashes, state.program_hashes);
+        assert_eq!(loaded.localnet_pid, state.localnet_pid);
+    }
+
+    #[test]
+    fn save_atomically_replaces_prior_cache() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = make_test_project(temp.path().to_path_buf());
+        save_state(&project, &state_with(&[("a", "h1")], Some(1))).expect("save 1");
+        save_state(&project, &state_with(&[("b", "h2")], Some(2))).expect("save 2");
+        let loaded = load_state(&project);
+        assert_eq!(loaded.localnet_pid, Some(2));
+        assert!(loaded.program_hashes.contains_key("b"));
+        assert!(!loaded.program_hashes.contains_key("a"));
+        // The temp file must not be left behind.
+        let tmp = temp.path().join(".scaffold/state/run_deploy.json.tmp");
+        assert!(!tmp.exists(), "temp file leaked: {}", tmp.display());
+    }
+
+    #[test]
+    fn malformed_cache_returns_default_with_warning() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = make_test_project(temp.path().to_path_buf());
+        let path = temp.path().join(".scaffold/state/run_deploy.json");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"{not valid json").unwrap();
+        let loaded = load_state(&project);
+        assert!(loaded.program_hashes.is_empty());
+        assert_eq!(loaded.localnet_pid, None);
+    }
+
+    #[test]
+    fn legacy_cache_without_localnet_pid_loads_as_none() {
+        // Cache files written before the localnet_pid field existed must
+        // still parse — they just force a re-deploy.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = make_test_project(temp.path().to_path_buf());
+        let path = temp.path().join(".scaffold/state/run_deploy.json");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, br#"{"program_hashes":{"hello":"deadbeef"}}"#).unwrap();
+        let loaded = load_state(&project);
+        assert_eq!(loaded.localnet_pid, None);
+        assert_eq!(
+            loaded.program_hashes.get("hello").map(String::as_str),
+            Some("deadbeef")
+        );
+    }
+
+    fn make_test_project(root: std::path::PathBuf) -> Project {
+        use crate::model::{
+            Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig, RepoRef, RunConfig,
+        };
+        Project {
+            root,
+            config: Config {
+                version: "0.2.0".to_string(),
+                cache_root: ".scaffold/cache".to_string(),
+                lez: RepoRef::default(),
+                spel: RepoRef::default(),
+                basecamp_repo: None,
+                lgpm_repo: None,
+                wallet_home_dir: ".scaffold/wallet".to_string(),
+                framework: FrameworkConfig {
+                    kind: "default".to_string(),
+                    version: "0.1.0".to_string(),
+                    idl: FrameworkIdlConfig {
+                        spec: "lssa-idl/0.1.0".to_string(),
+                        path: "idl".to_string(),
+                    },
+                },
+                localnet: LocalnetConfig {
+                    port: 3040,
+                    risc0_dev_mode: true,
+                },
+                modules: BTreeMap::new(),
+                run: RunConfig::default(),
+                basecamp: None,
+            },
+        }
     }
 }

--- a/src/commands/run_state.rs
+++ b/src/commands/run_state.rs
@@ -20,10 +20,16 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::commands::deploy::{discover_deployable_programs, discover_program_binaries};
+use crate::commands::wallet_support::load_wallet_runtime;
 use crate::constants::FRAMEWORK_KIND_LEZ_FRAMEWORK;
 use crate::model::Project;
 use crate::state::read_localnet_state;
 use crate::DynResult;
+
+/// Fallback sequencer address when the wallet config doesn't pin one and
+/// the wallet runtime isn't loadable yet. Mirrors `cmd_deploy`'s default
+/// so the cache key matches the address `cmd_deploy` would actually use.
+const DEFAULT_SEQUENCER_ADDR: &str = "http://127.0.0.1:3040";
 
 const RUN_DEPLOY_STATE_REL: &str = ".scaffold/state/run_deploy.json";
 const LOCALNET_STATE_REL: &str = ".scaffold/state/localnet.state";
@@ -61,6 +67,24 @@ pub(crate) fn compute_program_hashes(project: &Project) -> DynResult<BTreeMap<St
         return Ok(out);
     }
     let binaries = discover_program_binaries(&project.root, &programs);
+    // If a discovered guest source has no compiled `.bin` yet, the cache
+    // would otherwise hash only the subset that *is* built and could
+    // declare a hit against an old cache that predates the new source.
+    // Bail loudly so the user sees the missing-binary error here instead
+    // of `cmd_deploy` reporting it later — and so a cache hit can never
+    // skip a deploy that would have failed.
+    if binaries.len() != programs.len() {
+        let missing: Vec<&str> = programs
+            .iter()
+            .filter(|p| !binaries.contains_key(*p))
+            .map(String::as_str)
+            .collect();
+        anyhow::bail!(
+            "guest source(s) without a compiled binary: {}.\n\
+             Run `lgs build` to produce the missing `.bin` file(s) before re-running.",
+            missing.join(", ")
+        );
+    }
     let idl_dir = project.root.join(&project.config.framework.idl.path);
     let cfg_digest = config_digest(project);
     let is_lez_framework = project.config.framework.kind == FRAMEWORK_KIND_LEZ_FRAMEWORK;
@@ -103,15 +127,32 @@ pub(crate) fn compute_program_hashes(project: &Project) -> DynResult<BTreeMap<St
     Ok(out)
 }
 
-/// Canonical, stable digest of the deploy-affecting bits of scaffold.toml.
-/// Pinned to a small explicit set rather than serializing the whole config
-/// so unrelated config edits don't bust the cache.
+/// Canonical, stable digest of the deploy-affecting bits of scaffold.toml
+/// plus the resolved deploy target. Pinned to a small explicit set rather
+/// than serializing the whole config so unrelated edits don't bust the
+/// cache. The sequencer address comes from the wallet config when
+/// available (this is the address `cmd_deploy` actually targets) — that
+/// way `wallet_config.json` repointing at a different sequencer
+/// invalidates the cache even when `scaffold.toml` is unchanged.
 fn config_digest(project: &Project) -> String {
     let cfg = &project.config;
+    let sequencer = resolved_sequencer_addr(project);
     format!(
-        "port={}|wallet={}|idl={}",
-        cfg.localnet.port, cfg.wallet_home_dir, cfg.framework.idl.path
+        "port={}|wallet={}|idl={}|sequencer={}",
+        cfg.localnet.port, cfg.wallet_home_dir, cfg.framework.idl.path, sequencer
     )
+}
+
+/// Resolve the sequencer address `cmd_deploy` would use for this project.
+/// Falls back to `DEFAULT_SEQUENCER_ADDR` when the wallet runtime isn't
+/// loadable (e.g. on a fresh project before `lgs setup` ran). The
+/// fallback matches `cmd_deploy`'s own default, so cache and deploy stay
+/// in lockstep.
+fn resolved_sequencer_addr(project: &Project) -> String {
+    load_wallet_runtime(project)
+        .ok()
+        .and_then(|w| w.sequencer_addr)
+        .unwrap_or_else(|| DEFAULT_SEQUENCER_ADDR.to_string())
 }
 
 pub(crate) fn load_state(project: &Project) -> RunDeployState {
@@ -351,5 +392,107 @@ mod tests {
                 basecamp: None,
             },
         }
+    }
+
+    /// Stage a guest source under `methods/guest/src/bin/<stem>.rs` so
+    /// `discover_deployable_programs` will pick it up. Optionally stages a
+    /// matching `.bin` under a riscv32im release path so
+    /// `discover_program_binaries` finds it; pass `bin = false` to leave
+    /// the binary missing.
+    fn stage_guest_program(root: &Path, stem: &str, bin: bool) {
+        let src = root
+            .join("methods/guest/src/bin")
+            .join(format!("{stem}.rs"));
+        std::fs::create_dir_all(src.parent().unwrap()).unwrap();
+        std::fs::write(&src, b"// fixture\n").unwrap();
+        if bin {
+            // discover_program_binaries requires a `riscv32im*` segment
+            // and prefers paths containing `release`.
+            let bin_dir = root.join(format!(
+                "target/riscv-guest/riscv32im-risc0-zkvm-elf/release"
+            ));
+            std::fs::create_dir_all(&bin_dir).unwrap();
+            std::fs::write(bin_dir.join(format!("{stem}.bin")), b"\x7fELF...").unwrap();
+        }
+    }
+
+    #[test]
+    fn compute_hashes_bails_when_a_program_is_missing_its_bin() {
+        // Two guest sources, only one compiled. Without the missing-binary
+        // bail, `compute_program_hashes` would silently return a one-entry
+        // map matching whatever the prior cache stored for that single
+        // program, and `lgs run` would skip a deploy that `cmd_deploy`
+        // would have failed.
+        let temp = tempfile::tempdir().expect("tempdir");
+        stage_guest_program(temp.path(), "alpha", true);
+        stage_guest_program(temp.path(), "beta", false);
+        let project = make_test_project(temp.path().to_path_buf());
+
+        let err = compute_program_hashes(&project).expect_err("must bail");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("beta") && msg.contains("lgs build"),
+            "error must name the missing program and the build hint: {msg}"
+        );
+    }
+
+    #[test]
+    fn compute_hashes_succeeds_when_every_program_has_a_bin() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        stage_guest_program(temp.path(), "alpha", true);
+        stage_guest_program(temp.path(), "beta", true);
+        let project = make_test_project(temp.path().to_path_buf());
+
+        let hashes = compute_program_hashes(&project).expect("succeeds");
+        assert_eq!(hashes.len(), 2);
+        assert!(hashes.contains_key("alpha"));
+        assert!(hashes.contains_key("beta"));
+    }
+
+    #[test]
+    fn compute_hashes_includes_sequencer_addr_in_digest() {
+        // Two project trees identical apart from `wallet_config.json`'s
+        // sequencer_addr: hashes must differ. Without the sequencer in the
+        // digest, repointing the wallet at a different sequencer would
+        // skip deploy and silently leave the new target empty.
+        let temp_a = tempfile::tempdir().expect("tempdir a");
+        let temp_b = tempfile::tempdir().expect("tempdir b");
+        for root in [temp_a.path(), temp_b.path()] {
+            stage_guest_program(root, "alpha", true);
+            // Stage a wallet runtime so `load_wallet_runtime` succeeds.
+            // It needs the lez wallet binary plus a `wallet_config.json`.
+            let lez = root.join("lez");
+            std::fs::create_dir_all(lez.join("target/release")).unwrap();
+            std::fs::write(lez.join("target/release/wallet"), b"#!/bin/sh\n").unwrap();
+            let wallet_home = root.join(".scaffold/wallet");
+            std::fs::create_dir_all(&wallet_home).unwrap();
+        }
+        std::fs::write(
+            temp_a.path().join(".scaffold/wallet/wallet_config.json"),
+            br#"{"sequencer_addr":"http://127.0.0.1:3040"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            temp_b.path().join(".scaffold/wallet/wallet_config.json"),
+            br#"{"sequencer_addr":"http://10.0.0.1:9999"}"#,
+        )
+        .unwrap();
+
+        // RepoRef::default() leaves both `path` and `pin` empty; without
+        // a path `resolve_repo_path` bails and `load_wallet_runtime`
+        // falls through. Pin lez to the staged tree so the wallet
+        // runtime resolves and the wallet config is actually read.
+        let mut project_a = make_test_project(temp_a.path().to_path_buf());
+        project_a.config.lez.path = temp_a.path().join("lez").to_string_lossy().to_string();
+        let mut project_b = make_test_project(temp_b.path().to_path_buf());
+        project_b.config.lez.path = temp_b.path().join("lez").to_string_lossy().to_string();
+
+        let hashes_a = compute_program_hashes(&project_a).expect("a");
+        let hashes_b = compute_program_hashes(&project_b).expect("b");
+        assert_ne!(
+            hashes_a.get("alpha"),
+            hashes_b.get("alpha"),
+            "wallet sequencer_addr drift must invalidate the cache"
+        );
     }
 }


### PR DESCRIPTION
Adds an idempotence layer to the run pipeline's deploy step. Before invoking `cmd_deploy`, hash every guest `.bin` together with its matching IDL JSON and a small deploy-config digest (sequencer port, wallet home, IDL path), then compare against `.scaffold/state/run_deploy.json` from the prior run. Skip when **all** of (a) program hashes match, and (b) the cached sequencer PID matches the currently-running sequencer. Deploy and update the cache otherwise.

The PID gate is what closes the stale-deploy trap: `lgs localnet stop && lgs localnet start` wipes on-chain state but leaves the cache file intact, so without PID equality the next `lgs run` would skip deploy and silently leave the new chain empty. The config digest closes the analogous trap for `localnet.port` / `wallet_home_dir` / `framework.idl.path` edits without `--reset`. Folding IDL JSON into the program hash means an ABI-only edit forces a re-deploy even when the compiled binary is byte-identical; for `lez-framework` projects, a missing IDL file at hash time bails loudly rather than caching a partial digest.

The cache file is written via tempfile + rename in the same directory, so a SIGINT mid-write leaves the prior cache intact rather than truncating it. Malformed cache files (e.g. a truncated `run_deploy.json` from a crash) are recovered as cache-miss with a `warning:` line naming the path and the parse error, instead of silently re-deploying every run forever. Legacy state files without `localnet_pid` (written by an earlier iteration of this branch) parse via `#[serde(default)]` and are treated as unknown — forcing a re-deploy rather than trusting them.

Post-deploy hooks now also receive `SCAFFOLD_DEPLOY_SKIPPED=0|1` in the single-program shortcut so consumers can short-circuit redundant on-chain work.

## Env vars exposed to post-deploy hooks at this point of the stack

Always set:

- `SEQUENCER_URL`
- `NSSA_WALLET_HOME_DIR`
- `SCAFFOLD_PROJECT_ROOT`
- `SCAFFOLD_IDL_DIR`

Single-program shortcut (only when the project has exactly one deployable program):

- `SCAFFOLD_PROGRAM_ID` (omitted when `spel inspect` fails)
- `SCAFFOLD_GUEST_BIN`
- `SCAFFOLD_DEPLOY_SKIPPED` (new in this PR)

The multi-program env fan-out (`SCAFFOLD_PROGRAMS`, `SCAFFOLD_PROGRAM_ID_<name>`, `SCAFFOLD_PROGRAM_NAME`, etc.) lands in part 3 of the stack.

## Stack

This PR is part 2 of a 4-PR stack that splits PR #66. Part 1 of the original split (run-mvp) merged separately as #96, so the live stack is:

1. ~~feat/run-mvp~~ — landed as #96 ✅
2. **feat/run-deploy-cache ← this PR** — skip deploy when guest .bin + IDL + config hashes are unchanged and sequencer is the same instance
3. feat/run-multiprogram-env (#98, depends on this) — `SCAFFOLD_PROGRAMS`, `SCAFFOLD_PROGRAM_ID_<name>`, …
4. feat/run-reset-and-profiles (#99, depends on #98) — `--reset` wipe-and-reseed and named `[run.profiles.*]`
5. feat/run-watch (#100, depends on #99) — `--watch` re-runs pipeline on file changes

Base for this PR is `master`. Each downstream PR's base is the previous PR's branch; merge in order.

## Replaces part of

#66 — PR #66 will be retired by editing its description once this stack lands.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo check --all-targets`
- [x] `cargo test --all-targets` — 11 unit tests in `commands::run_state` covering `deploy_can_be_skipped` invariants (PID-match, PID-differs, PID-unknown-either-side, hash-differs, new-program, either-empty), `hex_encode` formatting, save→load round-trip, atomic-write tempfile cleanup, malformed-cache fallback, and legacy-cache forward-compat.
- [x] Dogfooded against a real Phase-1 project: cold run, no-change re-run (deploy skipped), source edit (re-deployed), deleted cache (re-deployed), corrupted cache (warning + re-deployed), `lgs localnet stop && start` between runs (PID mismatch → re-deployed), `SCAFFOLD_DEPLOY_SKIPPED` reaching the hook. See `docs/dogfood-pr97-2026-05-11.md` in the cryptarchs-scaffold-develop project for the writeup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>