### PR TITLE
feat(run): expose per-program env vars to post-deploy hooks

### DIFF
--- a/src/commands/idl.rs
+++ b/src/commands/idl.rs
@@ -123,7 +123,7 @@ fn canonical_json(text: &str) -> DynResult<String> {
     Ok(format!("{pretty}\n"))
 }
 
-fn sanitize_file_stem(name: &str) -> String {
+pub(crate) fn sanitize_file_stem(name: &str) -> String {
     let mut out = String::new();
     let mut prev_sep = false;
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -86,13 +86,19 @@ fn run_pipeline_once(project: &Project, hooks: &[String]) -> DynResult<()> {
         false
     };
 
+    // Collect deployed-program metadata for hook env injection regardless
+    // of whether deploy ran or was skipped — hooks address programs by
+    // name and shouldn't have to care about cache state.
+    let deployed = collect_deployed_programs(project, skipped);
+
     // Step 6: Post-deploy hooks (or summary)
     if has_hooks {
         let n = hooks.len();
         println!("[6/{total_steps}] Running {n} post-deploy hook(s)...");
+        warn_on_rewritten_program_names(&deployed);
         for (i, hook) in hooks.iter().enumerate() {
             println!("===> post_deploy[{}/{n}]: {hook}", i + 1);
-            run_post_deploy_hook(project, hook, skipped)?;
+            run_post_deploy_hook(project, hook, &deployed)?;
             println!("<=== post_deploy[{}/{n}] OK", i + 1);
         }
     } else {
@@ -158,7 +164,100 @@ fn print_deploy_summary(project: &Project) -> DynResult<()> {
     Ok(())
 }
 
-fn build_hook_command(project: &Project, hook_command: &str, deploy_skipped: bool) -> Command {
+/// Per-program metadata exposed to post-deploy hooks via env vars.
+/// `program_id` may be `None` when `spel inspect` fails (missing vendored
+/// binary, unreadable ELF). `skipped` mirrors the deploy step's outcome
+/// for that invocation — true when the hash cache short-circuited deploy.
+#[derive(Clone, Debug)]
+pub(crate) struct DeployedProgram {
+    pub(crate) name: String,
+    pub(crate) program_id: Option<String>,
+    pub(crate) binary_path: PathBuf,
+    pub(crate) skipped: bool,
+}
+
+fn collect_deployed_programs(project: &Project, skipped: bool) -> Vec<DeployedProgram> {
+    let programs_dir = project.root.join("methods/guest/src/bin");
+    if !programs_dir.exists() {
+        return Vec::new();
+    }
+    let Ok(programs) = discover_deployable_programs(&project.root) else {
+        return Vec::new();
+    };
+    let binaries = discover_program_binaries(&project.root, &programs);
+    let spel_bin = match resolve_repo_path(project, &project.config.spel, "spel") {
+        Ok(p) => p.join(SPEL_BIN_REL_PATH),
+        Err(_) => return Vec::new(),
+    };
+
+    let mut out = Vec::new();
+    for stem in programs {
+        let Some(bin_path) = binaries.get(&stem).cloned() else {
+            continue;
+        };
+        let program_id = extract_program_id(&spel_bin, &bin_path);
+        out.push(DeployedProgram {
+            name: stem,
+            program_id,
+            binary_path: bin_path,
+            skipped,
+        });
+    }
+    out
+}
+
+/// Replace any character that isn't `[A-Za-z0-9_]` with `_` so the result
+/// is a legal POSIX env var name suffix. Program names from
+/// `methods/guest/src/bin/*.rs` are typically already snake_case, but
+/// nothing prevents `my-program.rs` from existing — sanitize defensively.
+fn env_var_suffix(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// When a program filename contains characters that get rewritten in env
+/// var names (anything outside `[A-Za-z0-9_]`), the indexed forms
+/// `SCAFFOLD_PROGRAM_ID_<name>` use the rewritten suffix while
+/// `$SCAFFOLD_PROGRAMS` round-trips the raw filename. A hook that interpolates
+/// `$SCAFFOLD_PROGRAM_ID_my-program` would parse as
+/// `${SCAFFOLD_PROGRAM_ID_my}-program` and silently produce wrong output.
+/// Print one line per rewritten name so the user sees the actual var name to
+/// reference before the hook runs.
+fn warn_on_rewritten_program_names(deployed: &[DeployedProgram]) {
+    let rewrites: Vec<(&str, String)> = deployed
+        .iter()
+        .filter_map(|d| {
+            let suffix = env_var_suffix(&d.name);
+            if suffix == d.name {
+                None
+            } else {
+                Some((d.name.as_str(), suffix))
+            }
+        })
+        .collect();
+    if rewrites.is_empty() {
+        return;
+    }
+    println!(
+        "      note: program name(s) rewritten for env-var legality (any char outside [A-Za-z0-9_] becomes _):"
+    );
+    for (raw, suffix) in rewrites {
+        println!("        {raw} -> SCAFFOLD_PROGRAM_ID_{suffix} (and SCAFFOLD_GUEST_BIN_{suffix}, SCAFFOLD_DEPLOY_SKIPPED_{suffix})");
+    }
+}
+
+fn build_hook_command(
+    project: &Project,
+    hook_command: &str,
+    deployed: &[DeployedProgram],
+) -> Command {
     let port = project.config.localnet.port;
     let sequencer_url = format!("http://127.0.0.1:{port}");
     let wallet_home = project
@@ -185,51 +284,45 @@ fn build_hook_command(project: &Project, hook_command: &str, deploy_skipped: boo
         .env("SCAFFOLD_IDL_DIR", &idl_dir)
         .current_dir(&project.root);
 
-    // Single-program shortcut: when there's exactly one deployable program,
-    // expose its program-id and guest-binary path as env vars so simple
-    // hooks can call `spel` or the dogfood client without parsing the
-    // deploy summary. Multi-program env fan-out arrives in a later branch
-    // of this stack.
-    if let Some(binary_path) = single_program_binary(project) {
-        if let Some(spel_bin) = resolve_spel_bin(project) {
-            if let Some(id) = extract_program_id(&spel_bin, &binary_path) {
-                cmd.env("SCAFFOLD_PROGRAM_ID", id);
-            }
+    // Per-program metadata: `SCAFFOLD_PROGRAMS` holds the space-separated
+    // list of names, with parallel `SCAFFOLD_PROGRAM_ID_<name>`,
+    // `SCAFFOLD_GUEST_BIN_<name>`, `SCAFFOLD_DEPLOY_SKIPPED_<name>` per
+    // entry. Names are sanitized for env-var-suffix legality.
+    let names: Vec<&str> = deployed.iter().map(|d| d.name.as_str()).collect();
+    cmd.env("SCAFFOLD_PROGRAMS", names.join(" "));
+    for d in deployed {
+        let suffix = env_var_suffix(&d.name);
+        if let Some(id) = &d.program_id {
+            cmd.env(format!("SCAFFOLD_PROGRAM_ID_{suffix}"), id);
         }
-        cmd.env("SCAFFOLD_GUEST_BIN", &binary_path);
+        cmd.env(format!("SCAFFOLD_GUEST_BIN_{suffix}"), &d.binary_path);
+        cmd.env(
+            format!("SCAFFOLD_DEPLOY_SKIPPED_{suffix}"),
+            if d.skipped { "1" } else { "0" },
+        );
+    }
+    // Single-program shortcut: only set when there's exactly one program.
+    // Hooks that handle multi-program projects must use the indexed forms.
+    if let [single] = deployed {
+        cmd.env("SCAFFOLD_PROGRAM_NAME", &single.name);
+        if let Some(id) = &single.program_id {
+            cmd.env("SCAFFOLD_PROGRAM_ID", id);
+        }
+        cmd.env("SCAFFOLD_GUEST_BIN", &single.binary_path);
         cmd.env(
             "SCAFFOLD_DEPLOY_SKIPPED",
-            if deploy_skipped { "1" } else { "0" },
+            if single.skipped { "1" } else { "0" },
         );
     }
     cmd
 }
 
-fn single_program_binary(project: &Project) -> Option<PathBuf> {
-    let programs_dir = project.root.join("methods/guest/src/bin");
-    if !programs_dir.exists() {
-        return None;
-    }
-    let programs = discover_deployable_programs(&project.root).ok()?;
-    if programs.len() != 1 {
-        return None;
-    }
-    let binaries = discover_program_binaries(&project.root, &programs);
-    let stem = programs.into_iter().next()?;
-    binaries.get(&stem).cloned()
-}
-
-fn resolve_spel_bin(project: &Project) -> Option<PathBuf> {
-    let spel = resolve_repo_path(project, &project.config.spel, "spel").ok()?;
-    Some(spel.join(SPEL_BIN_REL_PATH))
-}
-
 fn run_post_deploy_hook(
     project: &Project,
     hook_command: &str,
-    deploy_skipped: bool,
+    deployed: &[DeployedProgram],
 ) -> DynResult<()> {
-    let status = build_hook_command(project, hook_command, deploy_skipped)
+    let status = build_hook_command(project, hook_command, deployed)
         .status()
         .context("failed to execute post-deploy hook")?;
 
@@ -296,7 +389,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$SEQUENCER_URL\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, false).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &[]).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "http://127.0.0.1:3040");
@@ -309,7 +402,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$NSSA_WALLET_HOME_DIR\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, false).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &[]).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert!(
@@ -325,7 +418,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$SCAFFOLD_PROJECT_ROOT\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, false).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &[]).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         let canonical = temp
@@ -342,7 +435,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$SCAFFOLD_IDL_DIR\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, false).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &[]).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert!(
@@ -359,7 +452,7 @@ mod tests {
         project.config.localnet.port = 9999;
 
         let hook = format!("echo \"$SEQUENCER_URL\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, false).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &[]).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "http://127.0.0.1:9999");
@@ -370,7 +463,7 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let project = make_test_project(temp.path().to_path_buf());
 
-        let result = run_post_deploy_hook(&project, "exit 42", false);
+        let result = run_post_deploy_hook(&project, "exit 42", &[]);
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(
@@ -386,7 +479,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("pwd > '{}'", pwd_file.display());
-        run_post_deploy_hook(&project, &hook, false).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &[]).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&pwd_file).expect("read pwd output");
         let canonical = temp
@@ -434,5 +527,139 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         print_deploy_summary(&project).expect("should succeed with missing dir");
+    }
+
+    fn fake_deployed(name: &str, id: Option<&str>, skipped: bool) -> DeployedProgram {
+        DeployedProgram {
+            name: name.to_string(),
+            program_id: id.map(str::to_string),
+            binary_path: PathBuf::from(format!("/fake/{name}.bin")),
+            skipped,
+        }
+    }
+
+    #[test]
+    fn hook_receives_program_id_indexed_by_name() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env_file = temp.path().join("env_out.txt");
+        let project = make_test_project(temp.path().to_path_buf());
+        let deployed = vec![fake_deployed("counter", Some("deadbeef"), false)];
+
+        let hook = format!(
+            "echo \"$SCAFFOLD_PROGRAM_ID_counter\" > '{}'",
+            env_file.display()
+        );
+        run_post_deploy_hook(&project, &hook, &deployed).expect("hook should succeed");
+
+        let content = std::fs::read_to_string(&env_file).expect("read env output");
+        assert_eq!(content.trim(), "deadbeef");
+    }
+
+    #[test]
+    fn hook_receives_single_program_shortcut_when_one_program() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env_file = temp.path().join("env_out.txt");
+        let project = make_test_project(temp.path().to_path_buf());
+        let deployed = vec![fake_deployed("counter", Some("abc123"), false)];
+
+        let hook = format!(
+            "printf '%s|%s|%s' \"$SCAFFOLD_PROGRAM_NAME\" \"$SCAFFOLD_PROGRAM_ID\" \"$SCAFFOLD_DEPLOY_SKIPPED\" > '{}'",
+            env_file.display()
+        );
+        run_post_deploy_hook(&project, &hook, &deployed).expect("hook should succeed");
+
+        let content = std::fs::read_to_string(&env_file).expect("read env output");
+        assert_eq!(content, "counter|abc123|0");
+    }
+
+    #[test]
+    fn hook_omits_single_program_shortcut_when_multiple() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env_file = temp.path().join("env_out.txt");
+        let project = make_test_project(temp.path().to_path_buf());
+        let deployed = vec![
+            fake_deployed("counter", Some("h1"), false),
+            fake_deployed("greeter", Some("h2"), false),
+        ];
+
+        let hook = format!(
+            "echo \"[${{SCAFFOLD_PROGRAM_NAME:-unset}}]\" > '{}'",
+            env_file.display()
+        );
+        run_post_deploy_hook(&project, &hook, &deployed).expect("hook should succeed");
+
+        let content = std::fs::read_to_string(&env_file).expect("read env output");
+        assert_eq!(content.trim(), "[unset]");
+    }
+
+    #[test]
+    fn hook_receives_programs_list_and_skipped_flag() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env_file = temp.path().join("env_out.txt");
+        let project = make_test_project(temp.path().to_path_buf());
+        let deployed = vec![
+            fake_deployed("a", None, true),
+            fake_deployed("b", Some("h"), true),
+        ];
+
+        let hook = format!(
+            "printf '%s|%s|%s' \"$SCAFFOLD_PROGRAMS\" \"$SCAFFOLD_DEPLOY_SKIPPED_a\" \"$SCAFFOLD_DEPLOY_SKIPPED_b\" > '{}'",
+            env_file.display()
+        );
+        run_post_deploy_hook(&project, &hook, &deployed).expect("hook should succeed");
+
+        let content = std::fs::read_to_string(&env_file).expect("read env output");
+        assert_eq!(content, "a b|1|1");
+    }
+
+    #[test]
+    fn hook_program_id_unset_when_extraction_failed() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env_file = temp.path().join("env_out.txt");
+        let project = make_test_project(temp.path().to_path_buf());
+        let deployed = vec![fake_deployed("noid", None, false)];
+
+        let hook = format!(
+            "echo \"[${{SCAFFOLD_PROGRAM_ID_noid:-unset}}]\" > '{}'",
+            env_file.display()
+        );
+        run_post_deploy_hook(&project, &hook, &deployed).expect("hook should succeed");
+
+        let content = std::fs::read_to_string(&env_file).expect("read env output");
+        assert_eq!(content.trim(), "[unset]");
+    }
+
+    #[test]
+    fn env_var_suffix_sanitizes_unsafe_characters() {
+        assert_eq!(env_var_suffix("plain"), "plain");
+        assert_eq!(env_var_suffix("with-dash"), "with_dash");
+        assert_eq!(env_var_suffix("dot.name"), "dot_name");
+        assert_eq!(env_var_suffix("a/b"), "a_b");
+    }
+
+    #[test]
+    fn warn_on_rewritten_program_names_only_lists_rewrites() {
+        // Just exercise the function on a mixed list; the println!s go to
+        // stdout (captured by `cargo test`) but we mainly want to confirm
+        // it doesn't panic and the rewrite-detection logic stays consistent
+        // with `env_var_suffix`.
+        let deployed = vec![
+            DeployedProgram {
+                name: "alphanumeric".to_string(),
+                program_id: None,
+                binary_path: PathBuf::from("/dev/null"),
+                skipped: false,
+            },
+            DeployedProgram {
+                name: "with-dash".to_string(),
+                program_id: None,
+                binary_path: PathBuf::from("/dev/null"),
+                skipped: false,
+            },
+        ];
+        warn_on_rewritten_program_names(&deployed);
+        // No assertion: the contract is "doesn't panic, prints only for
+        // rewritten names". The print_deploy_summary integration tests
+        // already lock in the user-visible output shape.
     }
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -108,17 +108,21 @@ fn run_pipeline_once(
         false
     };
 
+    // Collect deployed-program metadata for hook env injection regardless
+    // of whether deploy ran or was skipped — hooks address programs by
+    // name and shouldn't have to care about cache state.
+    // `extract_program_id` shells out to `spel inspect` once per program
+    // here so the per-hook loop doesn't multiply latency by hook count.
+    let deployed = collect_deployed_programs(project, deploy_skipped);
+
     // Step 6: Post-deploy hooks (or summary)
     if has_hooks {
         let n = hooks.len();
         println!("[6/{total_steps}] Running {n} post-deploy hook(s)...");
-        // Resolve the single-program shortcut metadata once: `extract_program_id`
-        // shells out to `spel inspect` with a per-call timeout, so doing it
-        // inside the loop would multiply latency by the hook count.
-        let single_program = resolve_single_program_metadata(project)?;
+        warn_on_rewritten_program_names(&deployed);
         for (i, hook) in hooks.iter().enumerate() {
             println!("===> post_deploy[{}/{n}]: {hook}", i + 1);
-            run_post_deploy_hook(project, hook, single_program.as_ref(), deploy_skipped)?;
+            run_post_deploy_hook(project, hook, &deployed)?;
             println!("<=== post_deploy[{}/{n}] OK", i + 1);
         }
     } else {
@@ -128,23 +132,93 @@ fn run_pipeline_once(
     Ok(())
 }
 
-/// Single-program shortcut metadata exposed to post-deploy hooks via env vars.
-/// Resolved once per `run` invocation and reused across hooks.
-struct SingleProgram {
-    binary_path: PathBuf,
-    program_id: Option<String>,
+/// Per-program metadata exposed to post-deploy hooks via env vars.
+/// `program_id` may be `None` when `spel inspect` fails (missing vendored
+/// binary, unreadable ELF). `skipped` mirrors the deploy step's outcome
+/// for that invocation — true when the hash cache short-circuited deploy.
+#[derive(Clone, Debug)]
+pub(crate) struct DeployedProgram {
+    pub(crate) name: String,
+    pub(crate) program_id: Option<String>,
+    pub(crate) binary_path: PathBuf,
+    pub(crate) skipped: bool,
 }
 
-fn resolve_single_program_metadata(project: &Project) -> DynResult<Option<SingleProgram>> {
-    let Some(binary_path) = single_program_binary(project)? else {
-        return Ok(None);
+fn collect_deployed_programs(project: &Project, skipped: bool) -> Vec<DeployedProgram> {
+    let programs_dir = project.root.join("methods/guest/src/bin");
+    if !programs_dir.exists() {
+        return Vec::new();
+    }
+    let Ok(programs) = discover_deployable_programs(&project.root) else {
+        return Vec::new();
     };
-    let program_id =
-        resolve_spel_bin(project).and_then(|spel_bin| extract_program_id(&spel_bin, &binary_path));
-    Ok(Some(SingleProgram {
-        binary_path,
-        program_id,
-    }))
+    let binaries = discover_program_binaries(&project.root, &programs);
+    let spel_bin = match resolve_repo_path(project, &project.config.spel, "spel") {
+        Ok(p) => p.join(SPEL_BIN_REL_PATH),
+        Err(_) => return Vec::new(),
+    };
+
+    let mut out = Vec::new();
+    for stem in programs {
+        let Some(bin_path) = binaries.get(&stem).cloned() else {
+            continue;
+        };
+        let program_id = extract_program_id(&spel_bin, &bin_path);
+        out.push(DeployedProgram {
+            name: stem,
+            program_id,
+            binary_path: bin_path,
+            skipped,
+        });
+    }
+    out
+}
+
+/// Replace any character that isn't `[A-Za-z0-9_]` with `_` so the result
+/// is a legal POSIX env var name suffix. Program names from
+/// `methods/guest/src/bin/*.rs` are typically already snake_case, but
+/// nothing prevents `my-program.rs` from existing — sanitize defensively.
+fn env_var_suffix(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// When a program filename contains characters that get rewritten in env
+/// var names (anything outside `[A-Za-z0-9_]`), the indexed forms
+/// `SCAFFOLD_PROGRAM_ID_<name>` use the rewritten suffix while
+/// `$SCAFFOLD_PROGRAMS` round-trips the raw filename. A hook that interpolates
+/// `$SCAFFOLD_PROGRAM_ID_my-program` would parse as
+/// `${SCAFFOLD_PROGRAM_ID_my}-program` and silently produce wrong output.
+/// Print one line per rewritten name so the user sees the actual var name to
+/// reference before the hook runs.
+fn warn_on_rewritten_program_names(deployed: &[DeployedProgram]) {
+    let rewrites: Vec<(&str, String)> = deployed
+        .iter()
+        .filter_map(|d| {
+            let suffix = env_var_suffix(&d.name);
+            if suffix == d.name {
+                None
+            } else {
+                Some((d.name.as_str(), suffix))
+            }
+        })
+        .collect();
+    if rewrites.is_empty() {
+        return;
+    }
+    println!(
+        "      note: program name(s) rewritten for env-var legality (any char outside [A-Za-z0-9_] becomes _):"
+    );
+    for (raw, suffix) in rewrites {
+        println!("        {raw} -> SCAFFOLD_PROGRAM_ID_{suffix} (and SCAFFOLD_GUEST_BIN_{suffix}, SCAFFOLD_DEPLOY_SKIPPED_{suffix})");
+    }
 }
 
 fn ensure_localnet(project: &Project, timeout_sec: u64) -> DynResult<()> {
@@ -206,8 +280,7 @@ fn print_deploy_summary(project: &Project) -> DynResult<()> {
 fn build_hook_command(
     project: &Project,
     hook_command: &str,
-    single_program: Option<&SingleProgram>,
-    deploy_skipped: bool,
+    deployed: &[DeployedProgram],
 ) -> Command {
     let port = project.config.localnet.port;
     let sequencer_url = format!("http://127.0.0.1:{port}");
@@ -226,6 +299,12 @@ fn build_hook_command(
         .canonicalize()
         .unwrap_or_else(|_| project.root.join(&project.config.framework.idl.path));
 
+    // Run-level deploy-skip state. All programs in a single invocation
+    // share the same value, so the first entry's `.skipped` flag is
+    // representative. Empty `deployed` means there were no programs to
+    // deploy in the first place — surface "0" rather than an unset var.
+    let run_deploy_skipped = deployed.first().is_some_and(|d| d.skipped);
+
     let mut cmd = Command::new("sh");
     cmd.arg("-c")
         .arg(hook_command)
@@ -238,67 +317,47 @@ fn build_hook_command(
         // it just as much as single-program ones.
         .env(
             "SCAFFOLD_DEPLOY_SKIPPED",
-            if deploy_skipped { "1" } else { "0" },
+            if run_deploy_skipped { "1" } else { "0" },
         )
         .current_dir(&project.root);
 
-    // Single-program shortcut: when there's exactly one deployable program,
-    // expose its program-id and guest-binary path as env vars so simple
-    // hooks can call `spel` or the dogfood client without parsing the
-    // deploy summary.
-    if let Some(sp) = single_program {
-        if let Some(id) = &sp.program_id {
+    // Per-program metadata: `SCAFFOLD_PROGRAMS` holds the space-separated
+    // list of names, with parallel `SCAFFOLD_PROGRAM_ID_<name>`,
+    // `SCAFFOLD_GUEST_BIN_<name>`, `SCAFFOLD_DEPLOY_SKIPPED_<name>` per
+    // entry. Names are sanitized for env-var-suffix legality.
+    let names: Vec<&str> = deployed.iter().map(|d| d.name.as_str()).collect();
+    cmd.env("SCAFFOLD_PROGRAMS", names.join(" "));
+    for d in deployed {
+        let suffix = env_var_suffix(&d.name);
+        if let Some(id) = &d.program_id {
+            cmd.env(format!("SCAFFOLD_PROGRAM_ID_{suffix}"), id);
+        }
+        cmd.env(format!("SCAFFOLD_GUEST_BIN_{suffix}"), &d.binary_path);
+        cmd.env(
+            format!("SCAFFOLD_DEPLOY_SKIPPED_{suffix}"),
+            if d.skipped { "1" } else { "0" },
+        );
+    }
+    // Single-program shortcut: only set when there's exactly one program.
+    // Hooks that handle multi-program projects must use the indexed forms.
+    // `SCAFFOLD_DEPLOY_SKIPPED` is set unconditionally above (run-level),
+    // so it's not duplicated here.
+    if let [single] = deployed {
+        cmd.env("SCAFFOLD_PROGRAM_NAME", &single.name);
+        if let Some(id) = &single.program_id {
             cmd.env("SCAFFOLD_PROGRAM_ID", id);
         }
-        cmd.env("SCAFFOLD_GUEST_BIN", &sp.binary_path);
+        cmd.env("SCAFFOLD_GUEST_BIN", &single.binary_path);
     }
     cmd
-}
-
-fn single_program_binary(project: &Project) -> DynResult<Option<PathBuf>> {
-    let programs_dir = project.root.join("methods/guest/src/bin");
-    if !programs_dir.exists() {
-        return Ok(None);
-    }
-    // Propagate I/O failures rather than treating them as "no programs":
-    // an unreadable bin dir is a real error, and silently dropping it
-    // strips the SCAFFOLD_GUEST_BIN env var from post-deploy hooks
-    // without ever surfacing the cause.
-    let programs = discover_deployable_programs(&project.root)
-        .context("failed to discover deployable programs for run")?;
-    if programs.len() != 1 {
-        return Ok(None);
-    }
-    let binaries = discover_program_binaries(&project.root, &programs);
-    Ok(binaries.get(&programs[0]).cloned())
-}
-
-fn resolve_spel_bin(project: &Project) -> Option<PathBuf> {
-    // Surface resolver failures rather than silently dropping them: the most
-    // common reasons `resolve_repo_path` errors here are exactly the cases
-    // the user cares about (misconfigured `[repos.spel]`, missing
-    // `cache_root`, broken pin). Without this warning, deploy succeeds and
-    // every post-deploy hook runs with `SCAFFOLD_PROGRAM_ID` /
-    // `SCAFFOLD_GUEST_BIN` mysteriously unset.
-    match resolve_repo_path(project, &project.config.spel, "spel") {
-        Ok(p) => Some(p.join(SPEL_BIN_REL_PATH)),
-        Err(e) => {
-            eprintln!(
-                "warning: cannot resolve spel binary: {e}; \
-                 SCAFFOLD_PROGRAM_ID will be unset for post-deploy hooks"
-            );
-            None
-        }
-    }
 }
 
 fn run_post_deploy_hook(
     project: &Project,
     hook_command: &str,
-    single_program: Option<&SingleProgram>,
-    deploy_skipped: bool,
+    deployed: &[DeployedProgram],
 ) -> DynResult<()> {
-    let status = build_hook_command(project, hook_command, single_program, deploy_skipped)
+    let status = build_hook_command(project, hook_command, deployed)
         .status()
         .context("failed to execute post-deploy hook")?;
 
@@ -365,7 +424,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$SEQUENCER_URL\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, None, false).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &[]).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "http://127.0.0.1:3040");
@@ -378,7 +437,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$NSSA_WALLET_HOME_DIR\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, None, false).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &[]).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert!(
@@ -394,7 +453,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$SCAFFOLD_PROJECT_ROOT\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, None, false).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &[]).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         let canonical = temp
@@ -411,7 +470,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$SCAFFOLD_IDL_DIR\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, None, false).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &[]).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert!(
@@ -428,7 +487,7 @@ mod tests {
         project.config.localnet.port = 9999;
 
         let hook = format!("echo \"$SEQUENCER_URL\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, None, false).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &[]).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "http://127.0.0.1:9999");
@@ -439,7 +498,7 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let project = make_test_project(temp.path().to_path_buf());
 
-        let result = run_post_deploy_hook(&project, "exit 42", None, false);
+        let result = run_post_deploy_hook(&project, "exit 42", &[]);
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(
@@ -455,7 +514,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("pwd > '{}'", pwd_file.display());
-        run_post_deploy_hook(&project, &hook, None, false).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &[]).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&pwd_file).expect("read pwd output");
         let canonical = temp
@@ -523,7 +582,7 @@ mod tests {
             }} > '{}'",
             env_file.display()
         );
-        run_post_deploy_hook(&project, &hook, None, false).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &[]).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         let canonical = temp
@@ -549,24 +608,35 @@ mod tests {
         );
     }
 
+    fn fake_deployed(name: &str, id: Option<&str>, skipped: bool) -> DeployedProgram {
+        DeployedProgram {
+            name: name.to_string(),
+            program_id: id.map(str::to_string),
+            binary_path: PathBuf::from(format!("/fake/{name}.bin")),
+            skipped,
+        }
+    }
+
     #[test]
     fn hook_receives_single_program_env_when_provided() {
-        // When `SingleProgram` is passed, `SCAFFOLD_PROGRAM_ID` and
-        // `SCAFFOLD_GUEST_BIN` reach the hook environment.
+        // When a single `DeployedProgram` is passed, `SCAFFOLD_PROGRAM_ID`
+        // and `SCAFFOLD_GUEST_BIN` reach the hook environment.
         let temp = tempfile::tempdir().expect("tempdir");
         let env_file = temp.path().join("env_out.txt");
         let project = make_test_project(temp.path().to_path_buf());
 
-        let single = SingleProgram {
-            binary_path: temp.path().join("counter.bin"),
+        let deployed = vec![DeployedProgram {
+            name: "counter".to_string(),
             program_id: Some("deadbeef".to_string()),
-        };
+            binary_path: temp.path().join("counter.bin"),
+            skipped: false,
+        }];
 
         let hook = format!(
             "echo \"$SCAFFOLD_PROGRAM_ID|$SCAFFOLD_GUEST_BIN\" > '{}'",
             env_file.display()
         );
-        run_post_deploy_hook(&project, &hook, Some(&single), false).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &deployed).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         let expected_bin = temp.path().join("counter.bin");
@@ -585,51 +655,27 @@ mod tests {
         let env_file = temp.path().join("env_out.txt");
         let project = make_test_project(temp.path().to_path_buf());
 
-        let single = SingleProgram {
-            binary_path: temp.path().join("counter.bin"),
+        let deployed = vec![DeployedProgram {
+            name: "counter".to_string(),
             program_id: None,
-        };
+            binary_path: temp.path().join("counter.bin"),
+            skipped: false,
+        }];
 
         let hook = format!(
             "if [ -z \"${{SCAFFOLD_PROGRAM_ID+set}}\" ]; then echo unset; else echo set; fi > '{}'",
             env_file.display()
         );
-        run_post_deploy_hook(&project, &hook, Some(&single), false).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &deployed).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "unset");
     }
 
     #[test]
-    fn resolve_spel_bin_returns_none_when_repo_unresolvable() {
-        // Regression for the silent-error-swallowing bug: when
-        // `[repos.spel]` is misconfigured (both path and pin empty),
-        // `resolve_spel_bin` must return `None` rather than panic, so the
-        // caller can still produce a `SingleProgram` with `program_id: None`
-        // and the post-deploy hook keeps running. The accompanying stderr
-        // warning is exercised in the binary via `eprintln!` and isn't
-        // captured here — what we lock in is that the failure mode stays
-        // `None`, not a panic.
-        let temp = tempfile::tempdir().expect("tempdir");
-        let mut project = make_test_project(temp.path().to_path_buf());
-        // Force `resolve_repo_path` to error: path empty AND pin empty.
-        project.config.spel = RepoRef {
-            source: "spel".to_string(),
-            path: String::new(),
-            pin: String::new(),
-            ..Default::default()
-        };
-        // Also blank the cache_root so the env layer doesn't accidentally
-        // succeed in a sandbox.
-        project.config.cache_root = String::new();
-
-        assert!(resolve_spel_bin(&project).is_none());
-    }
-
-    #[test]
     fn hook_omits_single_program_env_when_metadata_absent() {
-        // Multi-program (or no-program) projects pass `None`, and the
-        // single-program shortcut env vars must not be set.
+        // No-program projects pass `&[]`, and the single-program shortcut
+        // env vars must not be set.
         let temp = tempfile::tempdir().expect("tempdir");
         let env_file = temp.path().join("env_out.txt");
         let project = make_test_project(temp.path().to_path_buf());
@@ -638,35 +684,41 @@ mod tests {
             "echo \"id=${{SCAFFOLD_PROGRAM_ID+set}}|bin=${{SCAFFOLD_GUEST_BIN+set}}\" > '{}'",
             env_file.display()
         );
-        run_post_deploy_hook(&project, &hook, None, false).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &[]).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "id=|bin=");
     }
 
     #[test]
-    fn hook_receives_deploy_skipped_env_without_single_program() {
-        // `SCAFFOLD_DEPLOY_SKIPPED` is run-level state and must reach the
-        // hook even when there's no single-program shortcut to ride on
-        // (i.e. multi-program projects). Pre-fix, the env var was only
-        // exported inside the `if let Some(single_program)` block, so
-        // multi-program hooks never saw it.
+    fn hook_receives_deploy_skipped_env_for_multiprogram_run() {
+        // `SCAFFOLD_DEPLOY_SKIPPED` is run-level state and must reach
+        // multi-program hooks too — the env var is set unconditionally
+        // (driven by `deployed[0].skipped`), not gated on the
+        // single-program shortcut block.
         let temp = tempfile::tempdir().expect("tempdir");
         let env_file = temp.path().join("env_out.txt");
         let project = make_test_project(temp.path().to_path_buf());
+        let deployed = vec![
+            fake_deployed("a", Some("h1"), true),
+            fake_deployed("b", Some("h2"), true),
+        ];
 
         let hook = format!(
             "echo \"$SCAFFOLD_DEPLOY_SKIPPED\" > '{}'",
             env_file.display()
         );
-        run_post_deploy_hook(&project, &hook, None, true).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &deployed).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "1");
     }
 
     #[test]
-    fn hook_receives_deploy_skipped_zero_when_deploy_ran() {
+    fn hook_receives_deploy_skipped_zero_when_no_programs() {
+        // Empty `deployed` (no programs at all) still sets the env var,
+        // surfacing "0" rather than leaving it unset — hooks shouldn't
+        // need to disambiguate "deploy ran" from "no programs".
         let temp = tempfile::tempdir().expect("tempdir");
         let env_file = temp.path().join("env_out.txt");
         let project = make_test_project(temp.path().to_path_buf());
@@ -675,9 +727,134 @@ mod tests {
             "echo \"$SCAFFOLD_DEPLOY_SKIPPED\" > '{}'",
             env_file.display()
         );
-        run_post_deploy_hook(&project, &hook, None, false).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &[]).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "0");
+    }
+
+    #[test]
+    fn hook_receives_program_id_indexed_by_name() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env_file = temp.path().join("env_out.txt");
+        let project = make_test_project(temp.path().to_path_buf());
+        let deployed = vec![fake_deployed("counter", Some("deadbeef"), false)];
+
+        let hook = format!(
+            "echo \"$SCAFFOLD_PROGRAM_ID_counter\" > '{}'",
+            env_file.display()
+        );
+        run_post_deploy_hook(&project, &hook, &deployed).expect("hook should succeed");
+
+        let content = std::fs::read_to_string(&env_file).expect("read env output");
+        assert_eq!(content.trim(), "deadbeef");
+    }
+
+    #[test]
+    fn hook_receives_single_program_shortcut_when_one_program() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env_file = temp.path().join("env_out.txt");
+        let project = make_test_project(temp.path().to_path_buf());
+        let deployed = vec![fake_deployed("counter", Some("abc123"), false)];
+
+        let hook = format!(
+            "printf '%s|%s|%s' \"$SCAFFOLD_PROGRAM_NAME\" \"$SCAFFOLD_PROGRAM_ID\" \"$SCAFFOLD_DEPLOY_SKIPPED\" > '{}'",
+            env_file.display()
+        );
+        run_post_deploy_hook(&project, &hook, &deployed).expect("hook should succeed");
+
+        let content = std::fs::read_to_string(&env_file).expect("read env output");
+        assert_eq!(content, "counter|abc123|0");
+    }
+
+    #[test]
+    fn hook_omits_single_program_shortcut_when_multiple() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env_file = temp.path().join("env_out.txt");
+        let project = make_test_project(temp.path().to_path_buf());
+        let deployed = vec![
+            fake_deployed("counter", Some("h1"), false),
+            fake_deployed("greeter", Some("h2"), false),
+        ];
+
+        let hook = format!(
+            "echo \"[${{SCAFFOLD_PROGRAM_NAME:-unset}}]\" > '{}'",
+            env_file.display()
+        );
+        run_post_deploy_hook(&project, &hook, &deployed).expect("hook should succeed");
+
+        let content = std::fs::read_to_string(&env_file).expect("read env output");
+        assert_eq!(content.trim(), "[unset]");
+    }
+
+    #[test]
+    fn hook_receives_programs_list_and_skipped_flag() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env_file = temp.path().join("env_out.txt");
+        let project = make_test_project(temp.path().to_path_buf());
+        let deployed = vec![
+            fake_deployed("a", None, true),
+            fake_deployed("b", Some("h"), true),
+        ];
+
+        let hook = format!(
+            "printf '%s|%s|%s' \"$SCAFFOLD_PROGRAMS\" \"$SCAFFOLD_DEPLOY_SKIPPED_a\" \"$SCAFFOLD_DEPLOY_SKIPPED_b\" > '{}'",
+            env_file.display()
+        );
+        run_post_deploy_hook(&project, &hook, &deployed).expect("hook should succeed");
+
+        let content = std::fs::read_to_string(&env_file).expect("read env output");
+        assert_eq!(content, "a b|1|1");
+    }
+
+    #[test]
+    fn hook_program_id_unset_when_extraction_failed() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env_file = temp.path().join("env_out.txt");
+        let project = make_test_project(temp.path().to_path_buf());
+        let deployed = vec![fake_deployed("noid", None, false)];
+
+        let hook = format!(
+            "echo \"[${{SCAFFOLD_PROGRAM_ID_noid:-unset}}]\" > '{}'",
+            env_file.display()
+        );
+        run_post_deploy_hook(&project, &hook, &deployed).expect("hook should succeed");
+
+        let content = std::fs::read_to_string(&env_file).expect("read env output");
+        assert_eq!(content.trim(), "[unset]");
+    }
+
+    #[test]
+    fn env_var_suffix_sanitizes_unsafe_characters() {
+        assert_eq!(env_var_suffix("plain"), "plain");
+        assert_eq!(env_var_suffix("with-dash"), "with_dash");
+        assert_eq!(env_var_suffix("dot.name"), "dot_name");
+        assert_eq!(env_var_suffix("a/b"), "a_b");
+    }
+
+    #[test]
+    fn warn_on_rewritten_program_names_only_lists_rewrites() {
+        // Just exercise the function on a mixed list; the println!s go to
+        // stdout (captured by `cargo test`) but we mainly want to confirm
+        // it doesn't panic and the rewrite-detection logic stays consistent
+        // with `env_var_suffix`.
+        let deployed = vec![
+            DeployedProgram {
+                name: "alphanumeric".to_string(),
+                program_id: None,
+                binary_path: PathBuf::from("/dev/null"),
+                skipped: false,
+            },
+            DeployedProgram {
+                name: "with-dash".to_string(),
+                program_id: None,
+                binary_path: PathBuf::from("/dev/null"),
+                skipped: false,
+            },
+        ];
+        warn_on_rewritten_program_names(&deployed);
+        // No assertion: the contract is "doesn't panic, prints only for
+        // rewritten names". The print_deploy_summary integration tests
+        // already lock in the user-visible output shape.
     }
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -113,13 +113,14 @@ fn run_pipeline_once(
     // name and shouldn't have to care about cache state.
     // `extract_program_id` shells out to `spel inspect` once per program
     // here so the per-hook loop doesn't multiply latency by hook count.
-    let deployed = collect_deployed_programs(project, deploy_skipped);
+    let deployed = collect_deployed_programs(project, deploy_skipped)?;
 
     // Step 6: Post-deploy hooks (or summary)
     if has_hooks {
         let n = hooks.len();
         println!("[6/{total_steps}] Running {n} post-deploy hook(s)...");
-        warn_on_rewritten_program_names(&deployed);
+        check_env_var_suffix_collisions(&deployed.programs)?;
+        warn_on_rewritten_program_names(&deployed.programs);
         for (i, hook) in hooks.iter().enumerate() {
             println!("===> post_deploy[{}/{n}]: {hook}", i + 1);
             run_post_deploy_hook(project, hook, &deployed)?;
@@ -134,29 +135,43 @@ fn run_pipeline_once(
 
 /// Per-program metadata exposed to post-deploy hooks via env vars.
 /// `program_id` may be `None` when `spel inspect` fails (missing vendored
-/// binary, unreadable ELF). `skipped` mirrors the deploy step's outcome
-/// for that invocation — true when the hash cache short-circuited deploy.
+/// binary, unreadable ELF).
 #[derive(Clone, Debug)]
 pub(crate) struct DeployedProgram {
     pub(crate) name: String,
     pub(crate) program_id: Option<String>,
     pub(crate) binary_path: PathBuf,
-    pub(crate) skipped: bool,
 }
 
-fn collect_deployed_programs(project: &Project, skipped: bool) -> Vec<DeployedProgram> {
+/// Run-level outcome of step 5 plus per-program metadata. `skipped` is
+/// run-level (the cache either short-circuited the whole deploy or not),
+/// so it lives here rather than on each `DeployedProgram`.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct DeployedPrograms {
+    pub(crate) skipped: bool,
+    pub(crate) programs: Vec<DeployedProgram>,
+}
+
+/// Errors from `discover_deployable_programs` or `resolve_repo_path` are
+/// propagated rather than swallowed: an unreadable bin dir or a
+/// misconfigured `[repos.spel]` would otherwise silently strip
+/// `SCAFFOLD_PROGRAMS` and all indexed env vars from hooks. The
+/// missing-bin-dir case stays a successful empty result, because step 1
+/// (build) is the layer that validates project layout.
+fn collect_deployed_programs(project: &Project, skipped: bool) -> DynResult<DeployedPrograms> {
     let programs_dir = project.root.join("methods/guest/src/bin");
     if !programs_dir.exists() {
-        return Vec::new();
+        return Ok(DeployedPrograms {
+            skipped,
+            programs: Vec::new(),
+        });
     }
-    let Ok(programs) = discover_deployable_programs(&project.root) else {
-        return Vec::new();
-    };
+    let programs = discover_deployable_programs(&project.root)
+        .context("failed to discover deployable programs for run post-deploy env")?;
     let binaries = discover_program_binaries(&project.root, &programs);
-    let spel_bin = match resolve_repo_path(project, &project.config.spel, "spel") {
-        Ok(p) => p.join(SPEL_BIN_REL_PATH),
-        Err(_) => return Vec::new(),
-    };
+    let spel_repo = resolve_repo_path(project, &project.config.spel, "spel")
+        .context("failed to resolve spel repo path for run post-deploy env")?;
+    let spel_bin = spel_repo.join(SPEL_BIN_REL_PATH);
 
     let mut out = Vec::new();
     for stem in programs {
@@ -168,10 +183,44 @@ fn collect_deployed_programs(project: &Project, skipped: bool) -> Vec<DeployedPr
             name: stem,
             program_id,
             binary_path: bin_path,
-            skipped,
         });
     }
-    out
+    Ok(DeployedPrograms {
+        skipped,
+        programs: out,
+    })
+}
+
+/// Bail when two raw program names sanitize to the same env-var suffix
+/// (e.g. `my-program.rs` and `my_program.rs` both map to `my_program`).
+/// Without this, the second `cmd.env()` would silently shadow the first
+/// and hooks would see the wrong program_id/binary_path for one of them.
+fn check_env_var_suffix_collisions(programs: &[DeployedProgram]) -> DynResult<()> {
+    use std::collections::BTreeMap;
+    let mut groups: BTreeMap<String, Vec<&str>> = BTreeMap::new();
+    for p in programs {
+        groups
+            .entry(env_var_suffix(&p.name))
+            .or_default()
+            .push(p.name.as_str());
+    }
+    let collisions: Vec<(String, Vec<&str>)> = groups
+        .into_iter()
+        .filter(|(_, raws)| raws.len() > 1)
+        .collect();
+    if collisions.is_empty() {
+        return Ok(());
+    }
+    let mut msg = String::from(
+        "post-deploy env vars: program names collide after sanitization to [A-Za-z0-9_]:",
+    );
+    for (suffix, raws) in collisions {
+        msg.push_str(&format!("\n  {} -> {}", raws.join(", "), suffix));
+    }
+    msg.push_str(
+        "\nRename one of the program source files in methods/guest/src/bin/ to disambiguate.",
+    );
+    bail!("{msg}")
 }
 
 /// Replace any character that isn't `[A-Za-z0-9_]` with `_` so the result
@@ -280,7 +329,7 @@ fn print_deploy_summary(project: &Project) -> DynResult<()> {
 fn build_hook_command(
     project: &Project,
     hook_command: &str,
-    deployed: &[DeployedProgram],
+    deployed: &DeployedPrograms,
 ) -> Command {
     let port = project.config.localnet.port;
     let sequencer_url = format!("http://127.0.0.1:{port}");
@@ -299,11 +348,7 @@ fn build_hook_command(
         .canonicalize()
         .unwrap_or_else(|_| project.root.join(&project.config.framework.idl.path));
 
-    // Run-level deploy-skip state. All programs in a single invocation
-    // share the same value, so the first entry's `.skipped` flag is
-    // representative. Empty `deployed` means there were no programs to
-    // deploy in the first place — surface "0" rather than an unset var.
-    let run_deploy_skipped = deployed.first().is_some_and(|d| d.skipped);
+    let run_deploy_skipped = deployed.skipped;
 
     let mut cmd = Command::new("sh");
     cmd.arg("-c")
@@ -325,9 +370,9 @@ fn build_hook_command(
     // list of names, with parallel `SCAFFOLD_PROGRAM_ID_<name>`,
     // `SCAFFOLD_GUEST_BIN_<name>`, `SCAFFOLD_DEPLOY_SKIPPED_<name>` per
     // entry. Names are sanitized for env-var-suffix legality.
-    let names: Vec<&str> = deployed.iter().map(|d| d.name.as_str()).collect();
+    let names: Vec<&str> = deployed.programs.iter().map(|d| d.name.as_str()).collect();
     cmd.env("SCAFFOLD_PROGRAMS", names.join(" "));
-    for d in deployed {
+    for d in &deployed.programs {
         let suffix = env_var_suffix(&d.name);
         if let Some(id) = &d.program_id {
             cmd.env(format!("SCAFFOLD_PROGRAM_ID_{suffix}"), id);
@@ -335,14 +380,14 @@ fn build_hook_command(
         cmd.env(format!("SCAFFOLD_GUEST_BIN_{suffix}"), &d.binary_path);
         cmd.env(
             format!("SCAFFOLD_DEPLOY_SKIPPED_{suffix}"),
-            if d.skipped { "1" } else { "0" },
+            if run_deploy_skipped { "1" } else { "0" },
         );
     }
     // Single-program shortcut: only set when there's exactly one program.
     // Hooks that handle multi-program projects must use the indexed forms.
     // `SCAFFOLD_DEPLOY_SKIPPED` is set unconditionally above (run-level),
     // so it's not duplicated here.
-    if let [single] = deployed {
+    if let [single] = deployed.programs.as_slice() {
         cmd.env("SCAFFOLD_PROGRAM_NAME", &single.name);
         if let Some(id) = &single.program_id {
             cmd.env("SCAFFOLD_PROGRAM_ID", id);
@@ -355,7 +400,7 @@ fn build_hook_command(
 fn run_post_deploy_hook(
     project: &Project,
     hook_command: &str,
-    deployed: &[DeployedProgram],
+    deployed: &DeployedPrograms,
 ) -> DynResult<()> {
     let status = build_hook_command(project, hook_command, deployed)
         .status()
@@ -424,7 +469,8 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$SEQUENCER_URL\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, &[]).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default())
+            .expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "http://127.0.0.1:3040");
@@ -437,7 +483,8 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$NSSA_WALLET_HOME_DIR\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, &[]).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default())
+            .expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert!(
@@ -453,7 +500,8 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$SCAFFOLD_PROJECT_ROOT\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, &[]).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default())
+            .expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         let canonical = temp
@@ -470,7 +518,8 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$SCAFFOLD_IDL_DIR\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, &[]).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default())
+            .expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert!(
@@ -487,7 +536,8 @@ mod tests {
         project.config.localnet.port = 9999;
 
         let hook = format!("echo \"$SEQUENCER_URL\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, &[]).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default())
+            .expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "http://127.0.0.1:9999");
@@ -498,7 +548,7 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let project = make_test_project(temp.path().to_path_buf());
 
-        let result = run_post_deploy_hook(&project, "exit 42", &[]);
+        let result = run_post_deploy_hook(&project, "exit 42", &DeployedPrograms::default());
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(
@@ -514,7 +564,8 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("pwd > '{}'", pwd_file.display());
-        run_post_deploy_hook(&project, &hook, &[]).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default())
+            .expect("hook should succeed");
 
         let content = std::fs::read_to_string(&pwd_file).expect("read pwd output");
         let canonical = temp
@@ -582,7 +633,8 @@ mod tests {
             }} > '{}'",
             env_file.display()
         );
-        run_post_deploy_hook(&project, &hook, &[]).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default())
+            .expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         let canonical = temp
@@ -608,12 +660,18 @@ mod tests {
         );
     }
 
-    fn fake_deployed(name: &str, id: Option<&str>, skipped: bool) -> DeployedProgram {
+    fn fake_deployed(name: &str, id: Option<&str>) -> DeployedProgram {
         DeployedProgram {
             name: name.to_string(),
             program_id: id.map(str::to_string),
             binary_path: PathBuf::from(format!("/fake/{name}.bin")),
+        }
+    }
+
+    fn programs(progs: Vec<DeployedProgram>, skipped: bool) -> DeployedPrograms {
+        DeployedPrograms {
             skipped,
+            programs: progs,
         }
     }
 
@@ -625,12 +683,14 @@ mod tests {
         let env_file = temp.path().join("env_out.txt");
         let project = make_test_project(temp.path().to_path_buf());
 
-        let deployed = vec![DeployedProgram {
-            name: "counter".to_string(),
-            program_id: Some("deadbeef".to_string()),
-            binary_path: temp.path().join("counter.bin"),
-            skipped: false,
-        }];
+        let deployed = programs(
+            vec![DeployedProgram {
+                name: "counter".to_string(),
+                program_id: Some("deadbeef".to_string()),
+                binary_path: temp.path().join("counter.bin"),
+            }],
+            false,
+        );
 
         let hook = format!(
             "echo \"$SCAFFOLD_PROGRAM_ID|$SCAFFOLD_GUEST_BIN\" > '{}'",
@@ -655,12 +715,14 @@ mod tests {
         let env_file = temp.path().join("env_out.txt");
         let project = make_test_project(temp.path().to_path_buf());
 
-        let deployed = vec![DeployedProgram {
-            name: "counter".to_string(),
-            program_id: None,
-            binary_path: temp.path().join("counter.bin"),
-            skipped: false,
-        }];
+        let deployed = programs(
+            vec![DeployedProgram {
+                name: "counter".to_string(),
+                program_id: None,
+                binary_path: temp.path().join("counter.bin"),
+            }],
+            false,
+        );
 
         let hook = format!(
             "if [ -z \"${{SCAFFOLD_PROGRAM_ID+set}}\" ]; then echo unset; else echo set; fi > '{}'",
@@ -684,7 +746,8 @@ mod tests {
             "echo \"id=${{SCAFFOLD_PROGRAM_ID+set}}|bin=${{SCAFFOLD_GUEST_BIN+set}}\" > '{}'",
             env_file.display()
         );
-        run_post_deploy_hook(&project, &hook, &[]).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default())
+            .expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "id=|bin=");
@@ -699,10 +762,13 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let env_file = temp.path().join("env_out.txt");
         let project = make_test_project(temp.path().to_path_buf());
-        let deployed = vec![
-            fake_deployed("a", Some("h1"), true),
-            fake_deployed("b", Some("h2"), true),
-        ];
+        let deployed = programs(
+            vec![
+                fake_deployed("a", Some("h1")),
+                fake_deployed("b", Some("h2")),
+            ],
+            true,
+        );
 
         let hook = format!(
             "echo \"$SCAFFOLD_DEPLOY_SKIPPED\" > '{}'",
@@ -727,7 +793,8 @@ mod tests {
             "echo \"$SCAFFOLD_DEPLOY_SKIPPED\" > '{}'",
             env_file.display()
         );
-        run_post_deploy_hook(&project, &hook, &[]).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default())
+            .expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "0");
@@ -738,7 +805,7 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let env_file = temp.path().join("env_out.txt");
         let project = make_test_project(temp.path().to_path_buf());
-        let deployed = vec![fake_deployed("counter", Some("deadbeef"), false)];
+        let deployed = programs(vec![fake_deployed("counter", Some("deadbeef"))], false);
 
         let hook = format!(
             "echo \"$SCAFFOLD_PROGRAM_ID_counter\" > '{}'",
@@ -755,7 +822,7 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let env_file = temp.path().join("env_out.txt");
         let project = make_test_project(temp.path().to_path_buf());
-        let deployed = vec![fake_deployed("counter", Some("abc123"), false)];
+        let deployed = programs(vec![fake_deployed("counter", Some("abc123"))], false);
 
         let hook = format!(
             "printf '%s|%s|%s' \"$SCAFFOLD_PROGRAM_NAME\" \"$SCAFFOLD_PROGRAM_ID\" \"$SCAFFOLD_DEPLOY_SKIPPED\" > '{}'",
@@ -772,10 +839,13 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let env_file = temp.path().join("env_out.txt");
         let project = make_test_project(temp.path().to_path_buf());
-        let deployed = vec![
-            fake_deployed("counter", Some("h1"), false),
-            fake_deployed("greeter", Some("h2"), false),
-        ];
+        let deployed = programs(
+            vec![
+                fake_deployed("counter", Some("h1")),
+                fake_deployed("greeter", Some("h2")),
+            ],
+            false,
+        );
 
         let hook = format!(
             "echo \"[${{SCAFFOLD_PROGRAM_NAME:-unset}}]\" > '{}'",
@@ -792,10 +862,10 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let env_file = temp.path().join("env_out.txt");
         let project = make_test_project(temp.path().to_path_buf());
-        let deployed = vec![
-            fake_deployed("a", None, true),
-            fake_deployed("b", Some("h"), true),
-        ];
+        let deployed = programs(
+            vec![fake_deployed("a", None), fake_deployed("b", Some("h"))],
+            true,
+        );
 
         let hook = format!(
             "printf '%s|%s|%s' \"$SCAFFOLD_PROGRAMS\" \"$SCAFFOLD_DEPLOY_SKIPPED_a\" \"$SCAFFOLD_DEPLOY_SKIPPED_b\" > '{}'",
@@ -812,7 +882,7 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let env_file = temp.path().join("env_out.txt");
         let project = make_test_project(temp.path().to_path_buf());
-        let deployed = vec![fake_deployed("noid", None, false)];
+        let deployed = programs(vec![fake_deployed("noid", None)], false);
 
         let hook = format!(
             "echo \"[${{SCAFFOLD_PROGRAM_ID_noid:-unset}}]\" > '{}'",
@@ -833,6 +903,74 @@ mod tests {
     }
 
     #[test]
+    fn collect_deployed_programs_returns_empty_ok_when_bin_dir_missing() {
+        // No `methods/guest/src/bin` directory at all: this is a valid
+        // state for non-LEZ projects, so it's Ok(empty) — not an error.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = make_test_project(temp.path().to_path_buf());
+
+        let got = collect_deployed_programs(&project, false).expect("should be Ok");
+        assert!(got.programs.is_empty());
+        assert!(!got.skipped);
+    }
+
+    #[test]
+    fn collect_deployed_programs_propagates_spel_resolution_error() {
+        // Misconfigured `[repos.spel]` (both path and pin empty) must
+        // bubble up as a hard error rather than silently producing
+        // an empty `SCAFFOLD_PROGRAMS` for hooks.
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(temp.path().join("methods/guest/src/bin")).expect("create bin dir");
+        let mut project = make_test_project(temp.path().to_path_buf());
+        project.config.spel.path = String::new();
+        project.config.spel.pin = String::new();
+
+        let err = collect_deployed_programs(&project, false).expect_err("should be Err");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("spel"),
+            "expected error to mention spel, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn check_env_var_suffix_collisions_bails_on_collision() {
+        let progs = vec![
+            DeployedProgram {
+                name: "my-program".to_string(),
+                program_id: None,
+                binary_path: PathBuf::from("/dev/null"),
+            },
+            DeployedProgram {
+                name: "my_program".to_string(),
+                program_id: None,
+                binary_path: PathBuf::from("/dev/null"),
+            },
+        ];
+        let err = check_env_var_suffix_collisions(&progs).expect_err("should be Err");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("my-program"), "msg was: {msg}");
+        assert!(msg.contains("my_program"), "msg was: {msg}");
+    }
+
+    #[test]
+    fn check_env_var_suffix_collisions_passes_when_unique() {
+        let progs = vec![
+            DeployedProgram {
+                name: "counter".to_string(),
+                program_id: None,
+                binary_path: PathBuf::from("/dev/null"),
+            },
+            DeployedProgram {
+                name: "greeter".to_string(),
+                program_id: None,
+                binary_path: PathBuf::from("/dev/null"),
+            },
+        ];
+        check_env_var_suffix_collisions(&progs).expect("no collisions");
+    }
+
+    #[test]
     fn warn_on_rewritten_program_names_only_lists_rewrites() {
         // Just exercise the function on a mixed list; the println!s go to
         // stdout (captured by `cargo test`) but we mainly want to confirm
@@ -843,13 +981,11 @@ mod tests {
                 name: "alphanumeric".to_string(),
                 program_id: None,
                 binary_path: PathBuf::from("/dev/null"),
-                skipped: false,
             },
             DeployedProgram {
                 name: "with-dash".to_string(),
                 program_id: None,
                 binary_path: PathBuf::from("/dev/null"),
-                skipped: false,
             },
         ];
         warn_on_rewritten_program_names(&deployed);

--- a/src/commands/run_state.rs
+++ b/src/commands/run_state.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::commands::deploy::{discover_deployable_programs, discover_program_binaries};
+use crate::commands::idl::sanitize_file_stem;
 use crate::commands::wallet_support::load_wallet_runtime;
 use crate::constants::FRAMEWORK_KIND_LEZ_FRAMEWORK;
 use crate::model::Project;
@@ -103,8 +104,12 @@ pub(crate) fn compute_program_hashes(project: &Project) -> DynResult<BTreeMap<St
         hasher.update(cfg_digest.as_bytes());
         // Fold the corresponding IDL JSON (if any) into the program's
         // hash so that an ABI-only edit invalidates the cached deploy
-        // even when the compiled binary is byte-identical.
-        let idl_path = idl_dir.join(format!("{stem}.json"));
+        // even when the compiled binary is byte-identical. Use the
+        // same name-sanitizer as `build_idl_for_current_project`, since
+        // that's the path the IDL was actually written to: a raw stem
+        // like `my-program` would miss the on-disk `my_program.json`
+        // and bail with a misleading "run `lgs build idl`" error.
+        let idl_path = idl_dir.join(format!("{}.json", sanitize_file_stem(&stem)));
         if idl_path.exists() {
             let idl_bytes = std::fs::read(&idl_path)
                 .with_context(|| format!("read {} for hashing", idl_path.display()))?;
@@ -447,6 +452,29 @@ mod tests {
         assert_eq!(hashes.len(), 2);
         assert!(hashes.contains_key("alpha"));
         assert!(hashes.contains_key("beta"));
+    }
+
+    #[test]
+    fn compute_hashes_finds_sanitized_idl_for_dashed_program_name() {
+        // `build_idl_for_current_project` writes the IDL at
+        // `<sanitize_file_stem(stem)>.json` (e.g. `my-program.rs` →
+        // `my_program.json`). The hash lookup must use the same
+        // sanitizer; otherwise lez-framework projects with a `-` in the
+        // program filename bail with a misleading "run `lgs build idl`"
+        // message even though `build idl` ran successfully.
+        let temp = tempfile::tempdir().expect("tempdir");
+        stage_guest_program(temp.path(), "my-program", true);
+        let idl_dir = temp.path().join("idl");
+        std::fs::create_dir_all(&idl_dir).expect("create idl dir");
+        std::fs::write(idl_dir.join("my_program.json"), br#"{"abi": []}"#)
+            .expect("stage sanitized IDL");
+
+        let mut project = make_test_project(temp.path().to_path_buf());
+        project.config.framework.kind = FRAMEWORK_KIND_LEZ_FRAMEWORK.to_string();
+
+        let hashes =
+            compute_program_hashes(&project).expect("must succeed with the sanitized IDL on disk");
+        assert!(hashes.contains_key("my-program"));
     }
 
     #[test]


### PR DESCRIPTION
Branch 1 of the run-command stack only injected env vars for the single-program case. This slice fans out per-program metadata so hooks can address each deployed program by name in projects that declare multiple `methods/guest/src/bin/*.rs` entry points: `SCAFFOLD_PROGRAMS` (space-separated names), and parallel `SCAFFOLD_PROGRAM_ID_<name>`, `SCAFFOLD_GUEST_BIN_<name>`, `SCAFFOLD_DEPLOY_SKIPPED_<name>` per program. Names are sanitized for env-var-suffix legality (`-` → `_`, etc.); rewritten names get a stdout warning before the hook runs to head off `$SCAFFOLD_PROGRAM_ID_my-program` parsing as `${SCAFFOLD_PROGRAM_ID_my}-program`. The single-program shortcut from branch 1 still fires when there's exactly one program. A second sanitize check now hard-errors if two raw names collide after sanitization (e.g. `my-program.rs` + `my_program.rs`) so the second `cmd.env` can't silently shadow the first.

Two follow-ups landed on top of the original commit after dogfooding (cryptarchs-scaffold-develop, 2026-05-13):

- `4ee4ddc` — Address review feedback: `collect_deployed_programs` now returns `DynResult` and propagates errors from `discover_deployable_programs` / `resolve_repo_path` with context (a misconfigured `[repos.spel]` no longer silently strips the env vars). Run-level `skipped` lifted out of `DeployedProgram` into a wrapping `DeployedPrograms` struct.
- `e457755` — Sanitize the program stem when looking up the IDL file in `compute_program_hashes`. Without this, a guest source named `my-program.rs` (which `build idl` writes as `my_program.json`) bailed with a misleading "run `lgs build idl` first" error. Latent in PR #97; surfaced once non-trivial program names were exercised.

## Stack

This is part 3 of a 5-PR stack that splits PR #66:

1. feat/run-mvp — pipeline core, post-deploy hook, single-program env
2. feat/run-deploy-cache — skip deploy when guest .bin + IDL hashes are unchanged (#97, merged)
3. **feat/run-multiprogram-env ← this PR** — `SCAFFOLD_PROGRAMS`, `SCAFFOLD_PROGRAM_ID_<name>`, …
4. feat/run-reset-and-profiles (depends on 3) — `--reset` wipe-and-reseed and named `[run.profiles.*]`
5. feat/run-watch (depends on 4) — `--watch` re-runs pipeline on file changes

Each PR's base is the previous PR's branch; merge in order. Base for this PR is `master` (PR #97 has merged).

## Replaces part of

#66 — PR #66 will be retired by editing its description once this stack lands.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo check --all-targets`
- [x] `cargo test --all-targets` (passes locally; ~14 new tests covering: single-program shortcut presence/absence, multi-program shortcut suppression, name-indexed program-id, programs-list + skipped flag, missing program-id, env-var suffix sanitization, suffix collision detection, `collect_deployed_programs` error paths (missing bin dir Ok / misconfigured spel Err), and the IDL-stem sanitization fix)
- [x] Dogfooded on cryptarchs-scaffold-develop @ 2026-05-13 across single-program, multi-program, and cache-hit scenarios; see https://github.com/fryorcraken/cryptarchs-scaffold-develop/blob/scaffold-develop/docs/dogfood-pr98-2026-05-13.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>