### PR TITLE
feat(run): --reset and named [run.profiles.*] selectors

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -212,7 +212,19 @@ struct ReportArgs {
 
 #[derive(Debug, clap::Args)]
 struct RunArgs {
-    /// Skip post-deploy hooks even if scaffold.toml configures them
+    /// Select a named profile from `[run.profiles.<name>]`
+    #[arg(long, value_name = "NAME")]
+    profile: Option<String>,
+    /// Wipe rocksdb + wallet, restart sequencer, re-seed default wallet
+    /// (overrides scaffold.toml). Broader than `lgs localnet reset`: this
+    /// re-establishes the documented fresh-project state for the full
+    /// deploy cycle.
+    #[arg(long)]
+    reset: bool,
+    /// Skip the run-level reset even if scaffold.toml says true
+    #[arg(long, conflicts_with = "reset")]
+    no_reset: bool,
+    /// Skip post-deploy hooks even if the resolved profile defines them
     #[arg(long)]
     no_post_deploy: bool,
     /// Override post-deploy hooks (repeatable). Replaces config-defined hooks
@@ -517,6 +529,13 @@ pub(crate) fn run(args: Vec<String>) -> DynResult<()> {
         }
         Some(Commands::Doctor(args)) => cmd_doctor(args.json),
         Some(Commands::Run(args)) => {
+            let reset = if args.reset {
+                Some(true)
+            } else if args.no_reset {
+                Some(false)
+            } else {
+                None
+            };
             let post_deploy = if args.no_post_deploy {
                 Some(Vec::new())
             } else if !args.post_deploy.is_empty() {
@@ -525,6 +544,8 @@ pub(crate) fn run(args: Vec<String>) -> DynResult<()> {
                 None
             };
             cmd_run(RunInvocation {
+                profile: args.profile,
+                reset,
                 post_deploy_override: post_deploy,
             })
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -261,7 +261,19 @@ struct ReportArgs {
 
 #[derive(Debug, clap::Args)]
 struct RunArgs {
-    /// Skip post-deploy hooks even if scaffold.toml configures them
+    /// Select a named profile from `[run.profiles.<name>]`
+    #[arg(long, value_name = "NAME")]
+    profile: Option<String>,
+    /// Wipe rocksdb + wallet, restart sequencer, re-seed default wallet
+    /// (overrides scaffold.toml). Broader than `lgs localnet reset`: this
+    /// re-establishes the documented fresh-project state for the full
+    /// deploy cycle.
+    #[arg(long)]
+    reset: bool,
+    /// Skip the run-level reset even if scaffold.toml says true
+    #[arg(long, conflicts_with = "reset")]
+    no_reset: bool,
+    /// Skip post-deploy hooks even if the resolved profile defines them
     #[arg(long)]
     no_post_deploy: bool,
     /// Override post-deploy hooks (repeatable). Replaces config-defined hooks
@@ -616,6 +628,13 @@ pub(crate) fn run(args: Vec<String>) -> DynResult<()> {
         }
         Some(Commands::Doctor(args)) => cmd_doctor(args.json),
         Some(Commands::Run(args)) => {
+            let reset = if args.reset {
+                Some(true)
+            } else if args.no_reset {
+                Some(false)
+            } else {
+                None
+            };
             let post_deploy = if args.no_post_deploy {
                 Some(Vec::new())
             } else if !args.post_deploy.is_empty() {
@@ -624,6 +643,8 @@ pub(crate) fn run(args: Vec<String>) -> DynResult<()> {
                 None
             };
             cmd_run(RunInvocation {
+                profile: args.profile,
+                reset,
                 post_deploy_override: post_deploy,
                 localnet_timeout_sec: args.localnet_timeout,
             })

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -8,38 +8,69 @@ use crate::commands::deploy::{
     cmd_deploy, discover_deployable_programs, discover_program_binaries, extract_program_id,
 };
 use crate::commands::idl::build_idl_for_current_project;
-use crate::commands::localnet::{build_localnet_status_for_project, cmd_localnet, LocalnetAction};
+use crate::commands::localnet::{
+    build_localnet_status_for_project, cmd_localnet, cmd_localnet_reset, LocalnetAction,
+};
 use crate::commands::run_state::{
     compute_program_hashes, deploy_can_be_skipped, load_state, save_state, RunDeployState,
 };
+use crate::commands::setup::ensure_default_wallet_seeded;
 use crate::commands::wallet::{cmd_wallet_topup_inner, TopupOutcome};
 use crate::constants::SPEL_BIN_REL_PATH;
-use crate::model::{LocalnetOwnership, Project};
+use crate::model::{LocalnetOwnership, Project, RunProfile};
 use crate::project::{load_project, resolve_repo_path};
+use crate::state::prepare_wallet_home;
 use crate::DynResult;
 
+/// Number of seconds to wait for block production after a reset before
+/// considering the freshly-started localnet healthy. Matches the upper
+/// envelope of `cmd_localnet_reset`'s default verification timeout.
+const RESET_VERIFY_TIMEOUT_SEC: u64 = 30;
+
 /// All knobs that control a `lgs run` invocation. Built by `cli.rs` from
-/// the parsed `RunArgs` (with conflicting-flag resolution into `Option<Vec<_>>`)
+/// the parsed `RunArgs` (with conflicting-flag resolution into `Option<bool>`)
 /// and consumed by `cmd_run`. Grouping the fields together prevents the
 /// positional-swap class of bug.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct RunInvocation {
+    pub(crate) profile: Option<String>,
+    pub(crate) reset: Option<bool>,
     pub(crate) post_deploy_override: Option<Vec<String>>,
 }
 
 pub(crate) fn cmd_run(inv: RunInvocation) -> DynResult<()> {
     let project = load_project()?;
+    let resolved = project.config.run.resolve_profile(inv.profile.as_deref())?;
+    if let Some(name) = inv.profile.as_deref() {
+        println!("Using [run.profiles.{name}]");
+    } else if let Some(name) = project.config.run.default_profile.as_deref() {
+        println!("Using [run.profiles.{name}] (default_profile)");
+    }
     let hooks = inv
         .post_deploy_override
-        .unwrap_or_else(|| project.config.run.post_deploy.clone());
+        .unwrap_or_else(|| resolved.post_deploy.clone());
 
-    run_pipeline_once(&project, &hooks)
+    let params = PipelineParams {
+        resolved: resolved.clone(),
+        hooks,
+        reset_override: inv.reset,
+    };
+
+    run_pipeline_once(&project, &params)
 }
 
-fn run_pipeline_once(project: &Project, hooks: &[String]) -> DynResult<()> {
-    let has_hooks = !hooks.is_empty();
+#[derive(Clone)]
+struct PipelineParams {
+    resolved: RunProfile,
+    hooks: Vec<String>,
+    reset_override: Option<bool>,
+}
+
+fn run_pipeline_once(project: &Project, params: &PipelineParams) -> DynResult<()> {
+    let has_hooks = !params.hooks.is_empty();
     // Steps: build, build idl, localnet, topup, deploy, [+1 if hooks]
     let total_steps: u32 = if has_hooks { 6 } else { 5 };
+    let effective_reset = params.reset_override.unwrap_or(params.resolved.reset);
 
     // Step 1: Build (chains setup internally)
     println!("[1/{total_steps}] Building...");
@@ -49,9 +80,27 @@ fn run_pipeline_once(project: &Project, hooks: &[String]) -> DynResult<()> {
     println!("[2/{total_steps}] Building IDL...");
     build_idl_for_current_project()?;
 
-    // Step 3: Ensure localnet is running.
-    println!("[3/{total_steps}] Ensuring localnet...");
-    ensure_localnet(project)?;
+    // Step 3: Reset OR ensure localnet.
+    if effective_reset {
+        println!("[3/{total_steps}] Resetting localnet (wipes sequencer + wallet)...");
+        reset_for_run(project)?;
+        // A reset wipes on-chain state, so any prior deploy is gone:
+        // the next deploy must run regardless of hash equality. Tolerate
+        // NotFound (no prior run); surface anything else.
+        let state_file = project.root.join(".scaffold/state/run_deploy.json");
+        match std::fs::remove_file(&state_file) {
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(e).with_context(|| {
+                    format!("clear stale deploy state at {}", state_file.display())
+                });
+            }
+        }
+    } else {
+        println!("[3/{total_steps}] Ensuring localnet...");
+        ensure_localnet(project)?;
+    }
 
     // Step 4: Wallet topup
     println!("[4/{total_steps}] Topping up wallet...");
@@ -63,8 +112,8 @@ fn run_pipeline_once(project: &Project, hooks: &[String]) -> DynResult<()> {
     // Step 5: Deploy (idempotent: skip when guest .bin + IDL hashes both
     // match the prior deploy. IDL is folded in so an ABI-only edit forces
     // a re-deploy even if the binary is byte-identical). To force a
-    // re-deploy, delete `.scaffold/state/run_deploy.json` manually
-    // (a `--reset` switch arrives in a later branch of this stack).
+    // re-deploy, use `--reset` (which also clears the cache) or delete
+    // `.scaffold/state/run_deploy.json` manually.
     let current_hashes = compute_program_hashes(project)?;
     let prior = load_state(project);
     let skipped = if deploy_can_be_skipped(&current_hashes, &prior.program_hashes) {
@@ -93,10 +142,10 @@ fn run_pipeline_once(project: &Project, hooks: &[String]) -> DynResult<()> {
 
     // Step 6: Post-deploy hooks (or summary)
     if has_hooks {
-        let n = hooks.len();
+        let n = params.hooks.len();
         println!("[6/{total_steps}] Running {n} post-deploy hook(s)...");
         warn_on_rewritten_program_names(&deployed);
-        for (i, hook) in hooks.iter().enumerate() {
+        for (i, hook) in params.hooks.iter().enumerate() {
             println!("===> post_deploy[{}/{n}]: {hook}", i + 1);
             run_post_deploy_hook(project, hook, &deployed)?;
             println!("<=== post_deploy[{}/{n}] OK", i + 1);
@@ -106,6 +155,46 @@ fn run_pipeline_once(project: &Project, hooks: &[String]) -> DynResult<()> {
     }
 
     Ok(())
+}
+
+fn reset_for_run(project: &Project) -> DynResult<()> {
+    let lez = resolve_repo_path(project, &project.config.lez, "lez")?;
+    let state_path = project.root.join(".scaffold/state/localnet.state");
+    let log_path = project.root.join(".scaffold/logs/sequencer.log");
+    let localnet_addr = format!("127.0.0.1:{}", project.config.localnet.port);
+    cmd_localnet_reset(
+        project,
+        &lez,
+        &state_path,
+        &log_path,
+        &localnet_addr,
+        true, // reset_wallet — full wipe; reseed_after_wipe re-seeds below
+        RESET_VERIFY_TIMEOUT_SEC,
+    )?;
+    // The wipe deleted the wallet directory and state file; the next pipeline
+    // step (topup) would fail without a re-seed. Recover by calling the same
+    // primitives `cmd_setup` invokes when the wallet is absent. If the
+    // re-seed itself fails, stop the sequencer we just started so we don't
+    // strand the project in a half-wiped state with a running daemon.
+    if let Err(err) = reseed_after_wipe(project) {
+        let _ = cmd_localnet(LocalnetAction::Stop);
+        return Err(err.context(
+            "post-reset wallet re-seed failed; sequencer was stopped to avoid leaving a half-wiped project",
+        ));
+    }
+    Ok(())
+}
+
+/// Re-seed the project's default wallet after `cmd_localnet_reset` wiped
+/// it. Reuses the same primitives `cmd_setup` calls so the resulting
+/// `wallet.state` is byte-equivalent to a fresh `lgs setup`. Extracted as
+/// its own helper so the byte-equivalence test can drive it directly
+/// without booting a real sequencer.
+fn reseed_after_wipe(project: &Project) -> DynResult<()> {
+    let lez = resolve_repo_path(project, &project.config.lez, "lez")?;
+    let wallet_home = project.root.join(&project.config.wallet_home_dir);
+    prepare_wallet_home(&lez, &wallet_home)?;
+    ensure_default_wallet_seeded(&project.root, &wallet_home)
 }
 
 fn ensure_localnet(project: &Project) -> DynResult<()> {
@@ -661,5 +750,89 @@ mod tests {
         // No assertion: the contract is "doesn't panic, prints only for
         // rewritten names". The print_deploy_summary integration tests
         // already lock in the user-visible output shape.
+    }
+
+    /// After `lgs run --reset`, `wallet.state` must be byte-equivalent to a
+    /// freshly-seeded clean-setup baseline. This test enforces the
+    /// "reuse, don't duplicate" contract on the re-seed path: if anyone
+    /// reaches into `reset_for_run` and adds a parallel seed implementation,
+    /// the byte comparison breaks.
+    ///
+    /// We exercise the same primitives `cmd_setup` calls
+    /// (`prepare_wallet_home` + `ensure_default_wallet_seeded`) twice
+    /// against fresh state — once standing in for `cmd_setup`, once
+    /// standing in for the post-reset re-seed — and assert byte equality.
+    /// Booting a real sequencer is intentionally out of scope; this is the
+    /// part of the chain that isn't already covered by `cmd_localnet_reset`'s
+    /// own tests.
+    #[test]
+    fn reseed_after_wipe_matches_setup_baseline() {
+        use crate::commands::setup::ensure_default_wallet_seeded;
+        use crate::commands::wallet_support::{wallet_state_path, WALLET_CONFIG_PRIMARY};
+        use crate::state::prepare_wallet_home;
+
+        // Two parallel project trees with identical fake LEZ wallet configs.
+        // Both start from the same state a freshly-wiped project would: LEZ
+        // bundled wallet config exists on disk, but no `.scaffold/wallet/`.
+        let baseline = tempfile::tempdir().expect("baseline tempdir");
+        let post_reset = tempfile::tempdir().expect("post_reset tempdir");
+
+        for root in [baseline.path(), post_reset.path()] {
+            let lez_cfg_dir = root.join("lez/wallet/configs/debug");
+            std::fs::create_dir_all(&lez_cfg_dir).expect("create lez cfg dir");
+            std::fs::write(
+                lez_cfg_dir.join("wallet_config.json"),
+                r#"{
+  "initial_accounts": [
+    { "Public": { "account_id": "6iArKUXxhUJqS7kCaPNhwMWt3ro71PDyBj7jwAyE2VQV" } }
+  ]
+}"#,
+            )
+            .expect("write lez wallet config");
+        }
+
+        // Baseline: drive `cmd_setup`'s seed primitives directly.
+        {
+            let lez = baseline.path().join("lez");
+            let wallet_home = baseline.path().join(".scaffold/wallet");
+            prepare_wallet_home(&lez, &wallet_home).expect("baseline prepare");
+            ensure_default_wallet_seeded(baseline.path(), &wallet_home).expect("baseline seed");
+        }
+
+        // Post-reset: drive the actual helper `reset_for_run` calls.
+        // If anyone reaches into `reset_for_run` and adds a parallel seed
+        // implementation, this test breaks — that's the contract this
+        // assertion enforces over time.
+        // The fixture sets `lez.path = "lez"` (relative); make it absolute
+        // so the helper doesn't depend on cwd (tests run in parallel and
+        // can't share cwd).
+        let mut project = make_test_project(post_reset.path().to_path_buf());
+        project.config.lez.path = post_reset.path().join("lez").to_string_lossy().to_string();
+        reseed_after_wipe(&project).expect("post-reset reseed");
+
+        let baseline_state =
+            std::fs::read(wallet_state_path(baseline.path())).expect("read baseline state");
+        let post_reset_state =
+            std::fs::read(wallet_state_path(post_reset.path())).expect("read post-reset state");
+        assert_eq!(
+            baseline_state, post_reset_state,
+            "post-reset wallet.state must be byte-equivalent to clean-setup baseline"
+        );
+
+        let baseline_cfg = std::fs::read(
+            baseline
+                .path()
+                .join(".scaffold/wallet")
+                .join(WALLET_CONFIG_PRIMARY),
+        )
+        .expect("read baseline cfg");
+        let post_reset_cfg = std::fs::read(
+            post_reset
+                .path()
+                .join(".scaffold/wallet")
+                .join(WALLET_CONFIG_PRIMARY),
+        )
+        .expect("read post-reset cfg");
+        assert_eq!(baseline_cfg, post_reset_cfg);
     }
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -137,7 +137,7 @@ fn run_pipeline_once(project: &Project, params: &PipelineParams) -> DynResult<()
     let prior = load_state(project);
     let deploy_skipped = if deploy_can_be_skipped(&current_hashes, current_pid, &prior) {
         println!(
-            "[5/{total_steps}] Deploy skipped (guest binaries + IDL + config + sequencer unchanged; delete `.scaffold/state/run_deploy.json` to force a re-deploy)"
+            "[5/{total_steps}] Deploy skipped (guest binaries + IDL + config + sequencer unchanged; pass `--reset` to wipe and re-deploy, or delete `.scaffold/state/run_deploy.json` to force a re-deploy without a wipe)"
         );
         true
     } else {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -23,11 +23,6 @@ use crate::project::{load_project, resolve_repo_path, run_in_project_dir};
 use crate::state::prepare_wallet_home;
 use crate::DynResult;
 
-/// Number of seconds to wait for block production after a reset before
-/// considering the freshly-started localnet healthy. Matches the upper
-/// envelope of `cmd_localnet_reset`'s default verification timeout.
-const RESET_VERIFY_TIMEOUT_SEC: u64 = 30;
-
 /// All knobs that control a `lgs run` invocation. Built by `cli.rs` from
 /// the parsed `RunArgs` (with conflicting-flag resolution into `Option<bool>`)
 /// and consumed by `cmd_run`. Grouping the fields together prevents the
@@ -83,6 +78,17 @@ fn run_pipeline_once(project: &Project, params: &PipelineParams) -> DynResult<()
     let total_steps: u32 = if has_hooks { 6 } else { 5 };
     let effective_reset = params.reset_override.unwrap_or(params.resolved.reset);
 
+    // Surface destructive intent up front when reset comes from config
+    // (not from the CLI flag). With --reset the user already typed the
+    // word, so re-stating it is noise; with `reset = true` in scaffold.toml
+    // they may not realize step 3 will wipe rocksdb + wallet, so warn
+    // before step 1 instead of after the build has run.
+    if effective_reset && params.reset_override.is_none() {
+        eprintln!(
+            "warning: scaffold.toml requested reset = true; step 3 will wipe sequencer state + wallet. Pass --no-reset to override."
+        );
+    }
+
     // Step 1: Build (chains setup internally)
     println!("[1/{total_steps}] Building...");
     cmd_build_shortcut(None)?;
@@ -94,7 +100,7 @@ fn run_pipeline_once(project: &Project, params: &PipelineParams) -> DynResult<()
     // Step 3: Reset OR ensure localnet.
     if effective_reset {
         println!("[3/{total_steps}] Resetting localnet (wipes sequencer + wallet)...");
-        reset_for_run(project)?;
+        reset_for_run(project, params.localnet_timeout_sec)?;
         // A reset wipes on-chain state, so any prior deploy is gone:
         // the next deploy must run regardless of hash equality. Tolerate
         // NotFound (no prior run); surface anything else.
@@ -178,7 +184,7 @@ fn run_pipeline_once(project: &Project, params: &PipelineParams) -> DynResult<()
     Ok(())
 }
 
-fn reset_for_run(project: &Project) -> DynResult<()> {
+fn reset_for_run(project: &Project, verify_timeout_sec: u64) -> DynResult<()> {
     let lez = resolve_repo_path(project, &project.config.lez, "lez")?;
     let state_path = project.root.join(".scaffold/state/localnet.state");
     let log_path = project.root.join(".scaffold/logs/sequencer.log");
@@ -192,7 +198,7 @@ fn reset_for_run(project: &Project) -> DynResult<()> {
         false, // dry_run — actually perform the reset
         true,  // yes — non-interactive; run is the user-initiated action that authorizes it
         true,  // reset_wallet — full wipe; reseed_after_wipe re-seeds below
-        RESET_VERIFY_TIMEOUT_SEC,
+        verify_timeout_sec,
     )?;
     // The wipe deleted the wallet directory and state file; the next pipeline
     // step (topup) would fail without a re-seed. Recover by calling the same
@@ -1081,19 +1087,15 @@ mod tests {
         // already lock in the user-visible output shape.
     }
 
-    /// After `lgs run --reset`, `wallet.state` must be byte-equivalent to a
-    /// freshly-seeded clean-setup baseline. This test enforces the
-    /// "reuse, don't duplicate" contract on the re-seed path: if anyone
-    /// reaches into `reset_for_run` and adds a parallel seed implementation,
-    /// the byte comparison breaks.
-    ///
-    /// We exercise the same primitives `cmd_setup` calls
-    /// (`prepare_wallet_home` + `ensure_default_wallet_seeded`) twice
-    /// against fresh state — once standing in for `cmd_setup`, once
-    /// standing in for the post-reset re-seed — and assert byte equality.
-    /// Booting a real sequencer is intentionally out of scope; this is the
-    /// part of the chain that isn't already covered by `cmd_localnet_reset`'s
-    /// own tests.
+    /// Asserts that `reseed_after_wipe` produces a `wallet.state` byte-equivalent
+    /// to a fresh setup. The test does not exercise `reset_for_run` itself —
+    /// `cmd_localnet_reset` requires a real sequencer and isn't reachable from
+    /// unit-test scope. What this *does* lock down: if `reseed_after_wipe`
+    /// drifts away from calling the same primitives `cmd_setup` uses
+    /// (`prepare_wallet_home` + `ensure_default_wallet_seeded`), the byte
+    /// comparison breaks. `reset_for_run` itself must keep calling
+    /// `reseed_after_wipe` (not inline a parallel seed) — that contract is
+    /// enforced by code review, not by this test.
     #[test]
     fn reseed_after_wipe_matches_setup_baseline() {
         use crate::commands::setup::ensure_default_wallet_seeded;
@@ -1128,10 +1130,7 @@ mod tests {
             ensure_default_wallet_seeded(baseline.path(), &wallet_home).expect("baseline seed");
         }
 
-        // Post-reset: drive the actual helper `reset_for_run` calls.
-        // If anyone reaches into `reset_for_run` and adds a parallel seed
-        // implementation, this test breaks — that's the contract this
-        // assertion enforces over time.
+        // Post-reset: drive `reseed_after_wipe` directly.
         // The fixture sets `lez.path = "lez"` (relative); make it absolute
         // so the helper doesn't depend on cwd (tests run in parallel and
         // can't share cwd).

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -8,53 +8,80 @@ use crate::commands::deploy::{
     cmd_deploy, discover_deployable_programs, discover_program_binaries, extract_program_id,
 };
 use crate::commands::idl::build_idl_for_current_project;
-use crate::commands::localnet::{build_localnet_status_for_project, cmd_localnet, LocalnetAction};
+use crate::commands::localnet::{
+    build_localnet_status_for_project, cmd_localnet, cmd_localnet_reset, LocalnetAction,
+};
 use crate::commands::run_state::{
     compute_program_hashes, current_localnet_pid, deploy_can_be_skipped, load_state, save_state,
     RunDeployState,
 };
+use crate::commands::setup::ensure_default_wallet_seeded;
 use crate::commands::wallet::{cmd_wallet_topup_inner, TopupOutcome};
 use crate::constants::{DEFAULT_RUN_LOCALNET_TIMEOUT_SEC, SPEL_BIN_REL_PATH};
-use crate::model::{LocalnetOwnership, Project};
+use crate::model::{LocalnetOwnership, Project, RunProfile};
 use crate::project::{load_project, resolve_repo_path, run_in_project_dir};
+use crate::state::prepare_wallet_home;
 use crate::DynResult;
 
+/// Number of seconds to wait for block production after a reset before
+/// considering the freshly-started localnet healthy. Matches the upper
+/// envelope of `cmd_localnet_reset`'s default verification timeout.
+const RESET_VERIFY_TIMEOUT_SEC: u64 = 30;
+
 /// All knobs that control a `lgs run` invocation. Built by `cli.rs` from
-/// the parsed `RunArgs` (with conflicting-flag resolution into `Option<Vec<_>>`)
+/// the parsed `RunArgs` (with conflicting-flag resolution into `Option<bool>`)
 /// and consumed by `cmd_run`. Grouping the fields together prevents the
 /// positional-swap class of bug.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct RunInvocation {
+    pub(crate) profile: Option<String>,
+    pub(crate) reset: Option<bool>,
     pub(crate) post_deploy_override: Option<Vec<String>>,
     pub(crate) localnet_timeout_sec: Option<u64>,
 }
 
 pub(crate) fn cmd_run(inv: RunInvocation) -> DynResult<()> {
     let project = load_project()?;
+    let resolved = project.config.run.resolve_profile(inv.profile.as_deref())?;
+    if let Some(name) = inv.profile.as_deref() {
+        println!("Using [run.profiles.{name}]");
+    } else if let Some(name) = project.config.run.default_profile.as_deref() {
+        println!("Using [run.profiles.{name}] (default_profile)");
+    }
     let hooks = inv
         .post_deploy_override
-        .unwrap_or_else(|| project.config.run.post_deploy.clone());
+        .unwrap_or_else(|| resolved.post_deploy.clone());
     let localnet_timeout_sec = inv
         .localnet_timeout_sec
         .unwrap_or(DEFAULT_RUN_LOCALNET_TIMEOUT_SEC);
+
+    let params = PipelineParams {
+        resolved: resolved.clone(),
+        hooks,
+        reset_override: inv.reset,
+        localnet_timeout_sec,
+    };
 
     // Anchor the pipeline at the discovered project root. Otherwise commands
     // that resolve paths relative to cwd (`cmd_build_shortcut`,
     // `build_idl_for_current_project`, etc.) would build/deploy from whichever
     // subdirectory the user invoked `lgs run` in.
-    run_in_project_dir(Some(&project.root), || {
-        run_pipeline_once(&project, &hooks, localnet_timeout_sec)
-    })
+    run_in_project_dir(Some(&project.root), || run_pipeline_once(&project, &params))
 }
 
-fn run_pipeline_once(
-    project: &Project,
-    hooks: &[String],
+#[derive(Clone)]
+struct PipelineParams {
+    resolved: RunProfile,
+    hooks: Vec<String>,
+    reset_override: Option<bool>,
     localnet_timeout_sec: u64,
-) -> DynResult<()> {
-    let has_hooks = !hooks.is_empty();
+}
+
+fn run_pipeline_once(project: &Project, params: &PipelineParams) -> DynResult<()> {
+    let has_hooks = !params.hooks.is_empty();
     // Steps: build, build idl, localnet, topup, deploy, [+1 if hooks]
     let total_steps: u32 = if has_hooks { 6 } else { 5 };
+    let effective_reset = params.reset_override.unwrap_or(params.resolved.reset);
 
     // Step 1: Build (chains setup internally)
     println!("[1/{total_steps}] Building...");
@@ -64,9 +91,27 @@ fn run_pipeline_once(
     println!("[2/{total_steps}] Building IDL...");
     build_idl_for_current_project()?;
 
-    // Step 3: Ensure localnet is running.
-    println!("[3/{total_steps}] Ensuring localnet...");
-    ensure_localnet(project, localnet_timeout_sec)?;
+    // Step 3: Reset OR ensure localnet.
+    if effective_reset {
+        println!("[3/{total_steps}] Resetting localnet (wipes sequencer + wallet)...");
+        reset_for_run(project)?;
+        // A reset wipes on-chain state, so any prior deploy is gone:
+        // the next deploy must run regardless of hash equality. Tolerate
+        // NotFound (no prior run); surface anything else.
+        let state_file = project.root.join(".scaffold/state/run_deploy.json");
+        match std::fs::remove_file(&state_file) {
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(e).with_context(|| {
+                    format!("clear stale deploy state at {}", state_file.display())
+                });
+            }
+        }
+    } else {
+        println!("[3/{total_steps}] Ensuring localnet...");
+        ensure_localnet(project, params.localnet_timeout_sec)?;
+    }
 
     // Step 4: Wallet topup
     println!("[4/{total_steps}] Topping up wallet...");
@@ -84,9 +129,9 @@ fn run_pipeline_once(
     // instance that received it. A `lgs localnet stop && start` cycle
     // changes the sequencer PID and wipes on-chain state, so PID equality
     // is the gate that prevents stale-deploy false positives. To force a
-    // re-deploy without restarting localnet, delete
-    // `.scaffold/state/run_deploy.json` manually (a `--reset` switch
-    // arrives in a later branch of this stack).
+    // re-deploy without restarting localnet, use `--reset` (which also
+    // clears the cache) or delete `.scaffold/state/run_deploy.json`
+    // manually.
     let current_hashes = compute_program_hashes(project)?;
     let current_pid = current_localnet_pid(project);
     let prior = load_state(project);
@@ -117,11 +162,11 @@ fn run_pipeline_once(
 
     // Step 6: Post-deploy hooks (or summary)
     if has_hooks {
-        let n = hooks.len();
+        let n = params.hooks.len();
         println!("[6/{total_steps}] Running {n} post-deploy hook(s)...");
         check_env_var_suffix_collisions(&deployed.programs)?;
         warn_on_rewritten_program_names(&deployed.programs);
-        for (i, hook) in hooks.iter().enumerate() {
+        for (i, hook) in params.hooks.iter().enumerate() {
             println!("===> post_deploy[{}/{n}]: {hook}", i + 1);
             run_post_deploy_hook(project, hook, &deployed)?;
             println!("<=== post_deploy[{}/{n}] OK", i + 1);
@@ -131,6 +176,48 @@ fn run_pipeline_once(
     }
 
     Ok(())
+}
+
+fn reset_for_run(project: &Project) -> DynResult<()> {
+    let lez = resolve_repo_path(project, &project.config.lez, "lez")?;
+    let state_path = project.root.join(".scaffold/state/localnet.state");
+    let log_path = project.root.join(".scaffold/logs/sequencer.log");
+    let localnet_addr = format!("127.0.0.1:{}", project.config.localnet.port);
+    cmd_localnet_reset(
+        project,
+        &lez,
+        &state_path,
+        &log_path,
+        &localnet_addr,
+        false, // dry_run — actually perform the reset
+        true,  // yes — non-interactive; run is the user-initiated action that authorizes it
+        true,  // reset_wallet — full wipe; reseed_after_wipe re-seeds below
+        RESET_VERIFY_TIMEOUT_SEC,
+    )?;
+    // The wipe deleted the wallet directory and state file; the next pipeline
+    // step (topup) would fail without a re-seed. Recover by calling the same
+    // primitives `cmd_setup` invokes when the wallet is absent. If the
+    // re-seed itself fails, stop the sequencer we just started so we don't
+    // strand the project in a half-wiped state with a running daemon.
+    if let Err(err) = reseed_after_wipe(project) {
+        let _ = cmd_localnet(LocalnetAction::Stop);
+        return Err(err.context(
+            "post-reset wallet re-seed failed; sequencer was stopped to avoid leaving a half-wiped project",
+        ));
+    }
+    Ok(())
+}
+
+/// Re-seed the project's default wallet after `cmd_localnet_reset` wiped
+/// it. Reuses the same primitives `cmd_setup` calls so the resulting
+/// `wallet.state` is byte-equivalent to a fresh `lgs setup`. Extracted as
+/// its own helper so the byte-equivalence test can drive it directly
+/// without booting a real sequencer.
+fn reseed_after_wipe(project: &Project) -> DynResult<()> {
+    let lez = resolve_repo_path(project, &project.config.lez, "lez")?;
+    let wallet_home = project.root.join(&project.config.wallet_home_dir);
+    prepare_wallet_home(&lez, &wallet_home)?;
+    ensure_default_wallet_seeded(&project.root, &wallet_home)
 }
 
 /// Per-program metadata exposed to post-deploy hooks via env vars.
@@ -992,5 +1079,89 @@ mod tests {
         // No assertion: the contract is "doesn't panic, prints only for
         // rewritten names". The print_deploy_summary integration tests
         // already lock in the user-visible output shape.
+    }
+
+    /// After `lgs run --reset`, `wallet.state` must be byte-equivalent to a
+    /// freshly-seeded clean-setup baseline. This test enforces the
+    /// "reuse, don't duplicate" contract on the re-seed path: if anyone
+    /// reaches into `reset_for_run` and adds a parallel seed implementation,
+    /// the byte comparison breaks.
+    ///
+    /// We exercise the same primitives `cmd_setup` calls
+    /// (`prepare_wallet_home` + `ensure_default_wallet_seeded`) twice
+    /// against fresh state — once standing in for `cmd_setup`, once
+    /// standing in for the post-reset re-seed — and assert byte equality.
+    /// Booting a real sequencer is intentionally out of scope; this is the
+    /// part of the chain that isn't already covered by `cmd_localnet_reset`'s
+    /// own tests.
+    #[test]
+    fn reseed_after_wipe_matches_setup_baseline() {
+        use crate::commands::setup::ensure_default_wallet_seeded;
+        use crate::commands::wallet_support::{wallet_state_path, WALLET_CONFIG_PRIMARY};
+        use crate::state::prepare_wallet_home;
+
+        // Two parallel project trees with identical fake LEZ wallet configs.
+        // Both start from the same state a freshly-wiped project would: LEZ
+        // bundled wallet config exists on disk, but no `.scaffold/wallet/`.
+        let baseline = tempfile::tempdir().expect("baseline tempdir");
+        let post_reset = tempfile::tempdir().expect("post_reset tempdir");
+
+        for root in [baseline.path(), post_reset.path()] {
+            let lez_cfg_dir = root.join("lez/wallet/configs/debug");
+            std::fs::create_dir_all(&lez_cfg_dir).expect("create lez cfg dir");
+            std::fs::write(
+                lez_cfg_dir.join("wallet_config.json"),
+                r#"{
+  "initial_accounts": [
+    { "Public": { "account_id": "6iArKUXxhUJqS7kCaPNhwMWt3ro71PDyBj7jwAyE2VQV" } }
+  ]
+}"#,
+            )
+            .expect("write lez wallet config");
+        }
+
+        // Baseline: drive `cmd_setup`'s seed primitives directly.
+        {
+            let lez = baseline.path().join("lez");
+            let wallet_home = baseline.path().join(".scaffold/wallet");
+            prepare_wallet_home(&lez, &wallet_home).expect("baseline prepare");
+            ensure_default_wallet_seeded(baseline.path(), &wallet_home).expect("baseline seed");
+        }
+
+        // Post-reset: drive the actual helper `reset_for_run` calls.
+        // If anyone reaches into `reset_for_run` and adds a parallel seed
+        // implementation, this test breaks — that's the contract this
+        // assertion enforces over time.
+        // The fixture sets `lez.path = "lez"` (relative); make it absolute
+        // so the helper doesn't depend on cwd (tests run in parallel and
+        // can't share cwd).
+        let mut project = make_test_project(post_reset.path().to_path_buf());
+        project.config.lez.path = post_reset.path().join("lez").to_string_lossy().to_string();
+        reseed_after_wipe(&project).expect("post-reset reseed");
+
+        let baseline_state =
+            std::fs::read(wallet_state_path(baseline.path())).expect("read baseline state");
+        let post_reset_state =
+            std::fs::read(wallet_state_path(post_reset.path())).expect("read post-reset state");
+        assert_eq!(
+            baseline_state, post_reset_state,
+            "post-reset wallet.state must be byte-equivalent to clean-setup baseline"
+        );
+
+        let baseline_cfg = std::fs::read(
+            baseline
+                .path()
+                .join(".scaffold/wallet")
+                .join(WALLET_CONFIG_PRIMARY),
+        )
+        .expect("read baseline cfg");
+        let post_reset_cfg = std::fs::read(
+            post_reset
+                .path()
+                .join(".scaffold/wallet")
+                .join(WALLET_CONFIG_PRIMARY),
+        )
+        .expect("read post-reset cfg");
+        assert_eq!(baseline_cfg, post_reset_cfg);
     }
 }

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -79,7 +79,10 @@ fn sync_pinned_repo(repo: &RepoRef, path: &Path, label: &str) -> DynResult<()> {
     sync_repo_to_pin_at_path_with_opts(path, &repo.source, &repo.pin, label, opts)
 }
 
-fn ensure_default_wallet_seeded(project_root: &Path, wallet_home: &Path) -> DynResult<()> {
+pub(crate) fn ensure_default_wallet_seeded(
+    project_root: &Path,
+    wallet_home: &Path,
+) -> DynResult<()> {
     let should_seed = match read_default_wallet_address(project_root) {
         Ok(Some(existing)) => {
             println!("default wallet already configured: {existing}");

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -88,7 +88,10 @@ fn sync_pinned_repo(repo: &RepoRef, path: &Path, label: &str) -> DynResult<()> {
     sync_repo_to_pin_at_path_with_opts(path, &repo.source, &repo.pin, label, opts)
 }
 
-fn ensure_default_wallet_seeded(project_root: &Path, wallet_home: &Path) -> DynResult<()> {
+pub(crate) fn ensure_default_wallet_seeded(
+    project_root: &Path,
+    wallet_home: &Path,
+) -> DynResult<()> {
     let should_seed = match read_default_wallet_address(project_root) {
         Ok(Some(existing)) => {
             println!("default wallet already configured: {existing}");

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,7 +29,7 @@ use crate::constants::{
 };
 use crate::model::{
     BasecampConfig, Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig, ModuleEntry,
-    ModuleRole, RepoBuild, RepoRef, RunConfig,
+    ModuleRole, RepoBuild, RepoRef, RunConfig, RunProfile,
 };
 use crate::DynResult;
 
@@ -93,15 +93,52 @@ pub(crate) fn parse_config(text: &str) -> DynResult<Config> {
     })
 }
 
-/// Parse the `[run]` section. Branch-1 surface is the inline `post_deploy`
-/// only — string (single hook) or array (multiple). `[run.profiles.*]`,
-/// `default_profile`, and `reset` arrive in later branches.
 fn parse_run(doc: &DocumentMut) -> DynResult<RunConfig> {
     let Some(run_table) = doc.get("run").and_then(Item::as_table) else {
         return Ok(RunConfig::default());
     };
-    let post_deploy = parse_post_deploy(run_table.get("post_deploy"))?;
-    Ok(RunConfig { post_deploy })
+
+    let default_profile = read_string(run_table, "default_profile");
+    let inline_reset = run_table
+        .get("reset")
+        .and_then(Item::as_value)
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let inline_post_deploy = parse_post_deploy(run_table.get("post_deploy"))?;
+
+    let mut profiles: std::collections::BTreeMap<String, RunProfile> =
+        std::collections::BTreeMap::new();
+    if let Some(profiles_table) = run_table.get("profiles").and_then(Item::as_table) {
+        for (name, item) in profiles_table.iter() {
+            let table = item.as_table().ok_or_else(|| {
+                anyhow!("invalid scaffold.toml: [run.profiles.{name}] is not a table")
+            })?;
+            let reset = table
+                .get("reset")
+                .and_then(Item::as_value)
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let post_deploy = parse_post_deploy(table.get("post_deploy"))?;
+            profiles.insert(name.to_string(), RunProfile { reset, post_deploy });
+        }
+    }
+
+    if let Some(name) = &default_profile {
+        if !profiles.contains_key(name) {
+            bail!(
+                "invalid scaffold.toml: [run].default_profile = {name:?} but no [run.profiles.{name}] section"
+            );
+        }
+    }
+
+    Ok(RunConfig {
+        default_profile,
+        inline: RunProfile {
+            reset: inline_reset,
+            post_deploy: inline_post_deploy,
+        },
+        profiles,
+    })
 }
 
 fn parse_post_deploy(item: Option<&Item>) -> DynResult<Vec<String>> {
@@ -431,15 +468,52 @@ pub(crate) fn serialize_config(cfg: &Config) -> DynResult<String> {
 }
 
 fn write_run_config(doc: &mut DocumentMut, run: &RunConfig) -> DynResult<()> {
-    if run.post_deploy.is_empty() {
+    let has_inline = run.inline.reset || !run.inline.post_deploy.is_empty();
+    let has_default_profile = run.default_profile.is_some();
+    let has_profiles = !run.profiles.is_empty();
+    if !has_inline && !has_default_profile && !has_profiles {
         return Ok(());
     }
-    for hook in &run.post_deploy {
-        check_toml_value("run.post_deploy", hook)?;
-    }
+
     let run_item = doc.entry("run").or_insert(Item::Table(Table::new()));
     let run_table = run_item.as_table_mut().expect("run table");
-    run_table["post_deploy"] = post_deploy_value(&run.post_deploy);
+    if let Some(name) = &run.default_profile {
+        check_toml_value("run.default_profile", name)?;
+        run_table["default_profile"] = value(name);
+    }
+    if run.inline.reset {
+        run_table["reset"] = value(true);
+    }
+    if !run.inline.post_deploy.is_empty() {
+        for hook in &run.inline.post_deploy {
+            check_toml_value("run.post_deploy", hook)?;
+        }
+        run_table["post_deploy"] = post_deploy_value(&run.inline.post_deploy);
+    }
+
+    if has_profiles {
+        for (name, profile) in &run.profiles {
+            check_toml_value(&format!("run.profiles.{name}"), name)?;
+            for hook in &profile.post_deploy {
+                check_toml_value(&format!("run.profiles.{name}.post_deploy"), hook)?;
+            }
+            let table = ensure_subtable(doc, "run", "profiles");
+            // ensure_subtable returns the `profiles` table; we need a
+            // sub-sub-table keyed by `name`.
+            table.set_implicit(true);
+            let profile_table = table
+                .entry(name)
+                .or_insert(Item::Table(Table::new()))
+                .as_table_mut()
+                .expect("profile table");
+            if profile.reset {
+                profile_table["reset"] = value(true);
+            }
+            if !profile.post_deploy.is_empty() {
+                profile_table["post_deploy"] = post_deploy_value(&profile.post_deploy);
+            }
+        }
+    }
     Ok(())
 }
 
@@ -572,6 +646,10 @@ pub(crate) fn default_lgpm_repo(pin: &str) -> RepoRef {
 mod tests {
     use super::*;
     use crate::constants::{DEFAULT_BASECAMP_PIN, DEFAULT_LEZ, DEFAULT_LGPM_PIN, DEFAULT_SPEL};
+
+    fn base_config() -> Config {
+        parse_config(&minimal_v0_2_0()).expect("parse minimal v0.2.0")
+    }
 
     fn minimal_v0_2_0() -> String {
         format!(
@@ -797,5 +875,99 @@ role = "project"
         );
         let cfg = parse_config(&toml).expect("parse");
         assert_eq!(cfg.lez.path, "/abs/lez");
+    }
+
+    #[test]
+    fn parse_config_with_run_profile_subsection() {
+        let toml = minimal_v0_2_0()
+            + "[run.profiles.e2e]\nreset = true\npost_deploy = [\"scripts/e2e.sh\"]\n";
+        let cfg = parse_config(&toml).expect("parse");
+        let prof = cfg.run.profiles.get("e2e").expect("e2e present");
+        assert!(prof.reset);
+        assert_eq!(prof.post_deploy, vec!["scripts/e2e.sh".to_string()]);
+    }
+
+    #[test]
+    fn parse_config_default_profile_must_exist() {
+        let toml = minimal_v0_2_0() + "[run]\ndefault_profile = \"missing\"\n";
+        let err = parse_config(&toml).unwrap_err();
+        assert!(
+            err.to_string().contains("missing")
+                && err.to_string().contains("[run.profiles.missing]"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn parse_config_default_profile_resolves() {
+        let toml = minimal_v0_2_0()
+            + "[run]\ndefault_profile = \"play\"\n[run.profiles.play]\npost_deploy = \"echo play\"\n";
+        let cfg = parse_config(&toml).expect("parse");
+        assert_eq!(cfg.run.default_profile.as_deref(), Some("play"));
+        let resolved = cfg.run.resolve_profile(None).expect("resolve");
+        assert_eq!(resolved.post_deploy, vec!["echo play".to_string()]);
+    }
+
+    #[test]
+    fn resolve_profile_explicit_selector_wins() {
+        let toml = minimal_v0_2_0()
+            + "[run]\npost_deploy = [\"echo inline\"]\ndefault_profile = \"play\"\n[run.profiles.play]\npost_deploy = \"echo play\"\n[run.profiles.e2e]\npost_deploy = \"echo e2e\"\n";
+        let cfg = parse_config(&toml).expect("parse");
+        let r = cfg.run.resolve_profile(Some("e2e")).expect("resolve");
+        assert_eq!(r.post_deploy, vec!["echo e2e".to_string()]);
+    }
+
+    #[test]
+    fn resolve_profile_unknown_name_errors_with_known_list() {
+        let toml = minimal_v0_2_0()
+            + "[run.profiles.play]\npost_deploy = \"echo play\"\n[run.profiles.e2e]\npost_deploy = \"echo e2e\"\n";
+        let cfg = parse_config(&toml).expect("parse");
+        let err = cfg.run.resolve_profile(Some("missing")).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("missing"), "{msg}");
+        assert!(msg.contains("play") && msg.contains("e2e"), "{msg}");
+    }
+
+    #[test]
+    fn resolve_profile_falls_back_to_inline_when_no_default() {
+        let toml = minimal_v0_2_0() + "[run]\nreset = true\n";
+        let cfg = parse_config(&toml).expect("parse");
+        let r = cfg.run.resolve_profile(None).expect("resolve");
+        assert!(r.reset);
+        assert!(r.post_deploy.is_empty());
+    }
+
+    #[test]
+    fn run_profiles_round_trip_through_parse_serialize() {
+        let toml = minimal_v0_2_0()
+            + "[run]\ndefault_profile = \"dev\"\n[run.profiles.dev]\npost_deploy = [\"echo dev\"]\n[run.profiles.e2e]\nreset = true\npost_deploy = [\"echo e2e\"]\n";
+        let cfg1 = parse_config(&toml).expect("parse");
+        let serialized = serialize_config(&cfg1).expect("serialize");
+        let cfg2 = parse_config(&serialized).expect("re-parse");
+        assert_eq!(cfg2.run.default_profile.as_deref(), Some("dev"));
+        assert_eq!(cfg2.run.profiles.len(), 2);
+        let e2e = cfg2.run.profiles.get("e2e").expect("e2e");
+        assert!(e2e.reset);
+        assert_eq!(e2e.post_deploy, vec!["echo e2e".to_string()]);
+    }
+
+    #[test]
+    fn serialize_rejects_newline_in_profile_post_deploy() {
+        let mut cfg = base_config();
+        let mut profiles = std::collections::BTreeMap::new();
+        profiles.insert(
+            "dev".to_string(),
+            RunProfile {
+                reset: false,
+                post_deploy: vec!["echo a\n[run.profiles.evil]".to_string()],
+            },
+        );
+        cfg.run = RunConfig {
+            profiles,
+            ..RunConfig::default()
+        };
+        let err = serialize_config(&cfg).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("post_deploy") && msg.contains("dev"), "{msg}");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,7 +29,7 @@ use crate::constants::{
 };
 use crate::model::{
     BasecampConfig, Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig, ModuleEntry,
-    ModuleRole, RepoBuild, RepoRef, RunConfig,
+    ModuleRole, RepoBuild, RepoRef, RunConfig, RunProfile,
 };
 use crate::DynResult;
 
@@ -93,15 +93,52 @@ pub(crate) fn parse_config(text: &str) -> DynResult<Config> {
     })
 }
 
-/// Parse the `[run]` section. Branch-1 surface is the inline `post_deploy`
-/// only — string (single hook) or array (multiple). `[run.profiles.*]`,
-/// `default_profile`, and `reset` arrive in later branches.
 fn parse_run(doc: &DocumentMut) -> DynResult<RunConfig> {
     let Some(run_table) = doc.get("run").and_then(Item::as_table) else {
         return Ok(RunConfig::default());
     };
-    let post_deploy = parse_post_deploy(run_table.get("post_deploy"))?;
-    Ok(RunConfig { post_deploy })
+
+    let default_profile = read_string(run_table, "default_profile");
+    let inline_reset = run_table
+        .get("reset")
+        .and_then(Item::as_value)
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let inline_post_deploy = parse_post_deploy(run_table.get("post_deploy"))?;
+
+    let mut profiles: std::collections::BTreeMap<String, RunProfile> =
+        std::collections::BTreeMap::new();
+    if let Some(profiles_table) = run_table.get("profiles").and_then(Item::as_table) {
+        for (name, item) in profiles_table.iter() {
+            let table = item.as_table().ok_or_else(|| {
+                anyhow!("invalid scaffold.toml: [run.profiles.{name}] is not a table")
+            })?;
+            let reset = table
+                .get("reset")
+                .and_then(Item::as_value)
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let post_deploy = parse_post_deploy(table.get("post_deploy"))?;
+            profiles.insert(name.to_string(), RunProfile { reset, post_deploy });
+        }
+    }
+
+    if let Some(name) = &default_profile {
+        if !profiles.contains_key(name) {
+            bail!(
+                "invalid scaffold.toml: [run].default_profile = {name:?} but no [run.profiles.{name}] section"
+            );
+        }
+    }
+
+    Ok(RunConfig {
+        default_profile,
+        inline: RunProfile {
+            reset: inline_reset,
+            post_deploy: inline_post_deploy,
+        },
+        profiles,
+    })
 }
 
 fn parse_post_deploy(item: Option<&Item>) -> DynResult<Vec<String>> {
@@ -478,15 +515,52 @@ pub(crate) fn serialize_config(cfg: &Config) -> DynResult<String> {
 }
 
 fn write_run_config(doc: &mut DocumentMut, run: &RunConfig) -> DynResult<()> {
-    if run.post_deploy.is_empty() {
+    let has_inline = run.inline.reset || !run.inline.post_deploy.is_empty();
+    let has_default_profile = run.default_profile.is_some();
+    let has_profiles = !run.profiles.is_empty();
+    if !has_inline && !has_default_profile && !has_profiles {
         return Ok(());
     }
-    for hook in &run.post_deploy {
-        check_toml_value("run.post_deploy", hook)?;
-    }
+
     let run_item = doc.entry("run").or_insert(Item::Table(Table::new()));
     let run_table = run_item.as_table_mut().expect("run table");
-    run_table["post_deploy"] = post_deploy_value(&run.post_deploy);
+    if let Some(name) = &run.default_profile {
+        check_toml_value("run.default_profile", name)?;
+        run_table["default_profile"] = value(name);
+    }
+    if run.inline.reset {
+        run_table["reset"] = value(true);
+    }
+    if !run.inline.post_deploy.is_empty() {
+        for hook in &run.inline.post_deploy {
+            check_toml_value("run.post_deploy", hook)?;
+        }
+        run_table["post_deploy"] = post_deploy_value(&run.inline.post_deploy);
+    }
+
+    if has_profiles {
+        for (name, profile) in &run.profiles {
+            check_toml_value(&format!("run.profiles.{name}"), name)?;
+            for hook in &profile.post_deploy {
+                check_toml_value(&format!("run.profiles.{name}.post_deploy"), hook)?;
+            }
+            let table = ensure_subtable(doc, "run", "profiles");
+            // ensure_subtable returns the `profiles` table; we need a
+            // sub-sub-table keyed by `name`.
+            table.set_implicit(true);
+            let profile_table = table
+                .entry(name)
+                .or_insert(Item::Table(Table::new()))
+                .as_table_mut()
+                .expect("profile table");
+            if profile.reset {
+                profile_table["reset"] = value(true);
+            }
+            if !profile.post_deploy.is_empty() {
+                profile_table["post_deploy"] = post_deploy_value(&profile.post_deploy);
+            }
+        }
+    }
     Ok(())
 }
 
@@ -619,6 +693,10 @@ pub(crate) fn default_lgpm_repo(pin: &str) -> RepoRef {
 mod tests {
     use super::*;
     use crate::constants::{DEFAULT_BASECAMP_PIN, DEFAULT_LEZ, DEFAULT_LGPM_PIN, DEFAULT_SPEL};
+
+    fn base_config() -> Config {
+        parse_config(&minimal_v0_2_0()).expect("parse minimal v0.2.0")
+    }
 
     fn minimal_v0_2_0() -> String {
         format!(
@@ -917,5 +995,99 @@ role = "project"
         );
         let cfg = parse_config(&toml).expect("parse");
         assert_eq!(cfg.lez.path, "/abs/lez");
+    }
+
+    #[test]
+    fn parse_config_with_run_profile_subsection() {
+        let toml = minimal_v0_2_0()
+            + "[run.profiles.e2e]\nreset = true\npost_deploy = [\"scripts/e2e.sh\"]\n";
+        let cfg = parse_config(&toml).expect("parse");
+        let prof = cfg.run.profiles.get("e2e").expect("e2e present");
+        assert!(prof.reset);
+        assert_eq!(prof.post_deploy, vec!["scripts/e2e.sh".to_string()]);
+    }
+
+    #[test]
+    fn parse_config_default_profile_must_exist() {
+        let toml = minimal_v0_2_0() + "[run]\ndefault_profile = \"missing\"\n";
+        let err = parse_config(&toml).unwrap_err();
+        assert!(
+            err.to_string().contains("missing")
+                && err.to_string().contains("[run.profiles.missing]"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn parse_config_default_profile_resolves() {
+        let toml = minimal_v0_2_0()
+            + "[run]\ndefault_profile = \"play\"\n[run.profiles.play]\npost_deploy = \"echo play\"\n";
+        let cfg = parse_config(&toml).expect("parse");
+        assert_eq!(cfg.run.default_profile.as_deref(), Some("play"));
+        let resolved = cfg.run.resolve_profile(None).expect("resolve");
+        assert_eq!(resolved.post_deploy, vec!["echo play".to_string()]);
+    }
+
+    #[test]
+    fn resolve_profile_explicit_selector_wins() {
+        let toml = minimal_v0_2_0()
+            + "[run]\npost_deploy = [\"echo inline\"]\ndefault_profile = \"play\"\n[run.profiles.play]\npost_deploy = \"echo play\"\n[run.profiles.e2e]\npost_deploy = \"echo e2e\"\n";
+        let cfg = parse_config(&toml).expect("parse");
+        let r = cfg.run.resolve_profile(Some("e2e")).expect("resolve");
+        assert_eq!(r.post_deploy, vec!["echo e2e".to_string()]);
+    }
+
+    #[test]
+    fn resolve_profile_unknown_name_errors_with_known_list() {
+        let toml = minimal_v0_2_0()
+            + "[run.profiles.play]\npost_deploy = \"echo play\"\n[run.profiles.e2e]\npost_deploy = \"echo e2e\"\n";
+        let cfg = parse_config(&toml).expect("parse");
+        let err = cfg.run.resolve_profile(Some("missing")).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("missing"), "{msg}");
+        assert!(msg.contains("play") && msg.contains("e2e"), "{msg}");
+    }
+
+    #[test]
+    fn resolve_profile_falls_back_to_inline_when_no_default() {
+        let toml = minimal_v0_2_0() + "[run]\nreset = true\n";
+        let cfg = parse_config(&toml).expect("parse");
+        let r = cfg.run.resolve_profile(None).expect("resolve");
+        assert!(r.reset);
+        assert!(r.post_deploy.is_empty());
+    }
+
+    #[test]
+    fn run_profiles_round_trip_through_parse_serialize() {
+        let toml = minimal_v0_2_0()
+            + "[run]\ndefault_profile = \"dev\"\n[run.profiles.dev]\npost_deploy = [\"echo dev\"]\n[run.profiles.e2e]\nreset = true\npost_deploy = [\"echo e2e\"]\n";
+        let cfg1 = parse_config(&toml).expect("parse");
+        let serialized = serialize_config(&cfg1).expect("serialize");
+        let cfg2 = parse_config(&serialized).expect("re-parse");
+        assert_eq!(cfg2.run.default_profile.as_deref(), Some("dev"));
+        assert_eq!(cfg2.run.profiles.len(), 2);
+        let e2e = cfg2.run.profiles.get("e2e").expect("e2e");
+        assert!(e2e.reset);
+        assert_eq!(e2e.post_deploy, vec!["echo e2e".to_string()]);
+    }
+
+    #[test]
+    fn serialize_rejects_newline_in_profile_post_deploy() {
+        let mut cfg = base_config();
+        let mut profiles = std::collections::BTreeMap::new();
+        profiles.insert(
+            "dev".to_string(),
+            RunProfile {
+                reset: false,
+                post_deploy: vec!["echo a\n[run.profiles.evil]".to_string()],
+            },
+        );
+        cfg.run = RunConfig {
+            profiles,
+            ..RunConfig::default()
+        };
+        let err = serialize_config(&cfg).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("post_deploy") && msg.contains("dev"), "{msg}");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1057,6 +1057,23 @@ role = "project"
         assert!(r.post_deploy.is_empty());
     }
 
+    /// When `[run].default_profile` resolves, inline `[run]` values are
+    /// fully shadowed — they do not merge. Mirrors the `--profile X`
+    /// behavior so the two ways of selecting a profile have identical
+    /// semantics.
+    #[test]
+    fn resolve_profile_default_profile_fully_shadows_inline() {
+        let toml = minimal_v0_2_0()
+            + "[run]\ndefault_profile = \"dev\"\npost_deploy = [\"echo inline\"]\nreset = true\n[run.profiles.dev]\npost_deploy = [\"echo dev\"]\n";
+        let cfg = parse_config(&toml).expect("parse");
+        let r = cfg.run.resolve_profile(None).expect("resolve");
+        assert_eq!(r.post_deploy, vec!["echo dev".to_string()]);
+        assert!(
+            !r.reset,
+            "inline reset must not bleed into resolved profile"
+        );
+    }
+
     #[test]
     fn run_profiles_round_trip_through_parse_serialize() {
         let toml = minimal_v0_2_0()

--- a/src/model.rs
+++ b/src/model.rs
@@ -261,12 +261,52 @@ pub(crate) struct FrameworkIdlConfig {
     pub(crate) path: String,
 }
 
-/// `[run]` — config for the `lgs run` pipeline. Branch-1 surface is the
-/// minimal inline `post_deploy` hook(s); profile/reset support arrives in
-/// later branches of the run-command stack.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct RunProfile {
+    /// Wipe rocksdb + wallet, restart sequencer, re-seed default wallet.
+    /// Broader than `lgs localnet reset`: re-establishes the documented
+    /// fresh-project state for the full deploy cycle. Suitable both as
+    /// a manual recovery and as the per-run default for fixture-based
+    /// deterministic test suites where PDA-key collisions force a wipe.
+    pub(crate) reset: bool,
+    pub(crate) post_deploy: Vec<String>,
+}
+
 #[derive(Clone, Debug, Default)]
 pub(crate) struct RunConfig {
-    /// Inline `[run].post_deploy` — string (single hook) or array (multiple).
-    /// Empty when not configured.
-    pub(crate) post_deploy: Vec<String>,
+    /// Name of a profile in `profiles` to use when no `--profile` flag is
+    /// passed. If `Some` and the named profile exists, it shadows
+    /// `inline`.
+    pub(crate) default_profile: Option<String>,
+    /// Inline `[run]` keys parsed flat (not under a `[run.profiles.*]`
+    /// section) — the unnamed/legacy profile used when no `--profile`
+    /// flag and no `default_profile` resolves.
+    pub(crate) inline: RunProfile,
+    /// Named profiles parsed from `[run.profiles.<name>]` sub-sections.
+    pub(crate) profiles: std::collections::BTreeMap<String, RunProfile>,
+}
+
+impl RunConfig {
+    /// Resolve the effective `RunProfile` for a given `--profile` selector.
+    /// `Some(name)` errors if the profile is absent. `None` falls back to
+    /// `default_profile` if set, else the inline values.
+    pub(crate) fn resolve_profile(&self, selector: Option<&str>) -> anyhow::Result<RunProfile> {
+        match selector {
+            Some(name) => self.profiles.get(name).cloned().ok_or_else(|| {
+                let known: Vec<&str> = self.profiles.keys().map(String::as_str).collect();
+                anyhow::anyhow!(
+                    "scaffold.toml has no [run.profiles.{name}] section. Known profiles: [{}]",
+                    known.join(", ")
+                )
+            }),
+            None => match self.default_profile.as_deref() {
+                Some(name) => self.profiles.get(name).cloned().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "scaffold.toml `[run].default_profile = \"{name}\"` but no matching [run.profiles.{name}] section"
+                    )
+                }),
+                None => Ok(self.inline.clone()),
+            },
+        }
+    }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3609,9 +3609,83 @@ fn run_post_deploy_flag_overrides_configured_hooks() {
 }
 
 fn append_run_config(project_root: &Path, post_deploy: &[&str]) {
+    append_run_config_full(project_root, false, post_deploy);
+}
+
+fn append_run_config_full(project_root: &Path, reset: bool, post_deploy: &[&str]) {
     let toml_path = project_root.join("scaffold.toml");
     let mut content = fs::read_to_string(&toml_path).expect("read scaffold.toml");
     let quoted: Vec<String> = post_deploy.iter().map(|c| format!("\"{c}\"")).collect();
-    content.push_str(&format!("\n[run]\npost_deploy = [{}]\n", quoted.join(", ")));
+    content.push_str(&format!(
+        "\n[run]\nreset = {reset}\npost_deploy = [{}]\n",
+        quoted.join(", ")
+    ));
     fs::write(toml_path, content).expect("write scaffold.toml");
+}
+
+#[test]
+fn run_rejects_both_reset_flags() {
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .arg("run")
+        .arg("--reset")
+        .arg("--no-reset")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn run_help_lists_reset_flags() {
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .arg("run")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--reset").and(predicate::str::contains("--no-reset")));
+}
+
+#[test]
+fn run_with_reset_flag_starts_pipeline() {
+    let temp = tempdir().expect("tempdir");
+    setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .arg("run")
+        .arg("--reset")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("[1/5] Building..."));
+}
+
+#[test]
+fn run_with_reset_in_config_starts_pipeline() {
+    let temp = tempdir().expect("tempdir");
+    setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));
+    append_run_config_full(temp.path(), true, &[]);
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .arg("run")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("[1/5] Building..."));
+}
+
+#[test]
+fn run_no_reset_flag_overrides_config_reset_true() {
+    let temp = tempdir().expect("tempdir");
+    setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));
+    append_run_config_full(temp.path(), true, &[]);
+
+    // --no-reset must beat the config field (CLI overrides config).
+    // We can't observe the reset wasn't called from a mock project, but we
+    // can confirm the pipeline starts (no panic from conflicting parses).
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .arg("run")
+        .arg("--no-reset")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("[1/5] Building..."));
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4163,27 +4163,37 @@ fn run_with_reset_flag_starts_pipeline() {
     let temp = tempdir().expect("tempdir");
     setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));
 
+    // --reset on the CLI: no banner (user typed the word) and pipeline
+    // enters step 1 before the build fails on this mock project.
     Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
         .current_dir(temp.path())
         .arg("run")
         .arg("--reset")
         .assert()
         .failure()
-        .stdout(predicate::str::contains("[1/5] Building..."));
+        .stdout(predicate::str::contains("[1/5] Building..."))
+        .stderr(predicate::str::contains("scaffold.toml requested reset = true").not());
 }
 
 #[test]
-fn run_with_reset_in_config_starts_pipeline() {
+fn run_with_reset_in_config_emits_destructive_intent_warning() {
     let temp = tempdir().expect("tempdir");
     setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));
     append_run_config_full(temp.path(), true, &[]);
 
+    // reset = true in scaffold.toml without --reset on the CLI: the
+    // destructive-intent warning must fire on stderr before step 1, so a
+    // user who didn't realize `lgs run` would wipe their state finds out
+    // before the build runs.
     Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
         .current_dir(temp.path())
         .arg("run")
         .assert()
         .failure()
-        .stdout(predicate::str::contains("[1/5] Building..."));
+        .stdout(predicate::str::contains("[1/5] Building..."))
+        .stderr(predicate::str::contains(
+            "scaffold.toml requested reset = true",
+        ));
 }
 
 #[test]
@@ -4192,14 +4202,15 @@ fn run_no_reset_flag_overrides_config_reset_true() {
     setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));
     append_run_config_full(temp.path(), true, &[]);
 
-    // --no-reset must beat the config field (CLI overrides config).
-    // We can't observe the reset wasn't called from a mock project, but we
-    // can confirm the pipeline starts (no panic from conflicting parses).
+    // --no-reset must beat the config field (CLI overrides config). When
+    // effective_reset is false, the destructive-intent banner must NOT
+    // fire — that's the observable signal proving the override took effect.
     Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
         .current_dir(temp.path())
         .arg("run")
         .arg("--no-reset")
         .assert()
         .failure()
-        .stdout(predicate::str::contains("[1/5] Building..."));
+        .stdout(predicate::str::contains("[1/5] Building..."))
+        .stderr(predicate::str::contains("scaffold.toml requested reset = true").not());
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4123,9 +4123,83 @@ fn run_post_deploy_flag_overrides_configured_hooks() {
 }
 
 fn append_run_config(project_root: &Path, post_deploy: &[&str]) {
+    append_run_config_full(project_root, false, post_deploy);
+}
+
+fn append_run_config_full(project_root: &Path, reset: bool, post_deploy: &[&str]) {
     let toml_path = project_root.join("scaffold.toml");
     let mut content = fs::read_to_string(&toml_path).expect("read scaffold.toml");
     let quoted: Vec<String> = post_deploy.iter().map(|c| format!("\"{c}\"")).collect();
-    content.push_str(&format!("\n[run]\npost_deploy = [{}]\n", quoted.join(", ")));
+    content.push_str(&format!(
+        "\n[run]\nreset = {reset}\npost_deploy = [{}]\n",
+        quoted.join(", ")
+    ));
     fs::write(toml_path, content).expect("write scaffold.toml");
+}
+
+#[test]
+fn run_rejects_both_reset_flags() {
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .arg("run")
+        .arg("--reset")
+        .arg("--no-reset")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn run_help_lists_reset_flags() {
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .arg("run")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--reset").and(predicate::str::contains("--no-reset")));
+}
+
+#[test]
+fn run_with_reset_flag_starts_pipeline() {
+    let temp = tempdir().expect("tempdir");
+    setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .arg("run")
+        .arg("--reset")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("[1/5] Building..."));
+}
+
+#[test]
+fn run_with_reset_in_config_starts_pipeline() {
+    let temp = tempdir().expect("tempdir");
+    setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));
+    append_run_config_full(temp.path(), true, &[]);
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .arg("run")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("[1/5] Building..."));
+}
+
+#[test]
+fn run_no_reset_flag_overrides_config_reset_true() {
+    let temp = tempdir().expect("tempdir");
+    setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));
+    append_run_config_full(temp.path(), true, &[]);
+
+    // --no-reset must beat the config field (CLI overrides config).
+    // We can't observe the reset wasn't called from a mock project, but we
+    // can confirm the pipeline starts (no panic from conflicting parses).
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .arg("run")
+        .arg("--no-reset")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("[1/5] Building..."));
 }


### PR DESCRIPTION
Adds the two run-pipeline knobs that share the same `RunProfile` shape — selecting one of multiple pre-defined profiles, and (per profile or per invocation) wiping the localnet for a fresh deploy cycle.

CLI surface (additive, conflicts resolved into `Option<bool>`): `--profile <NAME>`, `--reset`, `--no-reset`.

scaffold.toml grows `[run].default_profile`, `[run].reset`, and `[run.profiles.<name>]` sub-sections with per-profile `reset` and `post_deploy`.

Reset semantics: stop sequencer → delete rocksdb → restart → verify block production → wipe wallet → re-seed default wallet via the same primitives `cmd_setup` calls. The `reseed_after_wipe_matches_setup_baseline` test locks in that `reseed_after_wipe` keeps calling those primitives (drift in `reset_for_run` itself is guarded by code review, not this test — the docstring is explicit about the scope).

When `reset = true` comes from scaffold.toml (without `--reset` on the CLI), a stderr warning fires before step 1 so a user who didn't realize `lgs run` would wipe their state finds out before the build runs.

## Stack

This is part 4 of a 5-PR stack that splits PR #66:

1. ~~feat/run-mvp~~ — merged (#95)
2. ~~feat/run-deploy-cache~~ — merged (#96)
3. ~~feat/run-multiprogram-env~~ — merged (#98)
4. **feat/run-reset-and-profiles ← this PR** — `--reset` wipe-and-reseed and named `[run.profiles.*]`
5. feat/run-watch (#100) — `--watch` re-runs pipeline on file changes (rebased onto this branch)

Base for this PR is `master` (parts 1–3 are landed).

## Replaces part of

#66 — PR #66 will be retired by editing its description once this stack lands.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo check --all-targets`
- [x] `cargo test --all-targets` (155 passed; new coverage: 5 CLI scenarios for reset flag conflicts/help/pipeline start, 7 config.rs round-trip tests for `[run.profiles.*]` and `default_profile` including the inline-shadowing contract, plus the byte-equivalence reseed test, plus stderr assertions on the destructive-intent warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>