### PR TITLE
feat(run): --watch re-runs pipeline on changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -244,6 +250,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +378,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -567,6 +597,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +639,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7b65860415f949f23fa882e669f2dbd4a0f0eeb1acdd56790b30494afd7da2f"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,7 +676,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "redox_syscall",
 ]
@@ -641,6 +711,7 @@ dependencies = [
  "flate2",
  "include_dir",
  "indicatif",
+ "notify",
  "predicates",
  "serde",
  "serde_json",
@@ -670,10 +741,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "num-traits"
@@ -793,7 +895,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -845,7 +947,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1313,7 +1415,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1364,11 +1466,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1377,7 +1488,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1391,19 +1502,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1413,9 +1545,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1431,9 +1575,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1443,9 +1599,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1520,7 +1688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ clap_complete = "4.5"
 include_dir = "0.7.4"
 indicatif = "0.17"
 flate2 = "1.1.0"
+notify = "6.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.140"
 sha2 = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ clap_complete = "4.5"
 include_dir = "0.7.4"
 indicatif = "0.17"
 flate2 = "1.1.0"
+notify = "6.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.140"
 sha2 = "0.10"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -231,6 +231,11 @@ struct RunArgs {
     /// for this invocation. Conflicts with --no-post-deploy.
     #[arg(long, value_name = "CMD", conflicts_with = "no_post_deploy")]
     post_deploy: Vec<String>,
+    /// After the initial run, watch the project for file changes and
+    /// re-run the pipeline (build + idl + deploy + hooks) on each change.
+    /// Localnet is reused; reset is skipped on re-runs.
+    #[arg(long)]
+    watch: bool,
 }
 
 #[derive(Debug, clap::Args)]
@@ -547,6 +552,7 @@ pub(crate) fn run(args: Vec<String>) -> DynResult<()> {
                 profile: args.profile,
                 reset,
                 post_deploy_override: post_deploy,
+                watch: args.watch,
             })
         }
         Some(Commands::Report(args)) => cmd_report(args.out, args.tail),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -282,6 +282,11 @@ struct RunArgs {
     post_deploy: Vec<String>,
     #[arg(long, value_name = "SECS", help = RUN_LOCALNET_TIMEOUT_HELP.as_str())]
     localnet_timeout: Option<u64>,
+    /// After the initial run, watch the project for file changes and
+    /// re-run the pipeline (build + idl + deploy + hooks) on each change.
+    /// Localnet is reused; reset is skipped on re-runs.
+    #[arg(long)]
+    watch: bool,
 }
 
 #[derive(Debug, clap::Args)]
@@ -647,6 +652,7 @@ pub(crate) fn run(args: Vec<String>) -> DynResult<()> {
                 reset,
                 post_deploy_override: post_deploy,
                 localnet_timeout_sec: args.localnet_timeout,
+                watch: args.watch,
             })
         }
         Some(Commands::Report(args)) => cmd_report(args.out, args.tail),

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,7 +1,10 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::mpsc;
+use std::time::Duration;
 
 use anyhow::{bail, Context};
+use notify::{RecursiveMode, Watcher};
 
 use crate::commands::build::cmd_build_shortcut;
 use crate::commands::deploy::{
@@ -22,6 +25,11 @@ use crate::project::{load_project, resolve_repo_path};
 use crate::state::prepare_wallet_home;
 use crate::DynResult;
 
+/// Debounce window for the watch loop. Filesystem events from a single
+/// editor save typically arrive in a flurry; sleep this long after the
+/// first event before re-running so we coalesce them.
+const WATCH_DEBOUNCE_MS: u64 = 500;
+
 /// Number of seconds to wait for block production after a reset before
 /// considering the freshly-started localnet healthy. Matches the upper
 /// envelope of `cmd_localnet_reset`'s default verification timeout.
@@ -36,6 +44,7 @@ pub(crate) struct RunInvocation {
     pub(crate) profile: Option<String>,
     pub(crate) reset: Option<bool>,
     pub(crate) post_deploy_override: Option<Vec<String>>,
+    pub(crate) watch: bool,
 }
 
 pub(crate) fn cmd_run(inv: RunInvocation) -> DynResult<()> {
@@ -50,13 +59,23 @@ pub(crate) fn cmd_run(inv: RunInvocation) -> DynResult<()> {
         .post_deploy_override
         .unwrap_or_else(|| resolved.post_deploy.clone());
 
-    let params = PipelineParams {
+    let mut params = PipelineParams {
         resolved: resolved.clone(),
         hooks,
         reset_override: inv.reset,
     };
 
-    run_pipeline_once(&project, &params)
+    run_pipeline_once(&project, &params)?;
+
+    if inv.watch {
+        // Subsequent iterations share the same hook/profile selection but
+        // never reset the localnet again — that would clobber the state
+        // hook code is verifying.
+        params.reset_override = Some(false);
+        watch_loop(&project, &params)?;
+    }
+
+    Ok(())
 }
 
 #[derive(Clone)]
@@ -190,6 +209,102 @@ fn reset_for_run(project: &Project) -> DynResult<()> {
 /// `wallet.state` is byte-equivalent to a fresh `lgs setup`. Extracted as
 /// its own helper so the byte-equivalence test can drive it directly
 /// without booting a real sequencer.
+fn watch_loop(project: &Project, params: &PipelineParams) -> DynResult<()> {
+    let (tx, rx) = mpsc::channel();
+    let mut watcher = notify::recommended_watcher(move |res| {
+        let _ = tx.send(res);
+    })
+    .context("create filesystem watcher")?;
+    watcher
+        .watch(&project.root, RecursiveMode::Recursive)
+        .context("watch project root")?;
+
+    // The IDL build writes JSON files into framework.idl.path on every
+    // iteration. Without ignoring that directory, those writes fire
+    // their own notify events → infinite loop. Resolve once before
+    // entering the loop. Use the project-relative form so we match
+    // both canonical and non-canonical event paths.
+    let idl_rel = PathBuf::from(&project.config.framework.idl.path);
+    let watch_ctx = WatchIgnore { idl_rel };
+
+    println!();
+    println!(
+        "===> watching {} for changes (Ctrl-C to exit)",
+        project.root.display()
+    );
+
+    loop {
+        let event = match rx.recv() {
+            Ok(Ok(ev)) => ev,
+            Ok(Err(err)) => {
+                eprintln!("watch error: {err}");
+                continue;
+            }
+            Err(_) => {
+                eprintln!("===> watcher channel disconnected; exiting watch loop");
+                break;
+            }
+        };
+        if !is_watched_event(project, &watch_ctx, &event) {
+            continue;
+        }
+        // Debounce: sleep then drain the rest of the burst.
+        std::thread::sleep(Duration::from_millis(WATCH_DEBOUNCE_MS));
+        while rx.try_recv().is_ok() {}
+        println!();
+        println!("===> change detected, re-running pipeline");
+        if let Err(err) = run_pipeline_once(project, params) {
+            eprintln!("pipeline failed: {err:#}");
+            eprintln!("===> waiting for next change");
+        }
+    }
+
+    Ok(())
+}
+
+struct WatchIgnore {
+    idl_rel: PathBuf,
+}
+
+fn is_watched_event(project: &Project, ctx: &WatchIgnore, event: &notify::Event) -> bool {
+    for path in &event.paths {
+        if !is_ignored_path(&project.root, ctx, path) {
+            return true;
+        }
+    }
+    false
+}
+
+fn is_ignored_path(project_root: &Path, ctx: &WatchIgnore, path: &Path) -> bool {
+    // `notify` may emit canonical (symlinks resolved) or non-canonical paths
+    // depending on the platform and how the project root was registered.
+    // Try both forms so we never silently *ignore* a project edit just
+    // because the OS canonicalized one side and not the other. Fail-open:
+    // a path we can't classify is treated as "watched" so the worst case
+    // is a spurious re-run, never a missed edit.
+    let canonical_root = project_root.canonicalize().ok();
+    let rel = path.strip_prefix(project_root).ok().or_else(|| {
+        canonical_root
+            .as_deref()
+            .and_then(|r| path.strip_prefix(r).ok())
+    });
+    let Some(rel) = rel else {
+        // Path doesn't belong to the project tree under either form. Ignore
+        // — this is a notify event from outside the watched directory.
+        return true;
+    };
+    for component in rel.components() {
+        let s = component.as_os_str().to_string_lossy();
+        if matches!(s.as_ref(), ".scaffold" | "target" | ".git") {
+            return true;
+        }
+    }
+    if rel.starts_with(&ctx.idl_rel) {
+        return true;
+    }
+    false
+}
+
 fn reseed_after_wipe(project: &Project) -> DynResult<()> {
     let lez = resolve_repo_path(project, &project.config.lez, "lez")?;
     let wallet_home = project.root.join(&project.config.wallet_home_dir);

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,7 +1,10 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::mpsc;
+use std::time::Duration;
 
 use anyhow::{bail, Context};
+use notify::{RecursiveMode, Watcher};
 
 use crate::commands::build::cmd_build_shortcut;
 use crate::commands::deploy::{
@@ -23,6 +26,11 @@ use crate::project::{load_project, resolve_repo_path, run_in_project_dir};
 use crate::state::prepare_wallet_home;
 use crate::DynResult;
 
+/// Debounce window for the watch loop. Filesystem events from a single
+/// editor save typically arrive in a flurry; sleep this long after the
+/// first event before re-running so we coalesce them.
+const WATCH_DEBOUNCE_MS: u64 = 500;
+
 /// All knobs that control a `lgs run` invocation. Built by `cli.rs` from
 /// the parsed `RunArgs` (with conflicting-flag resolution into `Option<bool>`)
 /// and consumed by `cmd_run`. Grouping the fields together prevents the
@@ -33,6 +41,7 @@ pub(crate) struct RunInvocation {
     pub(crate) reset: Option<bool>,
     pub(crate) post_deploy_override: Option<Vec<String>>,
     pub(crate) localnet_timeout_sec: Option<u64>,
+    pub(crate) watch: bool,
 }
 
 pub(crate) fn cmd_run(inv: RunInvocation) -> DynResult<()> {
@@ -50,7 +59,7 @@ pub(crate) fn cmd_run(inv: RunInvocation) -> DynResult<()> {
         .localnet_timeout_sec
         .unwrap_or(DEFAULT_RUN_LOCALNET_TIMEOUT_SEC);
 
-    let params = PipelineParams {
+    let mut params = PipelineParams {
         resolved: resolved.clone(),
         hooks,
         reset_override: inv.reset,
@@ -61,7 +70,19 @@ pub(crate) fn cmd_run(inv: RunInvocation) -> DynResult<()> {
     // that resolve paths relative to cwd (`cmd_build_shortcut`,
     // `build_idl_for_current_project`, etc.) would build/deploy from whichever
     // subdirectory the user invoked `lgs run` in.
-    run_in_project_dir(Some(&project.root), || run_pipeline_once(&project, &params))
+    run_in_project_dir(Some(&project.root), || {
+        run_pipeline_once(&project, &params)?;
+
+        if inv.watch {
+            // Subsequent iterations share the same hook/profile selection but
+            // never reset the localnet again — that would clobber the state
+            // hook code is verifying.
+            params.reset_override = Some(false);
+            watch_loop(&project, &params)?;
+        }
+
+        Ok(())
+    })
 }
 
 #[derive(Clone)]
@@ -219,6 +240,102 @@ fn reset_for_run(project: &Project, verify_timeout_sec: u64) -> DynResult<()> {
 /// `wallet.state` is byte-equivalent to a fresh `lgs setup`. Extracted as
 /// its own helper so the byte-equivalence test can drive it directly
 /// without booting a real sequencer.
+fn watch_loop(project: &Project, params: &PipelineParams) -> DynResult<()> {
+    let (tx, rx) = mpsc::channel();
+    let mut watcher = notify::recommended_watcher(move |res| {
+        let _ = tx.send(res);
+    })
+    .context("create filesystem watcher")?;
+    watcher
+        .watch(&project.root, RecursiveMode::Recursive)
+        .context("watch project root")?;
+
+    // The IDL build writes JSON files into framework.idl.path on every
+    // iteration. Without ignoring that directory, those writes fire
+    // their own notify events → infinite loop. Resolve once before
+    // entering the loop. Use the project-relative form so we match
+    // both canonical and non-canonical event paths.
+    let idl_rel = PathBuf::from(&project.config.framework.idl.path);
+    let watch_ctx = WatchIgnore { idl_rel };
+
+    println!();
+    println!(
+        "===> watching {} for changes (Ctrl-C to exit)",
+        project.root.display()
+    );
+
+    loop {
+        let event = match rx.recv() {
+            Ok(Ok(ev)) => ev,
+            Ok(Err(err)) => {
+                eprintln!("watch error: {err}");
+                continue;
+            }
+            Err(_) => {
+                eprintln!("===> watcher channel disconnected; exiting watch loop");
+                break;
+            }
+        };
+        if !is_watched_event(project, &watch_ctx, &event) {
+            continue;
+        }
+        // Debounce: sleep then drain the rest of the burst.
+        std::thread::sleep(Duration::from_millis(WATCH_DEBOUNCE_MS));
+        while rx.try_recv().is_ok() {}
+        println!();
+        println!("===> change detected, re-running pipeline");
+        if let Err(err) = run_pipeline_once(project, params) {
+            eprintln!("pipeline failed: {err:#}");
+            eprintln!("===> waiting for next change");
+        }
+    }
+
+    Ok(())
+}
+
+struct WatchIgnore {
+    idl_rel: PathBuf,
+}
+
+fn is_watched_event(project: &Project, ctx: &WatchIgnore, event: &notify::Event) -> bool {
+    for path in &event.paths {
+        if !is_ignored_path(&project.root, ctx, path) {
+            return true;
+        }
+    }
+    false
+}
+
+fn is_ignored_path(project_root: &Path, ctx: &WatchIgnore, path: &Path) -> bool {
+    // `notify` may emit canonical (symlinks resolved) or non-canonical paths
+    // depending on the platform and how the project root was registered.
+    // Try both forms so we never silently *ignore* a project edit just
+    // because the OS canonicalized one side and not the other. Fail-open:
+    // a path we can't classify is treated as "watched" so the worst case
+    // is a spurious re-run, never a missed edit.
+    let canonical_root = project_root.canonicalize().ok();
+    let rel = path.strip_prefix(project_root).ok().or_else(|| {
+        canonical_root
+            .as_deref()
+            .and_then(|r| path.strip_prefix(r).ok())
+    });
+    let Some(rel) = rel else {
+        // Path doesn't belong to the project tree under either form. Ignore
+        // — this is a notify event from outside the watched directory.
+        return true;
+    };
+    for component in rel.components() {
+        let s = component.as_os_str().to_string_lossy();
+        if matches!(s.as_ref(), ".scaffold" | "target" | ".git") {
+            return true;
+        }
+    }
+    if rel.starts_with(&ctx.idl_rel) {
+        return true;
+    }
+    false
+}
+
 fn reseed_after_wipe(project: &Project) -> DynResult<()> {
     let lez = resolve_repo_path(project, &project.config.lez, "lez")?;
     let wallet_home = project.root.join(&project.config.wallet_home_dir);


### PR DESCRIPTION
Adds a `--watch` flag to `lgs run`. After the first iteration completes, the process keeps running and re-executes the full pipeline on every project file change, debounced over a 500ms window so a flurry of editor save events coalesces into a single re-run. Reset is forced off on re-runs (the first iteration honors `--reset` / config; subsequent ones never wipe — that would clobber the state hooks are verifying). Watcher hygiene ignores `.scaffold/`, `target/`, `.git/`, and `framework.idl.path`; the IDL build's own JSON writes would otherwise fire notify events and produce an infinite loop. Path classification fails open — paths we can't categorize trigger a re-run, so the worst case is a spurious rebuild rather than a missed edit.

## Stack

This is part 5 (final) of a 5-PR stack that splits PR #66:

1. feat/run-mvp — pipeline core, post-deploy hook, single-program env
2. feat/run-deploy-cache — skip deploy when guest .bin + IDL hashes are unchanged
3. feat/run-multiprogram-env — `SCAFFOLD_PROGRAMS`, `SCAFFOLD_PROGRAM_ID_<n>`, …
4. feat/run-reset-and-profiles — `--reset` wipe-and-reseed and named `[run.profiles.*]`
5. **feat/run-watch ← this PR** — `--watch` re-runs pipeline on file changes

Each PR's base is the previous PR's branch; merge in order. Base for this PR is `feat/run-reset-and-profiles`.

## Replaces part of

#66 — PR #66 will be retired by editing its description once this stack lands.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo check --all-targets`
- [x] `cargo test --all-targets` (passes locally; the watch loop itself is exercised manually since it runs indefinitely. Filter helpers are covered by their own tests once a follow-up adds one — this slice is intentionally minimal so the watch surface lands behind a clear flag.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>