### PR TITLE
Add `specs/` directory with FURPS docs and ADRs for CLI/runtime contracts

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,24 @@
+# Specs
+
+Implementation-grounded specifications for public `logos-scaffold` behavior.
+
+## Scope
+
+These docs specify **current behavior** of:
+
+- CLI surface and flags
+- project lifecycle (`new/create`, `init`, `setup`)
+- runtime operations (`localnet`, `wallet`, `doctor`, `report`, `deploy` JSON behavior)
+- basecamp commands
+
+Root `FURPS.md` and `ADR.md` remain strategic docs. `specs/` is operational/current-state.
+
+## Contents
+
+- `furps/FURPS-0001-cli-surface-and-behavior.md`
+- `furps/FURPS-0002-project-lifecycle-and-repo-management.md`
+- `furps/FURPS-0003-runtime-ops-localnet-wallet-doctor-report.md`
+- `furps/FURPS-0004-basecamp-workflow.md`
+- `adr/ADR-0001-spec-driven-docs-separation.md`
+- `adr/ADR-0002-command-output-contracts.md`
+- `analysis/SPEC-GAP-ANALYSIS.md`

--- a/specs/adr/ADR-0001-spec-driven-docs-separation.md
+++ b/specs/adr/ADR-0001-spec-driven-docs-separation.md
@@ -1,0 +1,19 @@
+# ADR-0001: Separate Strategic Docs from Current-State Specs
+
+## Status
+Accepted
+
+## Decision
+
+Keep two layers:
+
+1. Root-level `FURPS.md` and `ADR.md` for strategy/roadmap context.
+2. `specs/` for concrete current-state behavior contracts.
+
+## Rationale
+
+Root docs include forward-looking content; reconstruction and regression review need implementation-grounded contracts.
+
+## Consequence
+
+When command behavior changes, update `specs/` in the same change.

--- a/specs/adr/ADR-0002-command-output-contracts.md
+++ b/specs/adr/ADR-0002-command-output-contracts.md
@@ -1,0 +1,20 @@
+# ADR-0002: CLI Output Is a Public Contract
+
+## Status
+Accepted
+
+## Decision
+
+For user-facing commands, treat output shape as API:
+
+1. Human mode: stable key lines and remediation hints.
+2. JSON mode: deterministic object structure suitable for automation.
+3. Introspection/help commands: no filesystem mutation.
+
+## Rationale
+
+Downstream CI/scripts depend on output shape, not only exit codes.
+
+## Consequence
+
+Output-shape changes require spec update and test update.

--- a/specs/analysis/SPEC-GAP-ANALYSIS.md
+++ b/specs/analysis/SPEC-GAP-ANALYSIS.md
@@ -1,0 +1,36 @@
+# Spec Gap Analysis
+
+## Objective
+
+List concrete under-specified public behaviors and where they are now specified.
+
+## Inputs Reviewed
+
+- `src/cli.rs`
+- `src/commands/*.rs`
+- `tests/cli.rs`
+- `README.md`
+- `DOGFOODING.md`
+- `docs/basecamp-module-requirements.md`
+
+## Gaps and Closures
+
+1. **CLI surface was spread across README/help/tests, not one contract.**
+   - Closure: `FURPS-0001`.
+
+2. **Lifecycle determinism (`init` migration role, `setup` vendoring scope) was fragmented.**
+   - Closure: `FURPS-0002`.
+
+3. **Machine-facing output contracts (`--json`, report archive expectations) were implicit.**
+   - Closure: `FURPS-0003` and `ADR-0002`.
+
+4. **Basecamp workflow had deep docs but no concise command-level contract.**
+   - Closure: `FURPS-0004`.
+
+5. **No rule for strategic docs vs implementation specs.**
+   - Closure: `ADR-0001`.
+
+## Remaining Gaps
+
+1. Add schema files (or explicit schemas in docs) for JSON outputs (`deploy`, `doctor`, `localnet status`, `report` manifest).
+2. Add a traceability table mapping each FURPS requirement to tests.

--- a/specs/furps/FURPS-0001-cli-surface-and-behavior.md
+++ b/specs/furps/FURPS-0001-cli-surface-and-behavior.md
@@ -1,0 +1,24 @@
+# FURPS-0001: CLI Surface and Behavior
+
+## Status
+Accepted
+
+## Functional Requirements
+
+1. Binaries: `logos-scaffold` and `lgs` are equivalent entry points.
+2. Public command groups include: `create/new`, `init`, `setup`, `build`, `deploy`, `localnet`, `wallet`, `spel`, `basecamp`, `doctor`, `report`, `completions`.
+3. `create` and `new` are aliases with shared flags.
+4. `completions` supports `bash` and `zsh`.
+5. Hidden self-test commands are excluded from normal help output.
+
+## Behavioral Requirements
+
+1. `--help` must be side-effect free.
+2. Help text must expose documented options for each command.
+
+## Acceptance Checks
+
+- `create --help` does not create files.
+- `wallet --help` includes `list`, `topup`, and `default`.
+- `deploy --help` shows optional program argument semantics.
+- `report --help` includes `--out` and `--tail`.

--- a/specs/furps/FURPS-0002-project-lifecycle-and-repo-management.md
+++ b/specs/furps/FURPS-0002-project-lifecycle-and-repo-management.md
@@ -1,0 +1,21 @@
+# FURPS-0002: Project Lifecycle and Repo Management
+
+## Status
+Accepted
+
+## Functional Requirements
+
+1. `new/create` scaffold a project.
+2. `init` bootstraps scaffold config in an existing project and is the migration entry point for outdated schema.
+3. `setup` resolves configured pinned repositories and builds project-local binaries required by scaffold commands.
+4. Wrapper commands (`wallet`, `spel`) execute project-resolved binaries, not global binaries.
+
+## Determinism Requirements
+
+1. Repository resolution must be pin-driven from project config/defaults.
+2. Commands requiring project context fail with actionable message when run outside project or on outdated schema.
+
+## Acceptance Checks
+
+- Re-running `init` on outdated config migrates schema path rather than requiring manual rewrite.
+- `setup` output and resulting binaries are project-scoped under scaffold-managed paths.

--- a/specs/furps/FURPS-0003-runtime-ops-localnet-wallet-doctor-report.md
+++ b/specs/furps/FURPS-0003-runtime-ops-localnet-wallet-doctor-report.md
@@ -1,0 +1,28 @@
+# FURPS-0003: Runtime Operations
+
+## Status
+Accepted
+
+## Functional Requirements
+
+1. `localnet` supports `start|stop|status|logs|reset`.
+2. `wallet` supports list/topup/default management and raw argument pass-through.
+3. `doctor` supports human output and `--json` output.
+4. `report` creates a sanitized diagnostic archive with manifest and warnings.
+
+## Output/Contract Requirements
+
+1. `localnet status --json` and `doctor --json` must emit machine-readable JSON.
+2. `report` archive must exclude wallet key material.
+3. `report` supports default output path and `--out` override.
+4. `deploy --json` behavior must remain deterministic by code path (single `--program-path` object vs discovery list object).
+
+## Safety/Reliability Requirements
+
+1. Localnet state handling must distinguish managed state from external listeners.
+2. Diagnostics collection must be best-effort and explicit about skipped data.
+
+## Acceptance Checks
+
+- Report archive includes manifest and diagnostics files, and omits `.scaffold/wallet/**`.
+- `doctor --json` and `localnet status --json` are parseable with `jq`.

--- a/specs/furps/FURPS-0004-basecamp-workflow.md
+++ b/specs/furps/FURPS-0004-basecamp-workflow.md
@@ -1,0 +1,25 @@
+# FURPS-0004: Basecamp Workflow
+
+## Status
+Accepted
+
+## Functional Requirements
+
+1. `basecamp setup` prepares pinned basecamp/lgpm tooling and profile roots.
+2. `basecamp modules` captures module sources into config as source-of-truth set.
+3. `basecamp install` replays captured modules into profiles.
+4. `basecamp launch <profile>` runs using profile-scoped state/env.
+5. `basecamp build-portable` builds/stages portable artifacts for project modules.
+6. `basecamp doctor` reports basecamp-specific health/drift information.
+
+## Determinism Requirements
+
+1. Module capture/replay is idempotent for unchanged inputs.
+2. Dependency/source resolution follows fixed precedence and fails fast when unresolved.
+3. Portable staging uses stable naming/order and does not mutate profile runtime state.
+
+## Acceptance Checks
+
+- Missing setup prerequisite yields actionable guidance.
+- Re-running modules capture with unchanged sources does not introduce unrelated churn.
+- `build-portable` output is staged under scaffold-managed portable directory.


### PR DESCRIPTION
### Motivation

- Capture implementation-grounded, current-state specifications for `logos-scaffold` public behavior including CLI surface, project lifecycle, runtime operations, and basecamp commands.
- Separate strategic/roadmap docs from operational contracts so command/output changes require spec updates and make behavior deterministic for automation. 

### Description

- Add top-level `specs/README.md` describing scope and contents of the specs corpus. 
- Add ADRs `specs/adr/ADR-0001-spec-driven-docs-separation.md` and `specs/adr/ADR-0002-command-output-contracts.md` to codify docs layering and that CLI output is a public contract. 
- Add FURPS operational specs `specs/furps/FURPS-0001-cli-surface-and-behavior.md`, `FURPS-0002-project-lifecycle-and-repo-management.md`, `FURPS-0003-runtime-ops-localnet-wallet-doctor-report.md`, and `FURPS-0004-basecamp-workflow.md` that enumerate functional, determinism, and acceptance checks. 
- Add `specs/analysis/SPEC-GAP-ANALYSIS.md` enumerating discovered gaps, closures, and remaining work such as JSON schema and test traceability. 

### Testing

- No automated tests were run as this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb513c2cc083318f35b521e23d3a09)