### PR TITLE
fix: remove doubled error: prefix and use invoked binary name in hints

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -441,7 +441,13 @@ pub(crate) fn run(args: Vec<String>) -> DynResult<()> {
                 print!("{err}");
                 return Ok(());
             }
-            _ => return Err(anyhow!(err.to_string())),
+            _ => {
+                // clap's Display already starts with "error: "; strip it to avoid
+                // "error: error: ..." when entry_main adds its own prefix.
+                let msg = err.to_string();
+                let msg = msg.strip_prefix("error: ").unwrap_or(&msg);
+                return Err(anyhow!("{}", msg));
+            }
         },
     };
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -12,10 +12,16 @@ use crate::DynResult;
 pub(crate) fn load_project() -> DynResult<Project> {
     let cwd = env::current_dir()?;
     let root = find_project_root(cwd.clone()).ok_or_else(|| {
-        anyhow!(
-            "Not a logos-scaffold project at {}. Run `logos-scaffold create <name>` (or `logos-scaffold new <name>`) first.",
-            cwd.display()
-        )
+        {
+            let bin = std::env::args()
+                .next()
+                .and_then(|p| std::path::Path::new(&p).file_name().map(|n| n.to_string_lossy().into_owned()))
+                .unwrap_or_else(|| "logos-scaffold".to_string());
+            anyhow!(
+                "Not a logos-scaffold project at {}. Run `{bin} create <name>` (or `{bin} new <name>`) first.",
+                cwd.display()
+            )
+        }
     })?;
 
     let config_path = root.join("scaffold.toml");


### PR DESCRIPTION
Fixes #78. Fixes #79.

## #78 — Doubled error: prefix

clap errors already start with 'error: ', entry_main adds another. Strip clap prefix before wrapping.

## #79 — Hardcoded binary name

Out-of-project hint hardcoded 'logos-scaffold'. Now uses argv[0] filename.

```
$ lgs build  # from /tmp
error: Not a logos-scaffold project at /tmp. Run `lgs create <name>` (or `lgs new <name>`) first.
```