### PR TITLE
fix(migrate): short-circuit migrator when scaffold.toml is already at v0.2.0

### DIFF
--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -36,6 +36,21 @@ pub(crate) struct MigrationReport {
 pub(crate) fn migrate_to_v0_2_0(doc: &mut DocumentMut) -> DynResult<MigrationReport> {
     let mut report = MigrationReport::default();
 
+    // Short-circuit when the file is already at the current schema version.
+    // The migrator's rewrites (lssa→lez drop, url strip, basecamp reshape, etc.)
+    // are pre-v0.2.0 fixups; running them against an already-current file can
+    // silently rewrite intentionally non-conformant content (e.g. a hand-kept
+    // `[repos.lssa]` for a fork).
+    if doc
+        .get("scaffold")
+        .and_then(Item::as_table)
+        .and_then(|t| t.get("version"))
+        .and_then(Item::as_str)
+        == Some(SCAFFOLD_TOML_SCHEMA_VERSION)
+    {
+        return Ok(report);
+    }
+
     // Ensure [scaffold] exists; bump version.
     let scaffold = doc.entry("scaffold").or_insert(Item::Table({
         let mut t = Table::new();
@@ -305,6 +320,41 @@ fn split_flake_ref(flake_ref: &str) -> Option<(String, String, String)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn migrator_short_circuits_on_current_version_and_preserves_stray_lssa() {
+        // A user keeps a hand-rolled [repos.lssa] in a v0.2.0 file (e.g. a fork
+        // that re-uses the old name). The migrator must not silently drop it.
+        let seed = r#"[scaffold]
+version = "0.2.0"
+
+[repos.lssa]
+source = "https://example.com/lssa.git"
+pin = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+[repos.lez]
+source = "https://example.com/lez.git"
+pin = "abc123abc123abc123abc123abc123abc123abc1"
+
+[repos.spel]
+source = "https://example.com/spel.git"
+pin = "feedfacefeedfacefeedfacefeedfacefeedface"
+"#;
+        let mut doc: DocumentMut = seed.parse().expect("parse seed");
+        let report = migrate_to_v0_2_0(&mut doc).expect("migrate");
+
+        assert!(
+            report.changes.is_empty(),
+            "no changes expected when already at v0.2.0, got: {:?}",
+            report.changes,
+        );
+        let after = doc.to_string();
+        assert!(
+            after.contains("[repos.lssa]"),
+            "stray [repos.lssa] must be preserved; got:\n{after}"
+        );
+        assert_eq!(after, seed, "document unchanged when version is current");
+    }
 
     #[test]
     fn split_flake_ref_pulls_apart_canonical_lgpm_form() {


### PR DESCRIPTION
## Description
`migrate_to_v0_2_0` in `src/migrate.rs` walks every pre-0.2.0 rewrite (lssa→lez alias drop, `url` strip, basecamp reshape, `[basecamp.modules.*]` move) unconditionally on entry. For files that are already at v0.2.0 this is mostly a no-op, but it can silently rewrite intentional content — most notably a hand-kept `[repos.lssa]` section (e.g. a fork that re-uses the old name). The current calling-side version gate in `parse_config` does not protect the migrator itself; any future caller that invokes the migrator directly (e.g. a `lgs migrate --check` flag) would inherit the same silent-rewrite hazard.

## Solution
- Add a one-shot version check at the top of `migrate_to_v0_2_0` (`src/migrate.rs:36-51`) that returns an empty `MigrationReport` when `[scaffold].version` already equals `SCAFFOLD_TOML_SCHEMA_VERSION`. Pre-v0.2.0 files (no version, or a different version) fall through to the existing rewrites unchanged.
- The existing `report.changes.is_empty()` guard in `commands::init::cmd_init_at` continues to bail with `"already at schema vX — nothing to migrate"`, so user-visible init behavior on a current file is unchanged.
- Add `migrator_short_circuits_on_current_version_and_preserves_stray_lssa` in `src/migrate.rs:325-359` — seeds a v0.2.0 document with a stray `[repos.lssa]` section, runs the migrator, and asserts the document is byte-identical and the report has no changes.

## Notes
- Pre-existing migration tests (`migrates_pre_spel_scaffold_toml`, `migrates_basecamp_pin_and_modules`, `migrates_repos_lssa_to_repos_lez`, `migration_drops_stale_lssa_when_lez_present`, `migration_strips_url_only_when_no_other_changes_needed`, `init_refuses_when_already_at_v0_2_0`) all still pass — they exercise pre-0.2.0 seed files that don't trigger the short-circuit.
- Tests run: `cargo test` → 238 unit tests + 135 integration tests, all green. New test passes locally.
- No change to the public migrator contract: callers still get a `MigrationReport` and still observe `changes.is_empty()` to detect "nothing happened".

Closes #110

---
Run ID: 20260511-234016
Authored by: scaffold-wozos-issue-impl recurring task (claude-code worker)