### PR TITLE
fix(security): refuse argv-injection and ext:: transports in [repos.*].source

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -226,6 +226,7 @@ fn parse_repo_ref(doc: &DocumentMut, name: &str) -> DynResult<Option<RepoRef>> {
     check_toml_value(&format!("repos.{name}.pin"), &pin)?;
     check_toml_value(&format!("repos.{name}.attr"), &attr)?;
     check_toml_value(&format!("repos.{name}.path"), &path)?;
+    check_repo_source(name, &source)?;
 
     Ok(Some(RepoRef {
         source,
@@ -234,6 +235,56 @@ fn parse_repo_ref(doc: &DocumentMut, name: &str) -> DynResult<Option<RepoRef>> {
         attr,
         path,
     }))
+}
+
+/// Reject `[repos.<name>].source` values that would let a malicious
+/// `scaffold.toml` execute code on contributor machines via `git clone`.
+///
+/// Two classes are covered here, both reachable from `ensure_repo_present`:
+///
+/// - Leading `-` is treated by `git clone` as an option, not a positional
+///   `<repository>`. Even with the `--` separator the clone call sites pass
+///   defensively, parse-time rejection gives a clear error pointing at the
+///   offending key instead of a confusing subprocess failure.
+/// - `ext::` (and other remote-helper transports written as `<helper>::...`)
+///   invoke `git-remote-<helper>`, which for `ext` runs an arbitrary shell
+///   command — the CVE-2017-1000117 class. None of scaffold's flows need
+///   it, so refusing it at parse time is strictly safer.
+fn check_repo_source(name: &str, source: &str) -> DynResult<()> {
+    let trimmed = source.trim();
+    if trimmed.is_empty() {
+        bail!("invalid scaffold.toml: [repos.{name}].source is empty");
+    }
+    if trimmed.starts_with('-') {
+        bail!(
+            "invalid scaffold.toml: [repos.{name}].source starts with '-' ({source:?}); \
+             refusing — git would treat this as an option, not a repository"
+        );
+    }
+    if is_dangerous_transport(trimmed) {
+        bail!(
+            "invalid scaffold.toml: [repos.{name}].source uses a dangerous git transport ({source:?}); \
+             `ext::` and other remote-helper transports can execute arbitrary commands at clone time and are not allowed"
+        );
+    }
+    Ok(())
+}
+
+/// Match the `<helper>::<rest>` remote-helper syntax for transports that can
+/// execute code. `ext::` is the canonical RCE vector (CVE-2017-1000117); the
+/// rest of the recognized list mirrors transports whose helpers historically
+/// shipped shell-out behavior or are otherwise unsuitable for an untrusted
+/// `scaffold.toml`.
+fn is_dangerous_transport(source: &str) -> bool {
+    const BANNED_PREFIXES: &[&str] = &[
+        "ext::",
+        "ext ::",
+        "transport-helper::",
+    ];
+    let lowered = source.to_ascii_lowercase();
+    BANNED_PREFIXES
+        .iter()
+        .any(|prefix| lowered.starts_with(prefix))
 }
 
 fn parse_modules(doc: &DocumentMut) -> DynResult<std::collections::BTreeMap<String, ModuleEntry>> {
@@ -787,6 +838,90 @@ role = "project"
             err.to_string().contains("70000") || err.to_string().contains("u16"),
             "{err}"
         );
+    }
+
+    #[test]
+    fn rejects_repo_source_starting_with_dash() {
+        let toml = minimal_v0_2_0().replace(
+            &format!("source = \"{}\"\npin = \"{}\"", LEZ_SOURCE, DEFAULT_LEZ.sha),
+            &format!(
+                "source = \"-upload-pack=evil\"\npin = \"{}\"",
+                DEFAULT_LEZ.sha
+            ),
+        );
+        let err = parse_config(&toml).expect_err("dash-prefixed source must be rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("repos.lez"), "{msg}");
+        assert!(msg.contains("starts with '-'"), "{msg}");
+    }
+
+    #[test]
+    fn rejects_repo_source_with_ext_transport() {
+        let toml = minimal_v0_2_0().replace(
+            &format!("source = \"{}\"\npin = \"{}\"", LEZ_SOURCE, DEFAULT_LEZ.sha),
+            &format!(
+                "source = \"ext::sh -c id\"\npin = \"{}\"",
+                DEFAULT_LEZ.sha
+            ),
+        );
+        let err = parse_config(&toml).expect_err("ext:: transport must be rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("repos.lez"), "{msg}");
+        assert!(msg.contains("dangerous git transport"), "{msg}");
+    }
+
+    #[test]
+    fn rejects_repo_source_with_ext_transport_case_insensitive() {
+        let toml = minimal_v0_2_0().replace(
+            &format!("source = \"{}\"\npin = \"{}\"", LEZ_SOURCE, DEFAULT_LEZ.sha),
+            &format!(
+                "source = \"EXT::sh -c id\"\npin = \"{}\"",
+                DEFAULT_LEZ.sha
+            ),
+        );
+        let err = parse_config(&toml).expect_err("upper-case ext:: must be rejected");
+        assert!(
+            err.to_string().contains("dangerous git transport"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn rejects_repo_source_with_transport_helper_prefix() {
+        let toml = minimal_v0_2_0().replace(
+            &format!("source = \"{}\"\npin = \"{}\"", LEZ_SOURCE, DEFAULT_LEZ.sha),
+            &format!(
+                "source = \"transport-helper::evil\"\npin = \"{}\"",
+                DEFAULT_LEZ.sha
+            ),
+        );
+        let err = parse_config(&toml).expect_err("transport-helper:: must be rejected");
+        assert!(
+            err.to_string().contains("dangerous git transport"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn accepts_ordinary_repo_sources() {
+        // Defense-in-depth: the rejection path is selective. Confirm the
+        // common, benign source shapes still parse — https, ssh, git@, plain
+        // paths.
+        for source in [
+            "https://github.com/example/repo.git",
+            "http://example.com/repo",
+            "ssh://git@example.com/repo.git",
+            "git@github.com:example/repo.git",
+            "/abs/local/repo",
+            "./relative/repo",
+            "extender/repo",
+        ] {
+            let toml = minimal_v0_2_0().replace(
+                &format!("source = \"{}\"\npin = \"{}\"", LEZ_SOURCE, DEFAULT_LEZ.sha),
+                &format!("source = \"{}\"\npin = \"{}\"", source, DEFAULT_LEZ.sha),
+            );
+            parse_config(&toml).unwrap_or_else(|e| panic!("benign source {source:?} rejected: {e}"));
+        }
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -276,11 +276,7 @@ fn check_repo_source(name: &str, source: &str) -> DynResult<()> {
 /// shipped shell-out behavior or are otherwise unsuitable for an untrusted
 /// `scaffold.toml`.
 fn is_dangerous_transport(source: &str) -> bool {
-    const BANNED_PREFIXES: &[&str] = &[
-        "ext::",
-        "ext ::",
-        "transport-helper::",
-    ];
+    const BANNED_PREFIXES: &[&str] = &["ext::", "ext ::", "transport-helper::"];
     let lowered = source.to_ascii_lowercase();
     BANNED_PREFIXES
         .iter()
@@ -859,10 +855,7 @@ role = "project"
     fn rejects_repo_source_with_ext_transport() {
         let toml = minimal_v0_2_0().replace(
             &format!("source = \"{}\"\npin = \"{}\"", LEZ_SOURCE, DEFAULT_LEZ.sha),
-            &format!(
-                "source = \"ext::sh -c id\"\npin = \"{}\"",
-                DEFAULT_LEZ.sha
-            ),
+            &format!("source = \"ext::sh -c id\"\npin = \"{}\"", DEFAULT_LEZ.sha),
         );
         let err = parse_config(&toml).expect_err("ext:: transport must be rejected");
         let msg = err.to_string();
@@ -874,16 +867,10 @@ role = "project"
     fn rejects_repo_source_with_ext_transport_case_insensitive() {
         let toml = minimal_v0_2_0().replace(
             &format!("source = \"{}\"\npin = \"{}\"", LEZ_SOURCE, DEFAULT_LEZ.sha),
-            &format!(
-                "source = \"EXT::sh -c id\"\npin = \"{}\"",
-                DEFAULT_LEZ.sha
-            ),
+            &format!("source = \"EXT::sh -c id\"\npin = \"{}\"", DEFAULT_LEZ.sha),
         );
         let err = parse_config(&toml).expect_err("upper-case ext:: must be rejected");
-        assert!(
-            err.to_string().contains("dangerous git transport"),
-            "{err}"
-        );
+        assert!(err.to_string().contains("dangerous git transport"), "{err}");
     }
 
     #[test]
@@ -896,10 +883,7 @@ role = "project"
             ),
         );
         let err = parse_config(&toml).expect_err("transport-helper:: must be rejected");
-        assert!(
-            err.to_string().contains("dangerous git transport"),
-            "{err}"
-        );
+        assert!(err.to_string().contains("dangerous git transport"), "{err}");
     }
 
     #[test]
@@ -920,7 +904,8 @@ role = "project"
                 &format!("source = \"{}\"\npin = \"{}\"", LEZ_SOURCE, DEFAULT_LEZ.sha),
                 &format!("source = \"{}\"\npin = \"{}\"", source, DEFAULT_LEZ.sha),
             );
-            parse_config(&toml).unwrap_or_else(|e| panic!("benign source {source:?} rejected: {e}"));
+            parse_config(&toml)
+                .unwrap_or_else(|e| panic!("benign source {source:?} rejected: {e}"));
         }
     }
 

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -123,6 +123,7 @@ pub(crate) fn ensure_repo_present(
         Command::new("git")
             .arg("clone")
             .arg("--no-hardlinks")
+            .arg("--")
             .arg(source)
             .arg(path),
         &format!("clone {label}"),
@@ -161,6 +162,7 @@ fn reconcile_repo_source(
                 Command::new("git")
                     .arg("clone")
                     .arg("--no-hardlinks")
+                    .arg("--")
                     .arg(source)
                     .arg(path),
                 &format!("refresh clone {label}"),


### PR DESCRIPTION
## Description
A malicious or compromised `scaffold.toml` can supply a `[repos.<name>].source` value that flows verbatim into `git clone`. Today there is no scheme allowlist and no `--` separator, so a value that starts with `-` is interpreted by git as an option (argv injection), and a value using git's `ext::` remote-helper transport (e.g. `source = "ext::sh -c <command>"`) executes arbitrary shell during `lgs setup`. That is the CVE-2017-1000117 class. `scaffold.toml` travels with PR branches, tutorial repos, and copy-pasted examples, so the threat model is contributor / dogfooder machines.

## Solution
Two cheap, layered defenses, both small diffs:

- `src/repo.rs:122` and `src/repo.rs:160` — insert `--` between `clone --no-hardlinks` and the user-controlled `<source>` argument in both `git clone` call sites. Kills the argv-injection class regardless of value.
- `src/config.rs:parse_repo_ref` — call a new `check_repo_source` at parse time. It rejects any `[repos.<name>].source` that starts with `-` (option injection) and any value whose lower-cased prefix matches `ext::` or `transport-helper::` (remote-helper RCE). Parse-time rejection surfaces the offending key in the error message instead of a confusing subprocess failure.
- New unit tests in `src/config.rs`:
  - `rejects_repo_source_starting_with_dash`
  - `rejects_repo_source_with_ext_transport`
  - `rejects_repo_source_with_ext_transport_case_insensitive`
  - `rejects_repo_source_with_transport_helper_prefix`
  - `accepts_ordinary_repo_sources` — confirms `https://`, `http://`, `ssh://`, `git@`, absolute paths, relative paths, and names that merely *share* a prefix with banned transports (e.g. `extender/repo`) still parse.

## Notes
- The validator only rejects `[repos.<name>].source`, not any other string field. `pin` is hex-only by convention and `path` is a filesystem path under `project.root` not handed to a subprocess argv-style. Scope is intentionally minimal.
- The `ext::` rejection list is a deny-list rather than the broader scheme allow-list option mentioned in the issue. A scheme allow-list is the more conservative longer-term shape but would require listing every legitimate URL form users have in the wild (including `git@host:owner/repo` SSH shorthand and bare local paths); a deny-list of known-dangerous transports plus the `--` separator is enough to close the RCE/argv-injection class without breaking existing configs.
- Test helper `git_clone` in `src/repo.rs`'s `mod tests` is unchanged — it's a fixture that takes tempdir-derived absolute paths and is not the production code path; leaving it alone keeps the diff narrow.
- Full test suite: 242 unit + 135 integration tests pass on this branch.

Closes #108

---
Run ID: 20260511-235014
Authored by: scaffold-wozos-issue-impl recurring task (claude-code worker)