### PR TITLE
fix(migrate): bail on [modules.<name>] collision during basecamp.modules move

### DIFF
--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -5,7 +5,7 @@
 //! sections survive. Anything the parser rejects in `config::detect_old_schema`
 //! is exactly what this module knows how to rewrite.
 
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 use toml_edit::{value, DocumentMut, Item, Table};
 
 use crate::constants::{
@@ -219,6 +219,13 @@ pub(crate) fn migrate_to_v0_2_0(doc: &mut DocumentMut) -> DynResult<MigrationRep
             .as_table_mut()
             .ok_or_else(|| anyhow!("[modules] is not a table"))?;
         for (name, t) in &moved_modules {
+            if modules_table.contains_key(name) {
+                bail!(
+                    "module name collision during migration: `{name}` exists in both \
+                     [basecamp.modules.{name}] and [modules.{name}]. Resolve by renaming \
+                     or removing one entry in scaffold.toml before re-running init."
+                );
+            }
             modules_table.insert(name, Item::Table(t.clone()));
         }
         report.changes.push(format!(
@@ -329,5 +336,108 @@ mod tests {
             "github:logos-co/logos-package-manager/e5c25989861f4487c3dc8c7b3bc0062bcbc3221f"
         )
         .is_none());
+    }
+
+    #[test]
+    fn migration_bails_on_module_name_collision_between_basecamp_modules_and_modules() {
+        // Pre-0.2.0 file that has BOTH a legacy [basecamp.modules.foo] and a
+        // pre-existing top-level [modules.foo] (hand-edited or half-migrated).
+        // The migrator must refuse rather than silently overwrite the existing
+        // [modules.foo] table — that is silent data loss in a version-controlled
+        // config file. The error must name the colliding module.
+        let input = r#"[scaffold]
+version = "0.1.1"
+
+[repos.lez]
+source = "u"
+pin = "abc"
+
+[repos.spel]
+source = "v"
+pin = "def"
+
+[basecamp]
+pin = "deadbeef"
+source = "https://example.com/basecamp"
+
+[basecamp.modules.foo]
+flake = "path:./legacy-foo"
+role = "project"
+
+[modules.foo]
+flake = "path:./new-foo"
+role = "project"
+"#;
+        let mut doc: DocumentMut = input.parse().expect("parse seed");
+        let err = match migrate_to_v0_2_0(&mut doc) {
+            Ok(_) => panic!("expected collision error, migration succeeded"),
+            Err(e) => e,
+        };
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("module name collision"),
+            "error should name the failure mode; got: {msg}"
+        );
+        assert!(
+            msg.contains("foo"),
+            "error should name the colliding module; got: {msg}"
+        );
+
+        // The pre-existing [modules.foo] must still carry the hand-edited
+        // flake — i.e. it was NOT clobbered before the bail.
+        let preserved = doc
+            .get("modules")
+            .and_then(Item::as_table)
+            .and_then(|m| m.get("foo"))
+            .and_then(Item::as_table)
+            .and_then(|t| t.get("flake"))
+            .and_then(Item::as_str)
+            .expect("modules.foo.flake preserved");
+        assert_eq!(preserved, "path:./new-foo");
+    }
+
+    #[test]
+    fn migration_moves_basecamp_modules_when_no_collision() {
+        // Sanity counterpart to the collision test: without a colliding
+        // [modules.<name>] entry, the modules move succeeds and the new
+        // [modules.foo] carries the legacy flake.
+        let input = r#"[scaffold]
+version = "0.1.1"
+
+[repos.lez]
+source = "u"
+pin = "abc"
+
+[repos.spel]
+source = "v"
+pin = "def"
+
+[basecamp]
+pin = "deadbeef"
+source = "https://example.com/basecamp"
+
+[basecamp.modules.foo]
+flake = "path:./legacy-foo"
+role = "project"
+"#;
+        let mut doc: DocumentMut = input.parse().expect("parse seed");
+        let report = migrate_to_v0_2_0(&mut doc).expect("migration succeeds");
+        assert!(
+            report
+                .changes
+                .iter()
+                .any(|c| c.contains("[basecamp.modules.*] -> [modules.*]")),
+            "expected modules-move entry in report; got: {:?}",
+            report.changes
+        );
+        let moved = doc
+            .get("modules")
+            .and_then(Item::as_table)
+            .and_then(|m| m.get("foo"))
+            .and_then(Item::as_table)
+            .and_then(|t| t.get("flake"))
+            .and_then(Item::as_str)
+            .expect("modules.foo.flake present after move");
+        assert_eq!(moved, "path:./legacy-foo");
     }
 }


### PR DESCRIPTION
## Description
`migrate_to_v0_2_0` moves modules from the legacy `[basecamp.modules.*]` section to top-level `[modules.*]` via `modules_table.insert(name, ...)` at `src/migrate.rs:221-223`. If a `[modules.<name>]` entry already exists at the new location with the same name (a hand-migrated file, two legacy entries that derive the same `module_name`, or a half-edited project) the insert silently overwrote the pre-existing table. The migrator then reported a successful migration while a tracked dependency declaration was gone. Silent data loss during schema migration on a version-controlled config file is the worst case — and it would land in the `lgs init` "success" path with no diagnostic, so the user would only notice when downstream `setup` / `basecamp` started missing entries.

## Solution
- `src/migrate.rs:221` — before each `modules_table.insert`, check `contains_key(name)` and `bail!` with a message that names the colliding module and points the user at renaming or removing one of the two entries. No partial migrations: the bail happens at the first collision so the file on disk is never mid-state (the caller, `cmd_init_at` at `src/commands/init.rs:43-51`, only writes the document back after a successful `migrate_to_v0_2_0` return).
- `src/migrate.rs` (top) — add `bail` to the `anyhow` imports.
- New regression tests in `src/migrate.rs::tests`:
  - `migration_bails_on_module_name_collision_between_basecamp_modules_and_modules` — seeds a doc with both `[basecamp.modules.foo]` and `[modules.foo]`, asserts the migrator errors with `module name collision` mentioning `foo`, and asserts the pre-existing `[modules.foo].flake` was not clobbered before the bail.
  - `migration_moves_basecamp_modules_when_no_collision` — sanity counterpart asserting the no-collision path still moves the legacy module and reports the change.

## Notes
- The collision only fires on the `[basecamp.modules.*] -> [modules.*]` move. Other migration steps (basecamp pin/source, lgpm_flake, lssa → lez rename) already either overwrite a single deterministic key or no-op, so the same class doesn't apply there.
- The bail message uses generic "init" rather than a hardcoded binary name because `migrate_to_v0_2_0` does not receive `bin_name` from its only caller; if a future refactor threads `bin_name` through, the message can be specialised then. Keeping the change narrow.
- TOML's own uniqueness rule prevents two `[basecamp.modules.foo]` entries in the same file, so the only reachable collision path is `[basecamp.modules.foo]` plus a pre-existing `[modules.foo]`. The test covers exactly that shape.
- Full test suite passes (239 unit + 135 integration + 0 doc-tests). Cargo build is clean. The pre-existing `unused import: WALLET_CONFIG_FALLBACK` warning in `src/commands/wallet_support.rs:469` is unrelated to this change.

Closes #109

---
Run ID: 20260512-000013
Authored by: scaffold-wozos-issue-impl recurring task (claude-code worker)