### PR TITLE
fix(repo): compare HEAD against resolved pin SHA, not raw pin string

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -53,7 +53,7 @@ pub(crate) fn sync_repo_to_pin_at_path_with_opts(
         &format!("git fetch ({label})"),
     );
 
-    ensure_pin_exists(path, source, pin, label)?;
+    let resolved_pin = ensure_pin_exists(path, source, pin, label)?;
 
     run_checked(
         Command::new("git")
@@ -64,9 +64,13 @@ pub(crate) fn sync_repo_to_pin_at_path_with_opts(
     )?;
 
     let head = git_head_sha(path)?;
-    if head != pin {
+    if head != resolved_pin {
+        // Comparison is against the resolved SHA, not the raw `pin` string —
+        // otherwise tag/branch pins (e.g. `pin = "v0.2.0"`) always trip this
+        // assertion even though the checkout succeeded.
         bail!(
-            "{label} pin mismatch after checkout (expected {}, got {})",
+            "{label} pin mismatch after checkout (expected {} resolved from {}, got {})",
+            resolved_pin,
             pin,
             head
         );
@@ -75,30 +79,31 @@ pub(crate) fn sync_repo_to_pin_at_path_with_opts(
     Ok(())
 }
 
+/// Verify that `pin` exists in the repo at `path` and return its resolved
+/// commit SHA. Accepts any revision spec `git rev-parse` understands (SHA,
+/// short SHA, tag, branch); the returned value is always a 40-hex SHA so
+/// callers can compare it byte-for-byte against `HEAD`.
 pub(crate) fn ensure_pin_exists(
     path: &Path,
     source: &str,
     pin: &str,
     label: &str,
-) -> DynResult<()> {
+) -> DynResult<String> {
     let rev = format!("{pin}^{{commit}}");
-    if run_capture(
+    match run_capture(
         Command::new("git")
             .current_dir(path)
             .arg("rev-parse")
             .arg("--verify")
             .arg(&rev),
         &format!("verify pin ({label})"),
-    )
-    .is_err()
-    {
-        bail!(
+    ) {
+        Ok(captured) => Ok(captured.stdout.trim().to_string()),
+        Err(_) => bail!(
             "configured {label} pin {pin} is not available in {} from source `{source}`. Ensure the repo source contains this commit (try `--lez-path` pointing to a repo that has it).",
             path.display(),
-        );
+        ),
     }
-
-    Ok(())
 }
 
 pub(crate) fn ensure_repo_present(
@@ -319,6 +324,33 @@ mod tests {
         let msg = format!("{err:#}");
         assert!(msg.contains("does not match requested source"));
         assert!(msg.contains("Refusing to reuse this repo"));
+    }
+
+    #[test]
+    fn pin_as_tag_succeeds_with_resolved_sha_check() {
+        // Regression: when `[repos.*].pin` is a tag (or any non-SHA ref), the
+        // post-checkout assertion used to compare the raw `pin` string against
+        // the 40-hex HEAD SHA and always fail. Now we compare against the
+        // SHA resolved by `git rev-parse <pin>^{commit}`.
+        let temp = tempdir().expect("tempdir");
+        let source = temp.path().join("source");
+        let cache_repo = temp.path().join("cache/repo");
+
+        let sha = init_repo_with_commit(&source, "a.txt", "a");
+        run_git(&source, &["tag", "v0.2.0"]);
+        git_clone(&source, &cache_repo);
+
+        sync_repo_to_pin_at_path_with_opts(
+            &cache_repo,
+            &source.display().to_string(),
+            "v0.2.0",
+            "lez",
+            RepoSyncOptions::fail_on_source_mismatch(),
+        )
+        .expect("tag-as-pin sync must succeed");
+
+        let head = git_head_sha(&cache_repo).expect("head");
+        assert_eq!(head, sha, "HEAD must resolve to the tagged commit");
     }
 
     #[test]


### PR DESCRIPTION
## Description
`[repos.<name>].pin` semantics imply immutability, but the post-checkout assertion in `sync_repo_to_pin_at_path_with_opts` compared the raw `pin` string against the 40-hex HEAD SHA. When `pin` was a tag or branch ref (e.g. `pin = "v0.2.0"`), `ensure_pin_exists` and `git checkout` both succeeded, then the SHA-equality check on `src/repo.rs:67` always failed with a confusing `"<label> pin mismatch after checkout (expected v0.2.0, got 35d8df…)"` even though the checkout had worked. README/FURPS+ lean on the SHA-pin invariant, and users who follow the natural intuition of writing a tag are silently blocked from `lgs setup`.

## Solution
- `src/repo.rs`: `ensure_pin_exists` already runs `git rev-parse --verify <pin>^{commit}` to verify the pin is reachable; capture and return that resolved 40-hex SHA instead of `()`. `sync_repo_to_pin_at_path_with_opts` now compares HEAD against the resolved SHA, so tag, branch, short-SHA, and full-SHA pins all work. Full-SHA pins continue to round-trip identically.
- The pin-mismatch error message now includes both the resolved SHA and the original `pin` for traceability when the assertion does trip (e.g. a concurrent checkout race).
- New regression test `pin_as_tag_succeeds_with_resolved_sha_check` in `src/repo.rs`'s `mod tests`: initializes a source repo, tags HEAD as `v0.2.0`, clones a cache copy, calls `sync_repo_to_pin_at_path_with_opts` with `pin = "v0.2.0"`, and asserts both the call succeeds and `HEAD` equals the tagged commit SHA.

## Notes
- Chose the friendlier of the two solutions named in the issue ("resolve `pin` to a SHA once and compare the resolved SHA against `head`") rather than rejecting non-SHA pins at config-parse time. This lets users write `pin = "v0.2.0-rc1"` and have it work, which matches the intuition surfaced in the issue. If a stricter "pin must be a SHA" invariant is desirable later, it can be layered on top in `parse_repo_ref`.
- `ensure_pin_exists` is `pub(crate)` and only has one in-tree caller (`sync_repo_to_pin_at_path_with_opts`); the signature change from `DynResult<()>` to `DynResult<String>` is contained.
- Full test suite (238 unit + 135 integration + new test) passes on this branch. Pre-existing clippy warnings in `basecamp.rs`, `wallet_support.rs`, `doctor_checks.rs`, and `process.rs` are unrelated to this change.

Closes #111

---
Run ID: 20260512-001011
Authored by: scaffold-wozos-issue-impl recurring task (claude-code worker)