### PR TITLE
fix(localnet): write patched sequencer config to project-owned state dir

### DIFF
--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -5,7 +5,7 @@ use std::process::Command;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use anyhow::{bail, Context};
+use anyhow::{anyhow, bail, Context};
 use serde_json::Value;
 
 use crate::circuits::ensure_circuits_for_subprocess;
@@ -214,16 +214,24 @@ fn cmd_localnet_start(
         bail!("{message}");
     }
 
-    patch_sequencer_config(lez, localnet_port)?;
+    let state_dir = state_path.parent().ok_or_else(|| {
+        anyhow!(
+            "localnet state path has no parent directory: {}",
+            state_path.display()
+        )
+    })?;
+    let patched_config_path = prepare_sequencer_config(lez, state_dir, localnet_port)?;
 
     // Use a path relative to lez (the child's cwd), not relative to the
     // parent's cwd.  `current_dir(lez)` applies before exec, so a parent-
     // relative path like `.scaffold/cache/repos/lez/target/release/…`
-    // would be resolved inside lez and fail with ENOENT.
+    // would be resolved inside lez and fail with ENOENT. The patched config
+    // path is absolute (under the project's `.scaffold/state/`), so it is
+    // unaffected by the cwd switch.
     let sequencer_pid = spawn_to_log(
         Command::new(format!("./{SEQUENCER_BIN_REL_PATH}"))
             .current_dir(lez)
-            .arg(SEQUENCER_CONFIG_REL_PATH)
+            .arg(&patched_config_path)
             .env("RUST_LOG", "info")
             .env("RISC0_DEV_MODE", if risc0_dev_mode { "1" } else { "0" }),
         log_path,
@@ -490,10 +498,24 @@ fn build_status_report(
     }
 }
 
-/// Patch `sequencer_config.json` so the sequencer listens on the configured
-/// port and accepts a block size large enough for scaffold's bundled deploy
-/// flow. The pinned LEZ version does not accept `--port` as a CLI flag — it
-/// reads everything from this file.
+/// Produce a sequencer config patched for scaffold's localnet — port set to
+/// the project's configured port and `max_block_size` widened so the bundled
+/// deploy flow fits in a single block — and return the absolute path to the
+/// patched file. The pinned LEZ version does not accept `--port` as a CLI flag
+/// — it reads everything from the config file passed as its first argument.
+///
+/// The patched copy is written under `dest_dir` (the project's
+/// `.scaffold/state/`), **not** back into the vendored LEZ checkout. Writing
+/// into the vendored repo would silently break three invariants the rest of
+/// scaffold relies on:
+///   1. `git_clean(lez)` would always report dirty, disabling the
+///      `AutoRecloneIfClean` safety net in `reconcile_repo_source` for cache
+///      repos.
+///   2. A `git checkout` during a pin bump would discard the patch, leaving
+///      the next `localnet start` running against unmodified upstream config
+///      until scaffold re-patches.
+///   3. `git status` in the LEZ tree would be permanently dirty after the
+///      first `localnet start`, hiding genuine local edits.
 ///
 /// Block-size bump: the upstream debug config caps `max_block_size` at 1 MiB,
 /// which a `lgs deploy` of the default template (5 risc0 guest ELFs ≈ 360 KiB
@@ -501,17 +523,17 @@ fn build_status_report(
 /// rather than carrying the deferred tx forward. Until LEZ stops aborting on
 /// deferral, scaffold widens the limit so the documented first-success path
 /// fits in a single block.
-fn patch_sequencer_config(lez: &Path, port: u16) -> DynResult<()> {
-    let config_path = lez.join(SEQUENCER_CONFIG_REL_PATH);
-    let text = fs::read_to_string(&config_path)
-        .with_context(|| format!("failed to read {}", config_path.display()))?;
+fn prepare_sequencer_config(lez: &Path, dest_dir: &Path, port: u16) -> DynResult<PathBuf> {
+    let src_path = lez.join(SEQUENCER_CONFIG_REL_PATH);
+    let text = fs::read_to_string(&src_path)
+        .with_context(|| format!("failed to read {}", src_path.display()))?;
     let mut doc: Value =
         serde_json::from_str(&text).context("failed to parse sequencer_config.json")?;
 
     let Some(obj) = doc.as_object_mut() else {
         bail!(
             "sequencer_config.json is not a JSON object: {}",
-            config_path.display()
+            src_path.display()
         );
     };
     obj.insert("port".to_string(), Value::Number(port.into()));
@@ -520,10 +542,13 @@ fn patch_sequencer_config(lez: &Path, port: u16) -> DynResult<()> {
         Value::String("8 MiB".to_string()),
     );
 
+    fs::create_dir_all(dest_dir)
+        .with_context(|| format!("failed to create {}", dest_dir.display()))?;
+    let dest_path = dest_dir.join("sequencer_config.json");
     let updated = serde_json::to_string_pretty(&doc).context("failed to serialize config")?;
-    fs::write(&config_path, format!("{updated}\n"))
-        .with_context(|| format!("failed to write {}", config_path.display()))?;
-    Ok(())
+    fs::write(&dest_path, format!("{updated}\n"))
+        .with_context(|| format!("failed to write {}", dest_path.display()))?;
+    Ok(dest_path)
 }
 
 fn read_log_tail(log_path: &Path, tail: usize) -> String {
@@ -840,12 +865,18 @@ mod tests {
     use std::net::TcpListener;
     use std::time::Duration;
 
-    use super::{reset_cleanup, verify_block_production, wait_for_pid_exit, wait_for_port_free};
+    use super::{
+        prepare_sequencer_config, reset_cleanup, verify_block_production, wait_for_pid_exit,
+        wait_for_port_free,
+    };
     use crate::commands::wallet_support::wallet_state_path;
+    use crate::constants::SEQUENCER_CONFIG_REL_PATH;
     use crate::error::ResetError;
     use crate::model::{
         Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig, Project, RepoRef, RunConfig,
     };
+    use crate::repo::git_clean;
+    use std::process::Command;
 
     fn make_test_project(temp: &tempfile::TempDir) -> (Project, PathBuf) {
         let lez_dir = temp.path().join(".scaffold/cache/repos/lez");
@@ -971,6 +1002,90 @@ mod tests {
         let err = wait_for_port_free(&addr, Duration::from_millis(300));
         drop(listener);
         assert!(err.is_err(), "expected timeout while listener was open");
+    }
+
+    /// Regression test for #114. `prepare_sequencer_config` must write the
+    /// patched copy under `dest_dir` (project-owned state) and leave the
+    /// vendored LEZ checkout byte-identical — otherwise `git_clean(lez)`
+    /// reports dirty and the `AutoRecloneIfClean` safety net in
+    /// `reconcile_repo_source` is silently disabled for cache repos.
+    #[test]
+    fn prepare_sequencer_config_does_not_dirty_vendored_lez_repo() {
+        let temp = tempdir().unwrap();
+        let lez = temp.path().join("lez");
+        let state_dir = temp.path().join(".scaffold/state");
+
+        // Build a real git repo under `lez` with the sequencer config committed
+        // at its real relative path, so `git status --porcelain` is initially
+        // empty and we can see any write-back to that file as a dirty diff.
+        let config_path = lez.join(SEQUENCER_CONFIG_REL_PATH);
+        fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        fs::write(&config_path, "{\n  \"port\": 3040\n}\n").unwrap();
+
+        let git_init = Command::new("git")
+            .args(["init", "--quiet", "--initial-branch=main"])
+            .current_dir(&lez)
+            .status()
+            .unwrap();
+        assert!(git_init.success(), "git init failed");
+        // Local identity so `git commit` doesn't require system-level config.
+        for (k, v) in [("user.email", "t@example.com"), ("user.name", "test")] {
+            Command::new("git")
+                .args(["config", k, v])
+                .current_dir(&lez)
+                .status()
+                .unwrap();
+        }
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(&lez)
+            .status()
+            .unwrap();
+        let commit = Command::new("git")
+            .args(["commit", "--quiet", "-m", "seed"])
+            .current_dir(&lez)
+            .status()
+            .unwrap();
+        assert!(commit.success(), "git commit failed");
+
+        assert!(
+            git_clean(&lez).unwrap(),
+            "test precondition: seeded lez tree should be clean"
+        );
+
+        let dest = prepare_sequencer_config(&lez, &state_dir, 4040).unwrap();
+
+        assert_eq!(
+            dest,
+            state_dir.join("sequencer_config.json"),
+            "patched config must land under the project state dir, not the lez repo"
+        );
+
+        let dest_json: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&dest).unwrap()).unwrap();
+        assert_eq!(dest_json["port"], serde_json::json!(4040));
+        assert_eq!(
+            dest_json["max_block_size"],
+            serde_json::json!("8 MiB"),
+            "patched copy should carry the widened max_block_size override"
+        );
+
+        let src_after: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(
+            src_after["port"],
+            serde_json::json!(3040),
+            "vendored sequencer_config.json must be left untouched"
+        );
+        assert!(
+            src_after.get("max_block_size").is_none(),
+            "vendored sequencer_config.json must be left untouched (no max_block_size injected)"
+        );
+
+        assert!(
+            git_clean(&lez).unwrap(),
+            "lez tree must remain clean after prepare_sequencer_config"
+        );
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -985,23 +985,45 @@ fn localnet_start_patches_config_and_uses_configured_port() {
         .assert()
         .success();
 
-    // Verify sequencer_config.json was patched with the configured port
-    let patched_config = fs::read_to_string(&config_path).expect("read patched config");
+    // The vendored config in the lez checkout must be left untouched.
+    // Regression for #114: in-place mutation broke `git_clean(lez)` and
+    // silently disabled the cache-repo auto-reclone safety net.
+    let vendored_after = fs::read_to_string(&config_path).expect("read vendored config");
+    let vendored_json: serde_json::Value =
+        serde_json::from_str(&vendored_after).expect("parse vendored config");
+    assert_eq!(
+        vendored_json["port"],
+        serde_json::Value::Number(3040.into()),
+        "vendored sequencer_config.json must not be mutated, got: {vendored_after}"
+    );
+
+    // The patched copy lives under the project's `.scaffold/state/`.
+    let patched_path = temp.path().join(".scaffold/state/sequencer_config.json");
+    let patched_config = fs::read_to_string(&patched_path).expect("read patched config");
     let config_json: serde_json::Value =
         serde_json::from_str(&patched_config).expect("parse patched config");
     assert_eq!(
         config_json["port"],
         serde_json::Value::Number(localnet_port.into()),
-        "expected port in sequencer_config.json to be patched to {localnet_port}, got: {patched_config}"
+        "expected port in patched sequencer_config.json to be {localnet_port}, got: {patched_config}"
     );
     assert_eq!(
         config_json["max_block_size"],
         serde_json::Value::String("8 MiB".to_string()),
-        "expected max_block_size in sequencer_config.json to be widened so multi-program deploys fit, got: {patched_config}"
+        "expected max_block_size in patched sequencer_config.json to be widened so multi-program deploys fit, got: {patched_config}"
+    );
+
+    // The sequencer must have been invoked with the absolute path to the
+    // patched copy, not the in-repo relative path.
+    let args = fs::read_to_string(&args_log).expect("read args log");
+    assert!(
+        args.lines()
+            .any(|line| line == patched_path.to_string_lossy()),
+        "expected sequencer to receive patched config path {}, got args: {args}",
+        patched_path.display()
     );
 
     // Verify --port was NOT passed as a CLI arg
-    let args = fs::read_to_string(&args_log).expect("read args log");
     assert!(
         !args.contains("--port"),
         "expected --port NOT to appear in sequencer args, got: {args}"


### PR DESCRIPTION
## Description

`logos-scaffold localnet start` currently mutates `sequencer_config.json` *inside the vendored LEZ checkout* on every invocation. That file is tracked in the LEZ git tree, so the write-back silently breaks three contracts the rest of scaffold relies on:

1. `git_clean(lez)` always reports dirty after the first start, which disables the `AutoRecloneIfClean` safety net in `reconcile_repo_source` for cache repos.
2. A `git checkout` triggered by a pin bump (via `sync_repo_to_pin_at_path_with_opts`) silently discards the patch, so the next `localnet start` runs against unmodified upstream config until scaffold re-patches.
3. `git status` in the LEZ tree is permanently dirty, hiding genuine local edits.

## Solution

- Replace `patch_sequencer_port(lez, port)` with `prepare_sequencer_config(lez, dest_dir, port) -> PathBuf` (`src/commands/localnet.rs`). The new helper reads the upstream config, sets the port, and writes the patched copy to `<dest_dir>/sequencer_config.json` — never back into the vendored tree.
- In `cmd_localnet_start`, derive `dest_dir` from `state_path.parent()` (i.e. `<project>/.scaffold/state/`) and pass the returned absolute path to the sequencer. The sequencer's working directory stays at `lez`, so any relative paths inside the config still resolve exactly as they did before.
- Add a unit regression test `prepare_sequencer_config_does_not_dirty_vendored_lez_repo` that seeds a real git repo at the lez path, runs the new helper, and asserts `git_clean(lez)` returns true and the vendored file is byte-identical.
- Update `localnet_start_patches_config_and_uses_configured_port` (in `tests/cli.rs`) to assert: the vendored config is unchanged (port stays at the seeded 3040), the patched copy lives at `<project>/.scaffold/state/sequencer_config.json` with the configured port, and the sequencer is invoked with the absolute path to that patched copy.

## Notes

- The pinned LEZ sequencer reads its port from the file passed as its first positional arg. Absolute paths work without further changes since the sequencer is launched with `current_dir(lez)` and the patched file lives outside the lez tree.
- `cmd_localnet_reset` re-uses `cmd_localnet_start`, so the same fix applies to `localnet reset` without further changes.
- The patched copy is regenerated on every start, so no extra cleanup is needed when the port changes; `cmd_localnet_stop` and `reset_cleanup` are unchanged.
- Full test suite: 238 unit + 135 integration, all passing.

Closes #114

---
Run ID: 20260512-004012
Authored by: scaffold-wozos-issue-impl recurring task (claude-code worker)