### PR TITLE
fix(localnet): confirm sequencer exit before deleting state file

### DIFF
--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -271,7 +271,38 @@ fn cmd_localnet_stop(state_path: &Path, localnet_port: u16) -> DynResult<()> {
     if let Some(pid) = report.tracked_pid {
         if report.tracked_running {
             println!("$ kill {pid} # sequencer");
-            let _ = Command::new("kill").arg(pid.to_string()).status();
+            let kill_output = Command::new("kill")
+                .arg(pid.to_string())
+                .output()
+                .context("failed to spawn `kill`")?;
+            let kill_succeeded = kill_output.status.success();
+
+            // Wait for the process to actually exit, regardless of `kill`'s
+            // exit code: TERM may have been delivered even if `kill` returned
+            // non-zero (race with reaping). If the process is still alive
+            // after the deadline, do not remove the state file — we still
+            // legitimately track this pid.
+            let pid_timeout = Duration::from_secs(5);
+            if !wait_for_pid_exit(pid, pid_timeout) {
+                if !kill_succeeded {
+                    let stderr = String::from_utf8_lossy(&kill_output.stderr)
+                        .trim()
+                        .to_string();
+                    return Err(LocalnetError::StopKillFailed { pid, stderr }.into());
+                }
+                return Err(LocalnetError::StopTimeout {
+                    pid,
+                    timeout_sec: pid_timeout.as_secs(),
+                }
+                .into());
+            }
+
+            // Process exited; wait briefly for the bound socket to be released
+            // so an immediate `localnet start` doesn't race the still-bound
+            // port. A timeout here is not fatal — the port may be held by a
+            // foreign listener that survived our sequencer, and `localnet
+            // start` will surface that with a more specific error.
+            let _ = wait_for_port_free(&localnet_addr, Duration::from_secs(5));
         } else {
             println!("sequencer state is stale (pid={pid} not running)");
         }
@@ -574,6 +605,21 @@ fn remove_file_if_exists(path: &Path, label: &str) -> DynResult<()> {
     Ok(())
 }
 
+/// Poll `pid` until it is no longer running (exited or zombie), or `timeout`
+/// elapses. Returns `true` if the process exited within the deadline.
+fn wait_for_pid_exit(pid: u32, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if !pid_running(pid) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
 /// Poll `localnet_addr` until no listener is accepting, or `timeout` elapses.
 fn wait_for_port_free(localnet_addr: &str, timeout: Duration) -> Result<(), ()> {
     let deadline = Instant::now() + timeout;
@@ -629,7 +675,7 @@ mod tests {
     use std::net::TcpListener;
     use std::time::Duration;
 
-    use super::{reset_cleanup, verify_block_production, wait_for_port_free};
+    use super::{reset_cleanup, verify_block_production, wait_for_pid_exit, wait_for_port_free};
     use crate::commands::wallet_support::wallet_state_path;
     use crate::error::ResetError;
     use crate::model::{
@@ -760,6 +806,38 @@ mod tests {
         let err = wait_for_port_free(&addr, Duration::from_millis(300));
         drop(listener);
         assert!(err.is_err(), "expected timeout while listener was open");
+    }
+
+    #[test]
+    fn wait_for_pid_exit_returns_true_after_process_dies() {
+        // Spawn a long sleep, then SIGKILL it. wait_for_pid_exit must observe
+        // the exit within the timeout — this is the success path that
+        // `cmd_localnet_stop` relies on before deleting the state file.
+        let mut child = std::process::Command::new("sleep")
+            .arg("10")
+            .spawn()
+            .expect("spawn sleep");
+        let pid = child.id();
+        child.kill().expect("kill sleep");
+        let exited = wait_for_pid_exit(pid, Duration::from_secs(2));
+        let _ = child.wait();
+        assert!(exited, "expected pid {pid} to exit within 2s after SIGKILL");
+    }
+
+    #[test]
+    fn wait_for_pid_exit_returns_false_when_pid_stays_alive() {
+        // While the child is still running, wait_for_pid_exit must time out
+        // rather than report success — this is the failure path that
+        // `cmd_localnet_stop` relies on to preserve the state file.
+        let mut child = std::process::Command::new("sleep")
+            .arg("10")
+            .spawn()
+            .expect("spawn sleep");
+        let pid = child.id();
+        let exited = wait_for_pid_exit(pid, Duration::from_millis(200));
+        let _ = child.kill();
+        let _ = child.wait();
+        assert!(!exited, "expected timeout while pid {pid} was still alive");
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,19 @@ pub(crate) enum LocalnetError {
         pid: u32,
         log_tail: String,
     },
+
+    #[error(
+        "failed to send TERM to sequencer (pid={pid}): {stderr}\n\
+         localnet state file preserved; resolve the kill failure manually and retry."
+    )]
+    StopKillFailed { pid: u32, stderr: String },
+
+    #[error(
+        "sequencer did not exit within {timeout_sec}s of TERM (pid={pid}).\n\
+         localnet state file preserved; the process may be ignoring TERM. \
+         Try `kill -9 {pid}` and retry `logos-scaffold localnet stop`."
+    )]
+    StopTimeout { pid: u32, timeout_sec: u64 },
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
## Description
`cmd_localnet_stop` (`src/commands/localnet.rs`) sent SIGTERM to the tracked sequencer pid, discarded the result, and immediately deleted `.scaffold/state/localnet.state`. If `kill` failed (permission denied, blocked signal, raced reap), scaffold lost track of a still-running sequencer and the next `localnet start` reported `LocalnetOwnership::Foreign`. If `kill` succeeded but the sequencer hadn't exited yet (TERM is async), the state file was removed before the bound port was released, so an immediate `localnet start` raced the still-bound socket. The stop→start sequence is the documented recovery path for stuck localnets, so silent state divergence here directly undermines the recovery flow that `LocalnetOwnership::StaleState` was added to surface.

## Solution
- Capture the exit status and stderr of `kill <pid>` instead of discarding them.
- Add a private `wait_for_pid_exit(pid, timeout)` helper that polls `pid_running` and returns whether the process exited within the deadline.
- In `cmd_localnet_stop`, wait up to 5s for the pid to exit after issuing TERM, then wait up to 5s for the bound port to be released before deleting the state file. If the pid is still alive after the deadline, return a typed `LocalnetError::StopKillFailed` (when `kill` reported failure) or `LocalnetError::StopTimeout` (when `kill` succeeded but the sequencer ignored TERM) and leave the state file in place so the tracked pid is still recoverable.
- Two new error variants in `src/error.rs` carry the pid and remediation hints (including the `kill -9 <pid>` fallback).
- Two unit tests for `wait_for_pid_exit`: one verifies the success path (spawn `sleep`, SIGKILL it, assert exit observed within 2s); the other verifies the timeout path (spawn `sleep`, assert no exit within 200ms while still running).

Files changed: `src/commands/localnet.rs`, `src/error.rs`.

## Notes
- TERM may have been delivered even when `kill` returns non-zero (eg. the process was reaped between the `pid_running` check and `kill`), so we wait for `pid_running` before deciding the kill truly failed. Only if both `kill` failed and the pid is still alive after the timeout do we report `StopKillFailed`.
- `wait_for_pid_exit` uses `pid_running` (not `pid_alive`), so a process that has exited but is still a zombie counts as "exited" — which is what `localnet start` cares about (the port is released when the process exits, not when it is reaped).
- The post-exit `wait_for_port_free` call uses a swallowed timeout: if the port is still held after the pid exited, the holder is something foreign and `localnet start` will surface that with its own (more specific) error.
- Pre-existing `cargo clippy -- -D warnings` failures (in `src/commands/basecamp.rs` and elsewhere) exist on `master`; this PR does not address them.

Closes #116

---
Run ID: 20260512-010012
Authored by: scaffold-wozos-issue-impl recurring task (claude-code worker)