### PR TITLE
fix(basecamp): pass --no-link so build-portable stops leaking result-* symlinks into flake source dirs

### DIFF
--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -814,8 +814,14 @@ fn swap_flake_attr(flake_ref: &str, expected: &str, replacement: &str) -> String
 
 /// Command-line arguments (after `nix`) plus an optional working-directory
 /// override. For `path:<abs>#<attr>` refs we cd into `<abs>` and invoke
-/// `nix build .#<attr>` so the default `./result-<attr>` symlink lands next
-/// to the flake. For remote refs we stay in the caller's cwd.
+/// `nix build .#<attr>`; for remote refs we stay in the caller's cwd.
+///
+/// `--no-link` is always passed: callers parse `--print-out-paths` stdout
+/// for the resolved store paths, and `cmd_basecamp_build_portable` creates
+/// its own load-ordered symlinks under `.scaffold/basecamp/portable/`. The
+/// default `nix build` `result-<attr>` symlink would otherwise land inside
+/// each `path:` flake's source directory — polluting the user's working
+/// copy with untracked files on every run.
 #[derive(Debug, PartialEq, Eq)]
 struct NixBuildInvocation {
     cwd_override: Option<PathBuf>,
@@ -843,6 +849,7 @@ fn build_portable_nix_invocation(
         args.push(name.clone());
         args.push(value.clone());
     }
+    args.push("--no-link".to_string());
     args.push("--print-out-paths".to_string());
 
     NixBuildInvocation { cwd_override, args }
@@ -3186,7 +3193,12 @@ mod tests {
         assert_eq!(inv.cwd_override.as_deref(), Some(Path::new("/abs/to/foo")));
         assert_eq!(
             inv.args,
-            vec!["build", ".#lgx-portable", "--print-out-paths"]
+            vec![
+                "build",
+                ".#lgx-portable",
+                "--no-link",
+                "--print-out-paths",
+            ]
         );
     }
 
@@ -3199,21 +3211,41 @@ mod tests {
         );
         assert_eq!(
             inv.args,
-            vec!["build", "github:foo/bar#lgx-portable", "--print-out-paths"]
+            vec![
+                "build",
+                "github:foo/bar#lgx-portable",
+                "--no-link",
+                "--print-out-paths",
+            ]
         );
     }
 
     #[test]
-    fn build_portable_nix_invocation_does_not_use_out_link() {
-        // Spec: `nix build` without `-o`, so the default `./result-<attr>` symlink
-        // lands next to the flake. No `--out-link`, no `--no-link`.
-        let inv = build_portable_nix_invocation("path:/abs/a#lgx-portable", &[]);
-        for forbidden in ["-o", "--out-link", "--no-link"] {
+    fn build_portable_nix_invocation_passes_no_link() {
+        // Regression guard for the stray-`result-*`-symlink bug: when the
+        // path:-ref branch cds into the flake source dir, `nix build` would
+        // otherwise drop a `result-<attr>` symlink there on every run. We
+        // rely on `--print-out-paths` for the store paths and create our
+        // own symlinks under `.scaffold/basecamp/portable/`, so `--no-link`
+        // is required regardless of ref kind.
+        for flake_ref in [
+            "path:/abs/a#lgx-portable",
+            "github:foo/bar#lgx-portable",
+            "git+https://example.com/repo#lgx-portable",
+        ] {
+            let inv = build_portable_nix_invocation(flake_ref, &[]);
             assert!(
-                !inv.args.iter().any(|a| a == forbidden),
-                "argv must not contain `{forbidden}`: {:?}",
+                inv.args.iter().any(|a| a == "--no-link"),
+                "argv for `{flake_ref}` must contain `--no-link`: {:?}",
                 inv.args
             );
+            for forbidden in ["-o", "--out-link"] {
+                assert!(
+                    !inv.args.iter().any(|a| a == forbidden),
+                    "argv for `{flake_ref}` must not contain `{forbidden}`: {:?}",
+                    inv.args
+                );
+            }
         }
     }
 
@@ -3231,6 +3263,7 @@ mod tests {
                 "--override-input",
                 "core",
                 "path:/abs/core",
+                "--no-link",
                 "--print-out-paths",
             ]
         );


### PR DESCRIPTION
## Description
`basecamp build-portable` cds into each `path:` flake's source directory and invokes `nix build .#<attr>` without `--out-link` or `--no-link`. Nix's default behavior drops a `result-<attr>` symlink into the current directory — which for a `path:` flake is the user's source tree. Every `build-portable` run leaves one stray `result-lgx-portable` per sub-flake in the user's working copy; they accumulate as untracked files in `git status` and never get cleaned up. The same flow already maintains its own canonical mirror under `.scaffold/basecamp/portable/`, so the default symlinks are pure pollution and violate the ADR safety contract that scaffold writes only inside `.scaffold/`.

## Solution
- `src/commands/basecamp.rs::build_portable_nix_invocation`: append `--no-link` to the nix argv before `--print-out-paths`. The caller already parses store paths from `--print-out-paths` stdout and materializes its own load-ordered symlinks (`.scaffold/basecamp/portable/{NN}-{name}.lgx`), so suppressing the default `result-*` symlink is lossless. Applied to both the `path:` ref branch (the bug's primary site) and the remote-ref branch, so all `nix build` invocations from this code path are consistent.
- Updated the `NixBuildInvocation` docstring to record the invariant and the reason for it.
- Tests:
  - Removed `build_portable_nix_invocation_does_not_use_out_link` — that assertion was codifying the bug (it forbade `--no-link`).
  - Added `build_portable_nix_invocation_passes_no_link` as the regression guard: asserts `--no-link` is present and `-o` / `--out-link` are absent for `path:`, `github:`, and `git+https:` refs.
  - Updated the three existing tests whose expected argv vectors needed the new `--no-link` entry.

## Notes
- `--no-link` was chosen over `--out-link <path>` because the caller does not consume the default symlink. Adding an `--out-link` target under `.scaffold/cache/basecamp/portable/result-<slug>` would create a second copy of state the existing `.scaffold/basecamp/portable/` symlinks already cover, and would require a new wipe-on-each-run cleanup path. `--no-link` is the minimal change.
- No new external dependencies. No `nix` version requirement change — `--no-link` has been a stable `nix build` flag since the Nix 2.4 CLI; the repo already uses `--print-out-paths` from the same era.
- The bug only surfaces when at least one project module is sourced as `path:`. Remote-only setups (all `github:` refs) were never affected, but applying `--no-link` to them too prevents a future regression if anyone switches the project root cwd model.
- Build: `cargo build` and `cargo build --release` succeeded.
- Tests: `cargo test` — 237 unit tests + 135 integration tests passed, 0 failed. The four targeted invocation tests (`build_portable_nix_invocation_*`) all pass under the new argv shape.

Closes #117

---
Run ID: 20260512-011013
Authored by: scaffold-wozos-issue-impl recurring task (claude-code worker)