### PR TITLE
fix(run): warn when spel repo cannot be resolved instead of silently disabling SCAFFOLD_PROGRAM_ID

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -233,8 +233,22 @@ fn single_program_binary(project: &Project) -> DynResult<Option<PathBuf>> {
 }
 
 fn resolve_spel_bin(project: &Project) -> Option<PathBuf> {
-    let spel = resolve_repo_path(project, &project.config.spel, "spel").ok()?;
-    Some(spel.join(SPEL_BIN_REL_PATH))
+    // Surface resolver failures rather than silently dropping them: the most
+    // common reasons `resolve_repo_path` errors here are exactly the cases
+    // the user cares about (misconfigured `[repos.spel]`, missing
+    // `cache_root`, broken pin). Without this warning, deploy succeeds and
+    // every post-deploy hook runs with `SCAFFOLD_PROGRAM_ID` /
+    // `SCAFFOLD_GUEST_BIN` mysteriously unset.
+    match resolve_repo_path(project, &project.config.spel, "spel") {
+        Ok(p) => Some(p.join(SPEL_BIN_REL_PATH)),
+        Err(e) => {
+            eprintln!(
+                "warning: cannot resolve spel binary: {e}; \
+                 SCAFFOLD_PROGRAM_ID will be unset for post-deploy hooks"
+            );
+            None
+        }
+    }
 }
 
 fn run_post_deploy_hook(
@@ -542,6 +556,32 @@ mod tests {
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "unset");
+    }
+
+    #[test]
+    fn resolve_spel_bin_returns_none_when_repo_unresolvable() {
+        // Regression for the silent-error-swallowing bug: when
+        // `[repos.spel]` is misconfigured (both path and pin empty),
+        // `resolve_spel_bin` must return `None` rather than panic, so the
+        // caller can still produce a `SingleProgram` with `program_id: None`
+        // and the post-deploy hook keeps running. The accompanying stderr
+        // warning is exercised in the binary via `eprintln!` and isn't
+        // captured here — what we lock in is that the failure mode stays
+        // `None`, not a panic.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut project = make_test_project(temp.path().to_path_buf());
+        // Force `resolve_repo_path` to error: path empty AND pin empty.
+        project.config.spel = RepoRef {
+            source: "spel".to_string(),
+            path: String::new(),
+            pin: String::new(),
+            ..Default::default()
+        };
+        // Also blank the cache_root so the env layer doesn't accidentally
+        // succeed in a sandbox.
+        project.config.cache_root = String::new();
+
+        assert!(resolve_spel_bin(&project).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Description

`lgs run`'s post-deploy hook contract advertises `SCAFFOLD_PROGRAM_ID` and `SCAFFOLD_GUEST_BIN` as env vars hooks can rely on for the single-program shortcut. Today, if the spel repo can't be resolved (a misconfigured `[repos.spel]`, missing `cache_root`, or a broken pin), `resolve_spel_bin` discards the error via `.ok()?` and the deploy proceeds with both env vars silently unset. A hook line like `--idl $SCAFFOLD_IDL_DIR/counter.json -p $SCAFFOLD_GUEST_BIN init` then fails downstream with a confusing "no such file or directory" that points the user nowhere near the real cause. This is the worst diagnostic shape for the documented inner-loop entry point.

## Solution

- Replace the `.ok()?` swallow in `resolve_spel_bin` (`src/commands/run.rs`) with a `match` that emits a single-line `eprintln!` warning before returning `None`. The warning names the resolver error and the user-visible consequence (`SCAFFOLD_PROGRAM_ID will be unset for post-deploy hooks`).
- Behavior preserved: the function still returns `None` on failure, so the caller (`resolve_single_program_metadata`) keeps producing a `SingleProgram` with `program_id: None` and post-deploy hooks still run. Only the *silence* of the failure changes.
- Added regression test `resolve_spel_bin_returns_none_when_repo_unresolvable` in `src/commands/run.rs` covering the misconfigured-`[repos.spel]` path (empty `path` AND empty `pin`) — locking in that the failure mode stays `None` rather than a panic. The `eprintln!` itself is exercised through the binary and isn't captured by the unit test.

## Notes

- Diagnostic shape mirrors the existing "spel inspect timed out / not built" path in `extract_program_id` (`src/commands/deploy.rs:493`), keeping operators with one consistent place to look for spel-related failures.
- A harder option — bailing the whole `run` pipeline at this point — was considered and rejected: deploy has already succeeded by the time hooks run, and hooks that don't reference `SCAFFOLD_PROGRAM_ID` shouldn't be punished for a stale `[repos.spel]`. The warning lets the user see the cause without altering the pipeline contract.
- No new dependencies. Build clean. `cargo test --lib` passes (238 tests, including the new one).

Closes #119

---
Run ID: 20260512-013014
Authored by: scaffold-wozos-issue-impl recurring task (claude-code worker)