### PR TITLE
docs: update [basecamp.modules.*] references to [modules.*] in dogfooding and module-requirements

### DIFF
--- a/DOGFOODING.md
+++ b/DOGFOODING.md
@@ -892,7 +892,7 @@ From the module project root:
 
 ```bash
 "$SCAFFOLD_BIN" basecamp modules
-grep -n '^\[basecamp' scaffold.toml
+grep -n '^\[modules\.' scaffold.toml
 "$SCAFFOLD_BIN" basecamp modules --show
 "$SCAFFOLD_BIN" basecamp install
 "$SCAFFOLD_BIN" basecamp install --print-output
@@ -909,12 +909,12 @@ If your project does not auto-discover correctly, capture explicit sources:
 
 ### Expected Success Signals
 
-- `basecamp modules` either auto-discovers project sub-flakes exposing `.#lgx` or accepts explicit `--path` / `--flake` sources and writes one `[basecamp.modules.<name>]` sub-section per source into `scaffold.toml`. The file remains human-editable; re-runs are byte-identical and never overwrite existing keys.
-- For each captured project source, scaffold also resolves declared `dependencies` and inserts `role = "dependency"` entries unless the dep is already keyed, is a basecamp preinstall (`capability_module`, `package_manager`, `counter`, `webview_app`, and their `_ui` siblings), or is resolvable via the source's own `flake.lock` / the scaffold-default table.
-- An unresolvable dep fails fast with a targeted error naming the dep and the two user-side fixes (capture as a project source, or add `[basecamp.modules.<name>]` with `role = "dependency"`); no silent drop.
+- `basecamp modules` either auto-discovers project sub-flakes exposing `.#lgx` or accepts explicit `--path` / `--flake` sources and writes one `[modules.<name>]` sub-section per source into `scaffold.toml`. The file remains human-editable; re-runs are byte-identical and never overwrite existing keys.
+- For each captured project source, scaffold also resolves declared `dependencies` and inserts `role = "dependency"` entries unless the dep is already keyed, is a basecamp preinstall (`capability_module`, `package_manager`, `package_manager_ui`, `counter`, `counter_qml`, `webview_app`, `basecamp_main_ui`; see `BASECAMP_PREINSTALLED_MODULES` in `src/constants.rs` for the authoritative list), or is resolvable via the source's own `flake.lock` / the scaffold-default table.
+- An unresolvable dep fails fast with a targeted error naming the dep and the two user-side fixes (capture as a project source, or add `[modules.<name>]` with `role = "dependency"`); no silent drop.
 - `basecamp modules --show` prints the captured set without mutating state.
 - `basecamp install` builds each project source (sibling `--override-input` rewrites apply for `path:../<sibling>` inputs in multi-flake projects) and shells out to `lgpm` to install into both `alice` and `bob`. By default it logs to `.scaffold/logs/<ts>-install.log` and prints a one-line status; `--print-output` (or `LOGOS_SCAFFOLD_PRINT_OUTPUT=1`) streams nix output directly.
-- `basecamp doctor` reports each profile's installed modules matching the captured set; drift between `[basecamp.modules]` and on-disk profile state is flagged, not hidden.
+- `basecamp doctor` reports each profile's installed modules matching the captured set; drift between `[modules]` and on-disk profile state is flagged, not hidden.
 - `basecamp launch alice` kills any prior `logos_host` / `logos-basecamp` descendants for that profile, scrubs the profile's XDG dirs under `.scaffold/basecamp/profiles/alice/`, reinstalls each captured source for that profile, sets `XDG_{CONFIG,DATA,CACHE}_HOME` plus `LOGOS_PROFILE=alice`, and `exec`s basecamp.
 
 ### Failure Signals / Common Pitfalls
@@ -923,12 +923,12 @@ If your project does not auto-discover correctly, capture explicit sources:
 - Re-running `basecamp modules` overwriting an existing key is a regression — manual edits in `scaffold.toml` must win.
 - An unresolved transitive `logos-module-builder` input that fails without naming the missing `follows` is a regression.
 - `install` succeeding when a build or `lgpm install` step actually failed is a fail; exit codes must be non-zero on any source failure.
-- `launch alice` with an empty `[basecamp.modules]` and without `--no-clean` must bail (rather than scrubbing the profile and leaving it empty).
+- `launch alice` with an empty `[modules]` and without `--no-clean` must bail (rather than scrubbing the profile and leaving it empty).
 - Sibling `--override-input` not being applied at probe time would surface as a build that resolves the wrong sibling pin during `basecamp modules` auto-discovery; record any such mismatch with the exact derived module names.
 
 ### Evidence to Capture
 
-- `scaffold.toml` excerpt showing `[basecamp.modules.<name>]` sub-sections with `flake`, `role`, and (for project sources) the in-project relative path used.
+- `scaffold.toml` excerpt showing `[modules.<name>]` sub-sections with `flake`, `role`, and (for project sources) the in-project relative path used.
 - `basecamp modules --show` output.
 - `basecamp install` log path under `.scaffold/logs/` plus the printed one-line status, or the `--print-output` stream.
 - `basecamp doctor` output post-install.
@@ -936,7 +936,7 @@ If your project does not auto-discover correctly, capture explicit sources:
 
 ### Execution Notes
 
-- `basecamp modules` is the sole automated writer of `[basecamp.modules]`. If the user manually edited an entry, do not re-run `basecamp modules` mid-scenario without recording the pre-edit state — manual entries are intentionally preserved.
+- `basecamp modules` is the sole automated writer of `[modules]`. If the user manually edited an entry, do not re-run `basecamp modules` mid-scenario without recording the pre-edit state — manual entries are intentionally preserved.
 - Only `path:../<sibling>` flake inputs are sibling-rewritten; `path:./sub`, `github:`, and `git+` schemes pass through. If a project uses multi-line input declarations, the line-level parser may not detect them — record any sibling-override miss along with the offending `flake.nix` excerpt.
 
 ## B3. Two-Instance P2P Dogfooding
@@ -1026,14 +1026,14 @@ test -e .scaffold/basecamp/profiles/alice/.scaffold-xdg-data/scratch/marker.txt 
 - The default `launch alice` removes any user-introduced files under the alice profile XDG dirs and reinstalls each captured source before `exec`ing basecamp.
 - `launch alice --no-clean` skips the scrub and reinstall; pre-existing files in the profile survive.
 - `rm -rf` on `launch` is bounded to `<project>/.scaffold/basecamp/profiles/<profile>/`. Never any path outside that root.
-- A `launch` that finds no modules in `[basecamp.modules]` and is invoked without `--no-clean` bails before scrubbing (the empty-install + scrubbed profile combination is the regression we're guarding against).
+- A `launch` that finds no modules in `[modules]` and is invoked without `--no-clean` bails before scrubbing (the empty-install + scrubbed profile combination is the regression we're guarding against).
 
 ### Failure Signals / Common Pitfalls
 
 - The `marker.txt` file surviving the default `launch alice` is a regression: clean-slate is the v1 contract.
 - `--no-clean` triggering a scrub anyway is an escape-hatch regression.
 - A `launch` scrubbing a path outside the profile's XDG dirs is a severe safety regression — capture the offending path and stop.
-- An empty `[basecamp.modules]` plus a default `launch` that wipes the profile and leaves it empty is the exact bug guarded by `fix(basecamp): bail on empty [basecamp.modules] in launch without --no-clean`; if you can reproduce it, that's a real regression.
+- An empty `[modules]` plus a default `launch` that wipes the profile and leaves it empty is the exact bug guarded by `fix(basecamp): bail on empty [modules] in launch without --no-clean`; if you can reproduce it, that's a real regression.
 
 ### Evidence to Capture
 
@@ -1050,7 +1050,7 @@ test -e .scaffold/basecamp/profiles/alice/.scaffold-xdg-data/scratch/marker.txt 
 
 ### Goal
 
-Validate that project sources captured under `[basecamp.modules]` with `role = "project"` can be built against their `#lgx-portable` flake output for hand-loading into a basecamp AppImage, and that runtime `role = "dependency"` entries are skipped.
+Validate that project sources captured under `[modules]` with `role = "project"` can be built against their `#lgx-portable` flake output for hand-loading into a basecamp AppImage, and that runtime `role = "dependency"` entries are skipped.
 
 ### Preconditions
 
@@ -1068,7 +1068,7 @@ ls .scaffold/basecamp/portable 2>/dev/null || find .scaffold -maxdepth 4 -name '
 
 ### Expected Success Signals
 
-- `build-portable` builds `.#lgx-portable` for each `role = "project"` entry in `[basecamp.modules]`, in dependency order, and writes / symlinks the resulting artefacts under `.scaffold/`.
+- `build-portable` builds `.#lgx-portable` for each `role = "project"` entry in `[modules]`, in dependency order, and writes / symlinks the resulting artefacts under `.scaffold/`.
 - `role = "dependency"` entries are skipped — the target AppImage provides its own copies.
 - A flake that does not expose `.#lgx-portable` fails with a targeted error naming the missing attribute, not a raw nix trace.
 
@@ -1100,9 +1100,9 @@ ls .scaffold/basecamp/portable 2>/dev/null || find .scaffold -maxdepth 4 -name '
 - Changes to CLI argument parsing, help text, or error messages: rerun `E1`.
 - Changes to `create`/`new` flags or template selection logic: rerun `E2`.
 - Changes to `basecamp setup` (pin sync, lgpm build, profile seeding, idempotency) or `basecamp doctor`: rerun `B1`.
-- Changes to `[basecamp.modules]` derivation, dependency resolution, sibling `--override-input` handling, or `basecamp install` invocation of `lgpm`: rerun `B2`.
+- Changes to `[modules]` derivation, dependency resolution, sibling `--override-input` handling, or `basecamp install` invocation of `lgpm`: rerun `B2`.
 - Changes to `basecamp launch` (kill-and-scrub semantics, XDG isolation, port-override env vars, p2p surface): rerun `B3`.
-- Changes to clean-slate / `--no-clean` semantics or the empty `[basecamp.modules]` guard on `launch`: rerun `B4`.
+- Changes to clean-slate / `--no-clean` semantics or the empty `[modules]` guard on `launch`: rerun `B4`.
 - Changes to `basecamp build-portable` (project/dependency role split, ordering, attr selection): rerun `B5`.
 
 When in doubt, rerun more scenarios rather than fewer.

--- a/docs/basecamp-module-requirements.md
+++ b/docs/basecamp-module-requirements.md
@@ -16,16 +16,16 @@ This is the contract between a module project and `logos-scaffold basecamp {setu
    - If a flake only exposes `packages.<system>.lgx-portable`, the resolver fails explicitly with a hint — it will not silently fall back. Expose `lgx` or pass `--flake <ref>#lgx-portable` on the command line to opt in.
    - If no flake exposes any `.lgx` attribute, the resolver fails with a generic hint pointing at `--path` / `--flake`.
 
-## The captured module set — `[basecamp.modules]` in scaffold.toml
+## The captured module set — `[modules]` in scaffold.toml
 
 The set of modules that `basecamp install` / `launch` / `build-portable` will act on lives in `scaffold.toml` as one sub-section per module, keyed by `module_name`:
 
 ```toml
-[basecamp.modules.tictactoe]
+[modules.tictactoe]
 flake = "path:/abs/tictactoe#lgx"
 role = "project"
 
-[basecamp.modules.delivery_module]
+[modules.delivery_module]
 flake = "github:logos-co/logos-delivery-module/1fde1566291fe062b98255003b9166b0261c6081#lgx"
 role = "dependency"
 ```
@@ -36,6 +36,8 @@ role = "dependency"
 
 `basecamp modules` is the sole writer of this section. The file stays human-editable — if you disagree with a generated entry, edit it directly.
 
+The pre-0.2.0 schema used `[basecamp.modules.<name>]`. Projects still on that layout are rejected at parse time with a hint pointing at `lgs init`; the section has moved to the top-level `[modules.<name>]` namespace.
+
 ### How entries get populated
 
 On every `basecamp modules` run (explicit `--flake` / `--path` args or auto-discovery), scaffold derives `module_name` for each source:
@@ -44,19 +46,19 @@ On every `basecamp modules` run (explicit `--flake` / `--path` args or auto-disc
 - **`.lgx` file paths** → read the sibling `metadata.json` if present; otherwise fall back to the filename stem and print a one-line assumption note.
 - **`github:` / other remote refs** → derive from the repo slug (strip `logos-` prefix, `-` → `_`) and print a one-line assumption note:
   ```
-  note: flake `github:logos-co/logos-storage-module/abc#lgx` — assumed module_name = `storage_module`. If wrong, edit `[basecamp.modules]` in scaffold.toml.
+  note: flake `github:logos-co/logos-storage-module/abc#lgx` — assumed module_name = `storage_module`. If wrong, edit `[modules]` in scaffold.toml.
   ```
   Edit the TOML if the guess is wrong — `basecamp modules` is **idempotent**: existing keys are never overwritten on re-run.
 
-Then for each project source's declared `dependencies`, scaffold resolves a flake ref for any name not already in `[basecamp.modules]`:
+Then for each project source's declared `dependencies`, scaffold resolves a flake ref for any name not already in `[modules]`:
 
-1. **Already keyed in `[basecamp.modules]`** (any role) → no-op. Whatever you have wins.
-2. **Basecamp preinstalls** (`capability_module`, `package_manager`, `counter`, `webview_app`, and their `_ui` siblings) → silent skip, basecamp ships them.
+1. **Already keyed in `[modules]`** (any role) → no-op. Whatever you have wins.
+2. **Basecamp preinstalls** (`capability_module`, `package_manager`, `package_manager_ui`, `counter`, `counter_qml`, `webview_app`, `basecamp_main_ui`; see `BASECAMP_PREINSTALLED_MODULES` in `src/constants.rs` for the authoritative list) → silent skip, basecamp ships them.
 3. **Declaring source's own `flake.lock`** → if the project source declares an input with the same name, scaffold reads the locked `github:<owner>/<repo>/<rev>` and rewrites to `#lgx`. Preferred path for most projects: whatever rev the module is already building against is, by definition, the rev its IPC clients expect at runtime.
 4. **Scaffold-default `BASECAMP_DEPENDENCIES`** → a hardcoded table keyed by module name (currently only `delivery_module`). Last-resort safety net for projects that don't carry the dep as a flake input.
-5. **Unresolved** → `basecamp modules` **fails with a targeted error** naming the dep and both user-side fixes (capture as a project source, or add an explicit `[basecamp.modules.<name>]` entry with `role = "dependency"`). No silent drop.
+5. **Unresolved** → `basecamp modules` **fails with a targeted error** naming the dep and both user-side fixes (capture as a project source, or add an explicit `[modules.<name>]` entry with `role = "dependency"`). No silent drop.
 
-Resolved deps are inserted into `[basecamp.modules]` with `role = "dependency"`. Re-running `basecamp modules` against the same sources is byte-identical.
+Resolved deps are inserted into `[modules]` with `role = "dependency"`. Re-running `basecamp modules` against the same sources is byte-identical.
 
 Implication for module authors: **declare each runtime dep as a flake input in your module's `flake.nix`**, even if your module doesn't technically build-link against it. It's the cleanest way to give scaffold an authoritative pin (step 3 above) without hitting the scaffold default.
 
@@ -129,12 +131,12 @@ logos-scaffold basecamp modules --flake github:me/my-module#lgx
 logos-scaffold basecamp modules --flake .#some-alt-attr
 ```
 
-Explicit sources skip root / sub-flake probing entirely. The entries land in `[basecamp.modules]` exactly as specified, `role = "project"`; re-run `basecamp modules` with different args to replace or extend. `basecamp install` then replays whatever the table captures.
+Explicit sources skip root / sub-flake probing entirely. The entries land in `[modules]` exactly as specified, `role = "project"`; re-run `basecamp modules` with different args to replace or extend. `basecamp install` then replays whatever the table captures.
 
 To override a single dependency pin without capturing it as a project source, edit `scaffold.toml` directly:
 
 ```toml
-[basecamp.modules.delivery_module]
+[modules.delivery_module]
 flake = "github:myfork/logos-delivery-module/abc123#lgx"
 role = "dependency"
 ```
@@ -147,7 +149,7 @@ role = "dependency"
 
 ```bash
 logos-scaffold basecamp build-portable
-# → builds .#lgx-portable for every `role = "project"` entry in [basecamp.modules]
+# → builds .#lgx-portable for every `role = "project"` entry in [modules]
 # → topologically orders by metadata.json dependencies (leaves first,
 #   so basecamp can resolve each module's deps before loading it)
 # → symlinks the built artefacts into `.scaffold/basecamp/portable/` as


### PR DESCRIPTION
## Description
The 0.2.0 schema migration moved the captured module set from `[basecamp.modules.<name>]` to top-level `[modules.<name>]` (see `src/model.rs:81-83` and `src/config.rs`'s `detect_old_schema`). `docs/basecamp-module-requirements.md` (the canonical project-compatibility contract printed verbatim by `lgs basecamp docs`) and the B-series scenarios in `DOGFOODING.md` still described the legacy shape, so anyone following either doc literally produced a `scaffold.toml` the parser hard-rejects. The B2 scenario also carried a `grep -n '^[basecamp' scaffold.toml` validation step that would silently miss the migrated section, and the prose description of `BASECAMP_PREINSTALLED_MODULES` did not match the actual constant in `src/constants.rs:146` (the "_ui siblings" phrasing covered neither `counter_qml` nor `basecamp_main_ui`).

## Solution
- Sweep `[basecamp.modules.*]` references in `docs/basecamp-module-requirements.md` and `DOGFOODING.md` to the current `[modules.*]` namespace, in prose, TOML examples, evidence checklists, and the "rerun guidance" matrix.
- Add a short historical note in `docs/basecamp-module-requirements.md` pointing at the rename and the parse-time rejection, so contributors reading an older project don't get confused.
- Replace the `grep -n '^[basecamp' scaffold.toml` validation step in `DOGFOODING.md` B2 with `grep -n '^[modules\.' scaffold.toml` so it actually matches the section it's meant to inspect.
- Rewrite the preinstall-modules prose to list each entry by name (`capability_module`, `package_manager`, `package_manager_ui`, `counter`, `counter_qml`, `webview_app`, `basecamp_main_ui`) and point at `BASECAMP_PREINSTALLED_MODULES` in `src/constants.rs` as the authoritative source, in both files.

## Notes
- This PR is doc-only; no behavior changes. `cargo check` and `cargo test --lib` both pass on master with these doc edits applied (237 tests, 0 failures).
- The preinstall prose was kept as prose rather than generated from the constant. Generation would require either build-time templating or a runtime `lgs basecamp docs` substitution path, both of which are out of scope for a doc-drift fix; pinning the prose against `src/constants.rs` by name plus a pointer keeps drift detectable without changing the docs-pipeline.
- The legacy schema reference at the top of the "captured module set" section is intentional and not a residual occurrence — it tells readers what the old layout was so they recognize the parse-time error from `detect_old_schema`.

Closes #120

---
Run ID: 20260512-014011
Authored by: scaffold-wozos-issue-impl recurring task (claude-code worker)