### PR TITLE
docs: align ADR.md/FURPS.md with current GitRef constants and tag value

### DIFF
--- a/ADR.md
+++ b/ADR.md
@@ -164,7 +164,7 @@ own build. Option (2) is even more brittle — any upstream change to the
 construction silently produces wrong IDs.
 
 Scaffold vendors `spel` per project the same way it vendors LEZ: clone
-`logos-co/spel` into the project, pin a commit (`DEFAULT_SPEL_PIN`,
+`logos-co/spel` into the project, pin a commit (`DEFAULT_SPEL.sha`,
 currently tag `v0.2.0-rc.5`), build it during `setup`, and invoke the
 project-local binary from `deploy`. `spel` itself depends on the same
 risc0 crate the user's project does, so the image ID it computes is
@@ -175,20 +175,20 @@ shipped default overridable via `[repos.spel].pin` in `scaffold.toml`;
 **LEZ-version alignment.** Spel itself vendors LEZ as a Cargo dependency
 for its sequencer-RPC client and wallet helpers. Picking a spel pin
 whose `spel-cli/Cargo.toml` references a different LEZ commit than
-scaffold's own `DEFAULT_LEZ_PIN` is a latent footgun: spel and the
+scaffold's own `DEFAULT_LEZ.sha` is a latent footgun: spel and the
 scaffold-built sequencer would speak different versions of the
 sequencer protocol, breaking `lgs spel -- ...` subcommands that hit
 the network. Image-ID computation is unaffected (it's purely guest-ELF
 + risc0-zkvm), but other spel surfaces would silently diverge.
 
-We pick `DEFAULT_SPEL_PIN` to satisfy this alignment at every bump
+We pick `DEFAULT_SPEL.sha` to satisfy this alignment at every bump
 (currently `v0.2.0-rc.5`, which pins LEZ via `tag = "v0.2.0-rc1"` —
-the same commit `DEFAULT_LEZ_PIN` resolves to). The counter-intuitive
+the same commit `DEFAULT_LEZ.sha` resolves to). The counter-intuitive
 naming — `v0.2.0-rc.5` is *newer* than the unsuffixed `v0.2.0` tag —
 is upstream's choice and a maintenance hazard worth flagging when
 revising the pin. `doctor` enforces alignment at runtime by reading
 `<spel.path>/spel-cli/Cargo.toml` and warning if neither
-`DEFAULT_LEZ_PIN` nor `DEFAULT_LEZ_TAG` appears in spel's dependency
+`DEFAULT_LEZ.sha` nor `DEFAULT_LEZ.tag` appears in spel's dependency
 declarations.
 
 The image ID is computed locally from the submitted ELF — scaffold does

--- a/FURPS.md
+++ b/FURPS.md
@@ -10,7 +10,7 @@
 4. Deploy command auto-discovers program binaries from `methods/target/` by matching program names, so non-template projects deploy without `--program-path`.
 5. Build command auto-compiles `methods/Cargo.toml` when present, so projects whose parent workspace excludes the Risc0 guest crate produce guest binaries via `lgs build` without a separate `cargo build --manifest-path methods/Cargo.toml`.
 6. Deploy outputs the deployed program's on-chain ID (the risc0 image ID) for every successful submission, in both the human-readable output and the `--json` output, so users can hand the value to a client without rerunning a separate inspection tool. The value is computed locally from the submitted ELF; on-chain inclusion verification is future work and depends on LEZ exposing deploy receipts.
-7. Scaffold vendors the `spel` CLI per project — clones `logos-co/spel` to a project-local path, pinned via `[repos.spel]` in `scaffold.toml`, and builds it during `setup` — mirroring the LEZ vendoring pattern. `deploy` invokes the project-local binary; no global `spel` install is required. The default spel pin is selected so spel itself vendors the same LEZ commit scaffold pins; `doctor` enforces this alignment at runtime by inspecting `spel-cli/Cargo.toml` and warning if spel's vendored LEZ diverges from `DEFAULT_LEZ_PIN`.
+7. Scaffold vendors the `spel` CLI per project — clones `logos-co/spel` to a project-local path, pinned via `[repos.spel]` in `scaffold.toml`, and builds it during `setup` — mirroring the LEZ vendoring pattern. `deploy` invokes the project-local binary; no global `spel` install is required. The default spel pin is selected so spel itself vendors the same LEZ commit scaffold pins; `doctor` enforces this alignment at runtime by inspecting `spel-cli/Cargo.toml` and warning if spel's vendored LEZ diverges from `DEFAULT_LEZ.sha`.
 8. `logos-scaffold spel -- <args...>` (and the `lgs spel -- <args...>` alias) proxies trailing arguments to the project-vendored `spel` binary, so any spel command (`inspect`, `pda`, `generate-idl`, etc.) runs against the project's pinned version without a global install. Exit codes are forwarded.
 9. `logos-scaffold deploy --json` output is a pure JSON object on stdout — no command-echo, no informational text — and absent values are omitted from the object rather than emitted as `null`. Consumers can pipe directly to `jq` and test field presence with `has(...)`. Subprocess command-echoes and progress messages stay off the JSON channel. Two shapes by code path: `--program-path … --json` emits a bare object `{"status":"submitted","program":...,"tx"?:...,"program_id"?:...}`; auto-discovery `--json` emits `{"deploys":[<entry>,...]}` with one entry per attempted program. Failed entries replace `program_id` with `error`. Auto-discovery exit code is non-zero when any entry failed; the JSON object is still emitted so consumers can inspect partial results.
 
@@ -36,7 +36,7 @@
 1. Scaffold version and toolchain versions are explicit in generated output so projects remain buildable over time.
 2. Network configuration for local and DevNet deployment is .env based config.
 3. The scaffolded project includes command references for build, deploy, and interaction steps.
-4. `logos-scaffold doctor` reports the `spel` repo presence and pin status, mirroring the existing LEZ checks, so drift from `DEFAULT_SPEL_PIN` is surfaced before it bites at deploy time.
+4. `logos-scaffold doctor` reports the `spel` repo presence and pin status, mirroring the existing LEZ checks, so drift from `DEFAULT_SPEL.sha` is surfaced before it bites at deploy time.
 5. `scaffold.toml` files predating the `[repos.spel]` section produce a targeted error from the config loader pointing at `logos-scaffold init` as the fix; `init` is safe to re-run and back-fills the missing section without overwriting customized fields.
 
 ### + (Privacy, Anonymity, Censorship-Resistance)
@@ -53,7 +53,7 @@
 - Logos Core DevEx for overall developer journey alignment and terminology.
 - Logos Blockchain and Logos Execution Environment for functionality.
 - Wallet Module for interactions with Logos Execution Environment.
-- `logos-co/spel` CLI — vendored per project at a pinned commit (`DEFAULT_SPEL_PIN`, currently tag `v0.2.0`); supplies the `spel inspect` output that `deploy` parses for the program ID.
+- `logos-co/spel` CLI — vendored per project at a pinned commit (`DEFAULT_SPEL.sha`, currently tag `v0.2.0-rc.5`); supplies the `spel inspect` output that `deploy` parses for the program ID.
 
 #### Runtime Dependencies
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -152,3 +152,47 @@ pub(crate) const BASECAMP_PREINSTALLED_MODULES: &[&str] = &[
     "webview_app",
     "basecamp_main_ui",
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Guards against doc-vs-code drift between the GitRef structs above and the
+    // canonical project docs (ADR.md, FURPS.md). The pre-GitRef constants were
+    // named `DEFAULT_{SPEL,LEZ}_PIN` / `DEFAULT_LEZ_TAG`; those names no longer
+    // exist in this file. Docs referencing them are stale and break grep.
+    const STALE_GITREF_NAMES: &[&str] =
+        &["DEFAULT_SPEL_PIN", "DEFAULT_LEZ_PIN", "DEFAULT_LEZ_TAG"];
+
+    #[test]
+    fn adr_md_does_not_reference_stale_gitref_names() {
+        let adr = include_str!("../ADR.md");
+        for name in STALE_GITREF_NAMES {
+            assert!(
+                !adr.contains(name),
+                "ADR.md references stale constant `{name}`; use `DEFAULT_SPEL.sha`, `DEFAULT_LEZ.sha`, or `DEFAULT_LEZ.tag` (see `src/constants.rs`)",
+            );
+        }
+    }
+
+    #[test]
+    fn furps_md_does_not_reference_stale_gitref_names() {
+        let furps = include_str!("../FURPS.md");
+        for name in STALE_GITREF_NAMES {
+            assert!(
+                !furps.contains(name),
+                "FURPS.md references stale constant `{name}`; use `DEFAULT_SPEL.sha`, `DEFAULT_LEZ.sha`, or `DEFAULT_LEZ.tag` (see `src/constants.rs`)",
+            );
+        }
+    }
+
+    #[test]
+    fn furps_md_references_current_spel_tag() {
+        let furps = include_str!("../FURPS.md");
+        assert!(
+            furps.contains(DEFAULT_SPEL.tag),
+            "FURPS.md should reference the current DEFAULT_SPEL.tag (`{}`); the doc fell behind the constant (note: unsuffixed `v0.2.0` is *older* than `v0.2.0-rc.5`)",
+            DEFAULT_SPEL.tag,
+        );
+    }
+}


### PR DESCRIPTION
## Description
`ADR.md` and `FURPS.md` referenced constants and a tag value that no longer match the source. The `0.2.0` work in `src/constants.rs` replaced flat `DEFAULT_SPEL_PIN` / `DEFAULT_LEZ_PIN` / `DEFAULT_LEZ_TAG` constants with `DEFAULT_LEZ` / `DEFAULT_SPEL` `GitRef` structs exposing `.sha` and `.tag` fields, and `DEFAULT_SPEL.tag` was bumped from `v0.2.0` to the (counter-intuitively newer) `v0.2.0-rc.5`. The two canonical docs (`ADR.md` LEZ-version-alignment section and `FURPS.md` Functionality #7 / Supportability #4 / Dependencies) still spelled out the pre-refactor names, and `FURPS.md` Dependencies listed `v0.2.0` as the current SPEL tag. That misled anyone trying to verify the runtime `check_spel_lez_alignment` invariant against the actual pin, and broke `grep` for new contributors reading the ADR.

## Solution
- `ADR.md:166-192` — rewrite five references (`DEFAULT_SPEL_PIN` x2, `DEFAULT_LEZ_PIN` x2, `DEFAULT_LEZ_TAG`) to `DEFAULT_SPEL.sha` / `DEFAULT_LEZ.sha` / `DEFAULT_LEZ.tag` so the doc identifiers match the struct-field names actually defined in `src/constants.rs`.
- `FURPS.md:13, 39, 56` — same rename for the three references in Functionality #7, Supportability #4, and the Dependencies bullet. The Dependencies bullet additionally corrects the SPEL tag value from `v0.2.0` to the current `DEFAULT_SPEL.tag` value `v0.2.0-rc.5`.
- `src/constants.rs` — add three unit tests (`adr_md_does_not_reference_stale_gitref_names`, `furps_md_does_not_reference_stale_gitref_names`, `furps_md_references_current_spel_tag`) that `include_str!` the docs and assert the stale names are gone and `FURPS.md` still mentions the current `DEFAULT_SPEL.tag`. These act as the doc-vs-code drift guard suggested in the issue's "Optional CI check" — any future SPEL tag bump or `GitRef` rename without a matching doc update fails `cargo test`.

Tests: `cargo test --offline --lib --bins` — 240 passed (237 prior + 3 new), 0 failed.

## Notes
- The `BASECAMP_PREINSTALLED_MODULES` drift item the issue mentions in passing is intentionally out of scope here — it was already addressed in PR #147 (issue #120), per the issue body's own pointer.
- The struct-field reference style (`DEFAULT_SPEL.sha`) is the most precise replacement: the rest of the prose in both files talks about commit pins (the `sha` field), and the line that previously named both `DEFAULT_LEZ_PIN` and `DEFAULT_LEZ_TAG` is preserved with `DEFAULT_LEZ.sha` / `DEFAULT_LEZ.tag` to keep the two-form GitRef explicit.
- Build/test ran offline on the existing toolchain; no new dependencies, no template or schema changes.

Closes #121

---
Run ID: 20260512-042014
Authored by: scaffold-wozos-issue-impl recurring task (claude-code worker)