### PR TITLE
feat(cli): add --cache-root flag to new/create

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -169,6 +169,14 @@ struct NewArgs {
     lez_path: Option<PathBuf>,
     #[arg(long, default_value = "default", help = TEMPLATE_HELP.as_str())]
     template: String,
+    /// Override the cache root for this project. Persisted to
+    /// `[scaffold].cache_root` in the generated scaffold.toml so all
+    /// subsequent commands honor it; also used during `new` itself for the
+    /// initial LEZ clone of non-vendored projects (`<cache-root>/repos/lez/<pin>/`).
+    /// Relative paths are resolved against the current working directory at
+    /// `new` time and persisted as absolute.
+    #[arg(long, value_name = "PATH")]
+    cache_root: Option<PathBuf>,
 }
 
 #[derive(Debug, clap::Args)]
@@ -457,6 +465,7 @@ pub(crate) fn run(args: Vec<String>) -> DynResult<()> {
             vendor_deps: args.vendor_deps,
             lez_path: args.lez_path,
             template: args.template,
+            cache_root: args.cache_root,
         }),
         Some(Commands::Setup(_)) => cmd_setup(),
         Some(Commands::Build(args)) => match args.subcommand {

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -26,6 +26,7 @@ pub(crate) struct NewCommand {
     pub(crate) template: String,
     pub(crate) vendor_deps: bool,
     pub(crate) lez_path: Option<PathBuf>,
+    pub(crate) cache_root: Option<PathBuf>,
 }
 
 pub(crate) fn cmd_new(cmd: NewCommand) -> DynResult<()> {
@@ -54,7 +55,13 @@ pub(crate) fn cmd_new(cmd: NewCommand) -> DynResult<()> {
     fs::create_dir_all(target.join(".scaffold/state"))?;
     fs::create_dir_all(target.join(".scaffold/logs"))?;
 
-    let (bootstrap_cache, _) = default_cache_root()?;
+    let (bootstrap_cache, persisted_cache_root) = match cmd.cache_root.as_deref() {
+        Some(path) => resolve_cli_cache_root(&cwd, path),
+        None => {
+            let (path, _) = default_cache_root()?;
+            (path, String::new())
+        }
+    };
     fs::create_dir_all(bootstrap_cache.join("repos"))?;
     fs::create_dir_all(bootstrap_cache.join("state"))?;
     fs::create_dir_all(bootstrap_cache.join("logs"))?;
@@ -111,7 +118,7 @@ pub(crate) fn cmd_new(cmd: NewCommand) -> DynResult<()> {
 
     let cfg = Config {
         version: SCAFFOLD_TOML_SCHEMA_VERSION.to_string(),
-        cache_root: String::new(),
+        cache_root: persisted_cache_root,
         lez,
         spel,
         // Default scaffolded projects don't pin basecamp/lgpm — only
@@ -199,6 +206,21 @@ fn cleanup_lez_hello_artifacts(project_root: &Path) -> DynResult<()> {
     Ok(())
 }
 
+/// Resolve a `--cache-root` value supplied on the CLI into the directory used
+/// for the bootstrap LEZ clone and the string persisted to
+/// `[scaffold].cache_root`. Relative paths anchor to `cwd` at `new` time
+/// (not the future project root) and are persisted as absolute so the
+/// generated scaffold.toml resolves consistently from any CWD.
+fn resolve_cli_cache_root(cwd: &Path, cache_root: &Path) -> (PathBuf, String) {
+    let abs = if cache_root.is_absolute() {
+        cache_root.to_path_buf()
+    } else {
+        cwd.join(cache_root)
+    };
+    let display = abs.display().to_string();
+    (abs, display)
+}
+
 pub(crate) fn to_cargo_crate_name(input: &str) -> String {
     let mut out = String::new();
     let mut prev_dash = false;
@@ -230,7 +252,33 @@ pub(crate) fn to_cargo_crate_name(input: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::to_cargo_crate_name;
+    use super::{resolve_cli_cache_root, to_cargo_crate_name};
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn resolve_cli_cache_root_keeps_absolute_path_as_is() {
+        let (abs, persisted) =
+            resolve_cli_cache_root(Path::new("/tmp/wherever"), Path::new("/abs/cache"));
+        assert_eq!(abs, PathBuf::from("/abs/cache"));
+        assert_eq!(persisted, "/abs/cache");
+    }
+
+    #[test]
+    fn resolve_cli_cache_root_joins_relative_path_against_cwd() {
+        let (abs, persisted) =
+            resolve_cli_cache_root(Path::new("/tmp/scratch"), Path::new("custom-cache"));
+        assert_eq!(abs, PathBuf::from("/tmp/scratch/custom-cache"));
+        assert_eq!(persisted, "/tmp/scratch/custom-cache");
+    }
+
+    #[test]
+    fn resolve_cli_cache_root_resolves_dot_prefixed_relative_path() {
+        let (abs, persisted) =
+            resolve_cli_cache_root(Path::new("/tmp/scratch"), Path::new("./custom-cache"));
+        assert_eq!(abs, PathBuf::from("/tmp/scratch/./custom-cache"));
+        assert_eq!(persisted, "/tmp/scratch/./custom-cache");
+    }
+
 
     #[test]
     fn simple_name_is_lowercased() {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -56,6 +56,24 @@ risc0_dev_mode = true
 "#;
 
 #[test]
+fn new_help_lists_documented_flags_including_cache_root() {
+    let temp = tempdir().expect("tempdir");
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .arg("new")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("--vendor-deps")
+                .and(predicate::str::contains("--lez-path"))
+                .and(predicate::str::contains("--template"))
+                .and(predicate::str::contains("--cache-root")),
+        );
+}
+
+#[test]
 fn create_help_does_not_mutate_filesystem() {
     let temp = tempdir().expect("tempdir");
 


### PR DESCRIPTION
## Description

`DOGFOODING.md` E2 (`Project Creation with Advanced Flags`) and `README.md` Command Semantics document a `--cache-root <PATH>` flag on `new`/`create`, but `src/cli.rs`'s `NewArgs` only carries `--vendor-deps`, `--lez-path`, and `--template`. Following the runbook verbatim (`"$SCAFFOLD_BIN" new dogfood-cache --cache-root "$SCRATCH_ROOT/custom-cache"`) fails clap parsing with `unexpected argument`, even though the capability already exists via `[scaffold].cache_root` in `scaffold.toml` and `LOGOS_SCAFFOLD_CACHE_ROOT`. This PR wires the CLI flag through so the documented command works.

## Solution

- `src/cli.rs`: add `cache_root: Option<PathBuf>` to `NewArgs` (`#[arg(long, value_name = "PATH")]`) and forward it to `NewCommand` in the `Create`/`New` match arm.
- `src/commands/new.rs`:
  - Add `cache_root: Option<PathBuf>` to `NewCommand`.
  - Resolve the supplied value via a small pure helper `resolve_cli_cache_root(cwd, path)`: absolute paths stay as-is; relative paths join to `cwd` at `new` time (not the future project root, which doesn't exist yet); the resolved absolute is persisted to `[scaffold].cache_root` so `resolve_cache_root` produces the same result from any CWD on subsequent commands.
  - Use the resolved path as the bootstrap LEZ cache root for non-vendored projects, matching the DOGFOODING expected signal that non-vendored clones land under `<cache-root>/repos/lez/<pin>/`. Vendored projects continue to clone into `.scaffold/repos/lez`; the `[scaffold].cache_root` is still written so it applies to future runs.
  - When the flag is omitted, behavior is unchanged (`default_cache_root()` chain + empty persisted value).
- `src/commands/new.rs` tests: three pure unit tests covering absolute, plain-relative, and `./`-prefixed relative path resolution.
- `tests/cli.rs`: `new_help_lists_documented_flags_including_cache_root` verifies `lgs new --help` advertises all four documented flags (`--vendor-deps`, `--lez-path`, `--template`, `--cache-root`) so this regression cannot recur silently.

Build: `cargo build --offline` finishes cleanly.
Tests: `cargo test --offline` — 240 lib + 136 integration passed (was 237 + 135 before; the four new tests included).

## Notes

- Relative-path semantics: anchored to cwd at `new` time, persisted absolute. This is the only consistent option — `resolve_cache_root` joins relative `cache_root` against `project.root`, but during `new` the project root does not yet exist, so a relative literal would resolve to different directories at `new` time vs. later commands. Persisting absolute eliminates the inconsistency; users who want machine-portable scaffold.toml are still served by the `LOGOS_SCAFFOLD_CACHE_ROOT` env layer.
- `--cache-root` paired with `--vendor-deps`: persists to `[scaffold].cache_root` but does not redirect the LEZ clone (vendored LEZ goes under `.scaffold/repos/lez` per the existing branch). The bootstrap cache directories are still created under the supplied path so `cache_root` is a valid resolved location on first use.
- No doc changes needed: `DOGFOODING.md` E2 and `README.md` Command Semantics already describe the flag's intended behavior; this PR makes the implementation match.

Closes #122

---
Run ID: 20260512-043014
Authored by: scaffold-wozos-issue-impl recurring task (claude-code worker)