### PR TITLE
fix(templates): patch logos-blockchain transitive deps to a known-good rev

### DIFF
--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -9,8 +9,8 @@ use crate::config::{
 };
 use crate::constants::{
     DEFAULT_BASECAMP_PIN, DEFAULT_FRAMEWORK_IDL_PATH, DEFAULT_FRAMEWORK_IDL_SPEC,
-    DEFAULT_FRAMEWORK_VERSION, DEFAULT_LEZ, DEFAULT_LGPM_PIN, DEFAULT_SPEL, FRAMEWORK_KIND_DEFAULT,
-    FRAMEWORK_KIND_LEZ_FRAMEWORK, LEZ_SOURCE, SCAFFOLD_TOML_SCHEMA_VERSION,
+    DEFAULT_FRAMEWORK_VERSION, DEFAULT_LB_PIN, DEFAULT_LEZ, DEFAULT_LGPM_PIN, DEFAULT_SPEL,
+    FRAMEWORK_KIND_DEFAULT, FRAMEWORK_KIND_LEZ_FRAMEWORK, LEZ_SOURCE, SCAFFOLD_TOML_SCHEMA_VERSION,
 };
 use crate::model::{Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig, RunConfig};
 use crate::project::default_cache_root;
@@ -148,6 +148,7 @@ pub(crate) fn cmd_new(cmd: NewCommand) -> DynResult<()> {
         crate_name: &crate_name,
         lez_pin: &cfg.lez.pin,
         spel_tag: DEFAULT_SPEL.tag,
+        lb_pin: DEFAULT_LB_PIN,
     };
     apply_overlay(&target, &template_variant, &overlay_ctx)?;
     if template_variant == FRAMEWORK_KIND_LEZ_FRAMEWORK {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -37,6 +37,25 @@ pub(crate) const DEFAULT_SPEL: GitRef = GitRef {
     tag: "v0.2.0-rc.5",
 };
 
+/// `logos-blockchain` rev that scaffold-generated projects use to pin the
+/// `logos-blockchain-*` transitive crates pulled in via LEZ.
+///
+/// `DEFAULT_LEZ` (v0.2.0-rc1) declares its `logos-blockchain-*` deps in
+/// `Cargo.toml` *without* a `rev`, so a downstream `cargo build` resolves
+/// each transitive crate against whatever `main` of `logos-blockchain` is
+/// at the moment of resolution. A regression on `main` (a `services/storage`
+/// file unconditionally `use`s a module gated behind the `rocksdb-backend`
+/// feature) currently breaks `lgs build` on a freshly scaffolded project.
+///
+/// To insulate generated projects from `main` drift, the templates ship a
+/// `[patch."https://github.com/logos-blockchain/logos-blockchain.git"]`
+/// table that pins every transitive `logos-blockchain-*` crate to this
+/// rev — the exact rev LEZ rc1's own `Cargo.lock` was tested against.
+/// Bump this in lock-step with `DEFAULT_LEZ`; LEZ rc2+ pins these deps
+/// itself so once `DEFAULT_LEZ` advances past rc1 the patch table can be
+/// dropped entirely.
+pub(crate) const DEFAULT_LB_PIN: &str = "81dbb4517aa466358ed425d92fad7d45a0c419fd";
+
 pub(crate) const DEFAULT_HELLO_WORLD_IMAGE_ID_HEX: &str =
     "4880b298f59699c1e4263c5c2245c80123632d608b9116f4b253c63e6c340771";
 pub(crate) const DEFAULT_WALLET_PASSWORD: &str = "logos-scaffold-v0";

--- a/src/template/project.rs
+++ b/src/template/project.rs
@@ -13,6 +13,7 @@ pub(crate) struct OverlayRenderContext<'a> {
     pub(crate) crate_name: &'a str,
     pub(crate) lez_pin: &'a str,
     pub(crate) spel_tag: &'a str,
+    pub(crate) lb_pin: &'a str,
 }
 
 pub(crate) fn apply_overlay(
@@ -107,7 +108,8 @@ fn render_template_text(raw: &str, ctx: &OverlayRenderContext<'_>) -> DynResult<
     let rendered = raw
         .replace("{{crate_name}}", ctx.crate_name)
         .replace("{{lez_pin}}", ctx.lez_pin)
-        .replace("{{spel_tag}}", ctx.spel_tag);
+        .replace("{{spel_tag}}", ctx.spel_tag)
+        .replace("{{lb_pin}}", ctx.lb_pin);
 
     if let Some(token) = find_unresolved_placeholder(&rendered) {
         bail!("unresolved template token `{token}`");
@@ -147,6 +149,7 @@ pub(crate) fn available_templates() -> Vec<String> {
 mod tests {
     use std::fs;
     use std::path::PathBuf;
+    use std::str::FromStr;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::{apply_overlay, render_template_text, OverlayRenderContext};
@@ -171,6 +174,7 @@ mod tests {
             crate_name: "my-app",
             lez_pin: "abc123",
             spel_tag: "v0.0.0-test",
+            lb_pin: "feedface00000000000000000000000000000000",
         };
 
         apply_overlay(&target, "default", &ctx).expect("failed to apply default overlay");
@@ -209,6 +213,7 @@ mod tests {
             crate_name: "my-app",
             lez_pin: "abc123",
             spel_tag: "v0.0.0-test",
+            lb_pin: "feedface00000000000000000000000000000000",
         };
 
         apply_overlay(&target, "lez-framework", &ctx).expect("failed to apply lez-framework");
@@ -245,6 +250,7 @@ mod tests {
             crate_name: "example-name",
             lez_pin: "deadbeef",
             spel_tag: "v0.0.0-test",
+            lb_pin: "feedface00000000000000000000000000000000",
         };
 
         apply_overlay(&target, "default", &ctx).expect("failed to apply default overlay");
@@ -259,12 +265,64 @@ mod tests {
     }
 
     #[test]
+    fn overlay_emits_logos_blockchain_patch_table_pinned_to_lb_pin() {
+        // Locks the workaround for `lgs build` failing because LEZ rc1's
+        // workspace pulls `logos-blockchain-*` crates without a `rev`, so a
+        // fresh resolution picks up an upstream `main` commit whose
+        // `services/storage` unconditionally `use`s a feature-gated module
+        // and fails to compile. The templates ship a `[patch]` table that
+        // pins every transitive `logos-blockchain-*` crate to `{{lb_pin}}`.
+        // Drop this test (and the patch table) only after the parent LEZ
+        // pin advances past rc1 — LEZ rc2+ pins these deps itself.
+        for variant in ["default", "lez-framework"] {
+            let target = mk_temp_dir(&format!("lb-patch-{variant}"));
+            let ctx = OverlayRenderContext {
+                crate_name: "my-app",
+                lez_pin: "abc123",
+                spel_tag: "v0.0.0-test",
+                lb_pin: "feedface00000000000000000000000000000000",
+            };
+            apply_overlay(&target, variant, &ctx)
+                .unwrap_or_else(|e| panic!("apply_overlay({variant}) failed: {e}"));
+            let cargo = fs::read_to_string(target.join("Cargo.toml"))
+                .expect("failed to read generated Cargo.toml");
+            assert!(
+                cargo.contains(
+                    "[patch.\"https://github.com/logos-blockchain/logos-blockchain.git\"]"
+                ),
+                "{variant}: generated Cargo.toml must declare the logos-blockchain patch table; got:\n{cargo}"
+            );
+            assert!(
+                cargo.contains("logos-blockchain-storage-service = { git ="),
+                "{variant}: patch table must pin logos-blockchain-storage-service (the rocksdb-backend regression)"
+            );
+            // Every patch entry should carry the rendered lb_pin, not a literal placeholder.
+            assert!(
+                cargo.contains("rev = \"feedface00000000000000000000000000000000\""),
+                "{variant}: patch table must render {{{{lb_pin}}}} into a rev string"
+            );
+            assert!(
+                !cargo.contains("{{lb_pin}}"),
+                "{variant}: unresolved {{{{lb_pin}}}} placeholder leaked into output"
+            );
+            // Final guard: the rendered Cargo.toml must still parse as TOML.
+            // A malformed patch table would otherwise blow up at `cargo build`
+            // on the user's machine with a confusing manifest-parse error.
+            toml_edit::DocumentMut::from_str(&cargo).unwrap_or_else(|e| {
+                panic!("{variant}: generated Cargo.toml is not valid TOML: {e}\n---\n{cargo}")
+            });
+            fs::remove_dir_all(&target).expect("failed to cleanup temporary test directory");
+        }
+    }
+
+    #[test]
     fn static_files_match_template_content_after_overlay() {
         let target = mk_temp_dir("parity");
         let ctx = OverlayRenderContext {
             crate_name: "my-app",
             lez_pin: "abc123",
             spel_tag: "v0.0.0-test",
+            lb_pin: "feedface00000000000000000000000000000000",
         };
 
         apply_overlay(&target, "default", &ctx).expect("failed to apply default overlay");
@@ -297,6 +355,7 @@ mod tests {
             crate_name: "my-app",
             lez_pin: "abc123",
             spel_tag: "v0.0.0-test",
+            lb_pin: "feedface00000000000000000000000000000000",
         };
 
         apply_overlay(&target, "default", &ctx).expect("failed to apply default overlay");
@@ -346,6 +405,7 @@ mod tests {
             crate_name: "my-app",
             lez_pin: "abc123",
             spel_tag: "v0.2.0-rc.5",
+            lb_pin: "feedface00000000000000000000000000000000",
         };
         let rendered = render_template_text(
             "spel-framework = { git = \"...\", tag = \"{{spel_tag}}\" }",
@@ -364,6 +424,7 @@ mod tests {
             crate_name: "my-app",
             lez_pin: "abc123",
             spel_tag: "v0.0.0-test",
+            lb_pin: "feedface00000000000000000000000000000000",
         };
 
         let err = render_template_text("name = \"{{unknown_token}}\"", &ctx)

--- a/templates/default/Cargo.toml.template
+++ b/templates/default/Cargo.toml.template
@@ -41,3 +41,44 @@ example_program_deployment_methods = { path = "methods" }
 anyhow.workspace = true
 clap.workspace = true
 tokio = { workspace = true, features = ["macros"] }
+
+# LEZ v0.2.0-rc1 declares its `logos-blockchain-*` deps without a `rev`,
+# so a fresh `cargo build` resolves every transitive `logos-blockchain-*`
+# crate against whatever `main` of logos-blockchain happens to be. A
+# regression on `main` (a `services/storage` file unconditionally `use`s a
+# module gated behind the `rocksdb-backend` feature) currently breaks the
+# build. Pin every transitive `logos-blockchain-*` crate to the exact rev
+# LEZ rc1's own `Cargo.lock` was tested against. Drop this table whenever
+# the parent `nssa`/`wallet` pin advances to LEZ rc2 or newer — those
+# tags pin the `logos-blockchain-*` deps themselves.
+[patch."https://github.com/logos-blockchain/logos-blockchain.git"]
+logos-blockchain-blend-crypto = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-blend-message = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-blend-proofs = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-chain-broadcast-service = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-chain-service = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-circuits-prover = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-circuits-utils = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-common-http-client = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-core = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-cryptarchia-engine = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-cryptarchia-sync = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-groth16 = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-http-api-common = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-key-management-system-keys = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-key-management-system-macros = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-key-management-system-operators = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-key-management-system-service = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-ledger = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-network-service = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-poc = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-pol = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-poq = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-poseidon2 = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-services-utils = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-storage-service = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-time-service = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-utils = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-utxotree = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-witness-generator = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-zksign = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }

--- a/templates/lez-framework/Cargo.toml.template
+++ b/templates/lez-framework/Cargo.toml.template
@@ -53,3 +53,44 @@ example_program_deployment_methods = { path = "methods" }
 serde.workspace = true
 clap.workspace = true
 tokio = { workspace = true, features = ["macros"] }
+
+# LEZ v0.2.0-rc1 declares its `logos-blockchain-*` deps without a `rev`,
+# so a fresh `cargo build` resolves every transitive `logos-blockchain-*`
+# crate against whatever `main` of logos-blockchain happens to be. A
+# regression on `main` (a `services/storage` file unconditionally `use`s a
+# module gated behind the `rocksdb-backend` feature) currently breaks the
+# build. Pin every transitive `logos-blockchain-*` crate to the exact rev
+# LEZ rc1's own `Cargo.lock` was tested against. Drop this table whenever
+# the parent `nssa`/`wallet` pin advances to LEZ rc2 or newer — those
+# tags pin the `logos-blockchain-*` deps themselves.
+[patch."https://github.com/logos-blockchain/logos-blockchain.git"]
+logos-blockchain-blend-crypto = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-blend-message = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-blend-proofs = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-chain-broadcast-service = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-chain-service = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-circuits-prover = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-circuits-utils = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-common-http-client = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-core = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-cryptarchia-engine = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-cryptarchia-sync = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-groth16 = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-http-api-common = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-key-management-system-keys = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-key-management-system-macros = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-key-management-system-operators = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-key-management-system-service = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-ledger = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-network-service = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-poc = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-pol = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-poq = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-poseidon2 = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-services-utils = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-storage-service = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-time-service = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-utils = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-utxotree = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-witness-generator = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }
+logos-blockchain-zksign = { git = "https://github.com/logos-blockchain/logos-blockchain.git", rev = "{{lb_pin}}" }


### PR DESCRIPTION
## Description
`lgs build` on a freshly scaffolded `lez-framework` (or `default`) project fails to compile `logos-blockchain-storage-service`, blocking the primary user flow described in `FURPS.md` Functional 1. The root cause is upstream: LEZ v0.2.0-rc1 (current `DEFAULT_LEZ`) declares its `logos-blockchain-*` workspace deps without a `rev`, so a fresh `cargo build` resolves every transitive `logos-blockchain-*` crate against whatever `main` of `logos-blockchain` happens to be. A regression on `main` (`services/storage/src/api/chain/mod.rs:17` adds an unconditional `use crate::api::backend::rocksdb::chain::HeaderIdStream;` even though `api::backend::rocksdb` is gated behind the `rocksdb-backend` feature) breaks the build with `E0433: could not find rocksdb in backend`.

## Solution
- Add a new `DEFAULT_LB_PIN` constant in `src/constants.rs` set to `81dbb4517aa466358ed425d92fad7d45a0c419fd` — the exact `logos-blockchain` rev LEZ rc1's own `Cargo.lock` was tested against. The accompanying doc-comment ties this rev to `DEFAULT_LEZ` and notes that the patch table can be dropped once `DEFAULT_LEZ` advances to LEZ rc2 or newer (rc2+ pins these deps itself).
- Plumb the rev through a new `{{lb_pin}}` overlay placeholder: extend `OverlayRenderContext` in `src/template/project.rs`, wire the substitution in `render_template_text`, and pass `DEFAULT_LB_PIN` from `src/commands/new.rs`.
- Ship a `[patch."https://github.com/logos-blockchain/logos-blockchain.git"]` table in both `templates/default/Cargo.toml.template` and `templates/lez-framework/Cargo.toml.template`. The table pins all 30 transitive `logos-blockchain-*` crates (the set enumerated by LEZ rc1's `Cargo.lock`) to `{{lb_pin}}`. Every crate must be patched to the same rev because Cargo otherwise leaves un-patched siblings to resolve against `main` HEAD, which would mix incompatible workspace revs.
- Add `overlay_emits_logos_blockchain_patch_table_pinned_to_lb_pin` in `src/template/project.rs`. The test renders both templates, asserts the `[patch."https://github.com/logos-blockchain/logos-blockchain.git"]` header is present, asserts the `logos-blockchain-storage-service` patch entry (the crate at the centre of the reported failure) is rendered, asserts the rendered `rev` matches the supplied `lb_pin`, asserts no `{{lb_pin}}` placeholder leaked, and `toml_edit::DocumentMut::from_str`-parses the result to guard against malformed patch tables surfacing only at user-side `cargo build`.

Files changed:
- `src/constants.rs` (+19 / -0)
- `src/template/project.rs` (+62 / -1)
- `src/commands/new.rs` (+3 / -2)
- `templates/default/Cargo.toml.template` (+41 / -0)
- `templates/lez-framework/Cargo.toml.template` (+41 / -0)

Build: `cargo build --lib` succeeded.
Tests: `cargo test --lib` (238 passed, 0 failed) and `cargo test --test cli` (135 passed, 0 failed). The new regression test passes.

## Notes
- This is a downstream workaround for an upstream bug. The proper long-term fix is one of: (a) `logos-blockchain` re-gates `services/storage/src/api/chain/mod.rs:17` behind `#[cfg(feature = "rocksdb-backend")]`, (b) `logos-execution-zone` v0.2.0-rc1 backports the rev-pinning that rc2+ already ships, or (c) scaffold advances `DEFAULT_LEZ` to LEZ rc2 or newer (this requires the matching `DEFAULT_SPEL` bump per the cross-framework invariant documented above `DEFAULT_LEZ` in `src/constants.rs`). Once any of those land the entire patch table can be dropped; the inline comment in the templates spells this out.
- 30 `logos-blockchain-*` crates appear in the patch table — every one that LEZ rc1's `Cargo.lock` resolved. Cargo emits a warning for unused `[patch]` entries; if the resolver does not need a particular crate in practice the warning is benign. Trimming the list to only the strictly-needed subset was considered and rejected because the `logos-blockchain-*` crates share a workspace upstream and must stay co-versioned — leaving any one to resolve against `main` HEAD would risk ABI skew against the pinned siblings.
- ARM64-specific caveats: none. The patch table is platform-independent.
- Did not bump `DEFAULT_LEZ` / `DEFAULT_SPEL` together because that would couple this bug fix to a release-management decision; the patch is the smaller blast radius.

Closes #133

---
Run ID: 20260512-052012
Authored by: scaffold-wozos-issue-impl recurring task (claude-code worker)