### PR TITLE
docs(scope): mark deferred FURPS+/ADR items and annotate .env.local

### DIFF
--- a/ADR.md
+++ b/ADR.md
@@ -27,12 +27,33 @@ Use native Cargo-based build flow as the primary compilation path.
 
 ## Network Configuration
 
-Developers need explicit, editable environment targeting for local and DevNet workflows.
-Use environment-file based network configuration as the default model.
-Generated projects include env files for local and DevNet,
-wallet interaction settings used by deploy and wallet-based interaction commands.
-Env files are familiar and automation-friendly,
-but require strict handling to avoid credential leakage.
+Developers need explicit, editable network targeting per project.
+Use `scaffold.toml` (the `[localnet]` and `[wallet]` sections) as the
+sole source of truth for runtime network parameters; this is the default
+model and the only one currently shipped.
+
+An earlier design considered environment-file based network configuration
+as the default model and proposed generated `.env.local` / `.env.devnet`
+files for local and DevNet workflows. That direction was deferred: it
+would have required scaffold to grow and maintain an env-file sourcing
+layer in addition to the existing TOML config loader, and the
+shipped commands already read network configuration exclusively from
+`scaffold.toml`. Re-introducing an env-file layer later would be a
+single-direction migration.
+
+Generated projects currently ship a `templates/default/.env.local`
+template. It is bundled (key-only, redacted) into `lgs report`
+diagnostic tarballs for support purposes but is **not** sourced by
+scaffold at runtime — `src/commands/localnet.rs` hardcodes the
+sequencer's `RUST_LOG` and `RISC0_DEV_MODE` values when spawning the
+process, independent of `.env.local`'s contents. The template carries a
+header comment to that effect so users editing it do not expect their
+edits to change `lgs localnet start` behavior.
+
+DevNet support is deferred — see "Deferred Items" in `FURPS.md`. Picking
+it up later will reopen the network-targeting question; a future ADR
+entry can revisit whether DevNet's selection knob belongs in
+`scaffold.toml`, an env file, or a CLI flag.
 
 ## Portable Artefact Build is Separate from Install
 

--- a/FURPS.md
+++ b/FURPS.md
@@ -4,9 +4,9 @@
 
 ### Functionality
 
-1. One public DevNet vertical slice: generate wallet, fund wallet, deploy contract, execute one transaction type, verify result.
+1. **(deferred)** One public DevNet vertical slice: generate wallet, fund wallet, deploy contract, execute one transaction type, verify result. — DevNet support is not yet shipped; scaffold currently targets the standalone localnet flow only. See "Deferred Items" at the end of this file.
 2. Integrate wallet generation as part of the scaffold workflow for bootstrap and interaction flows.
-3. Support native token topup for wallet operations on local and DevNet environments.
+3. Support native token topup for wallet operations on local environments (DevNet topup is **deferred** alongside DevNet support generally).
 4. Deploy command auto-discovers program binaries from `methods/target/` by matching program names, so non-template projects deploy without `--program-path`.
 5. Build command auto-compiles `methods/Cargo.toml` when present, so projects whose parent workspace excludes the Risc0 guest crate produce guest binaries via `lgs build` without a separate `cargo build --manifest-path methods/Cargo.toml`.
 6. Deploy outputs the deployed program's on-chain ID (the risc0 image ID) for every successful submission, in both the human-readable output and the `--json` output, so users can hand the value to a client without rerunning a separate inspection tool. The value is computed locally from the submitted ELF; on-chain inclusion verification is future work and depends on LEZ exposing deploy receipts.
@@ -24,7 +24,7 @@
 
 ### Reliability
 
-1. The vertical slice must succeed 3 times in a row on a clean machine with deterministic wallets.
+1. **(deferred)** The vertical slice must succeed 3 times in a row on a clean machine with deterministic wallets. — Tied to the deferred DevNet vertical slice (Functional 1).
 2. Local network can be started and torn down in isolation without modifying host-global blockchain state.
 
 ### Performance
@@ -34,7 +34,7 @@
 ### Supportability
 
 1. Scaffold version and toolchain versions are explicit in generated output so projects remain buildable over time.
-2. Network configuration for local and DevNet deployment is .env based config.
+2. Per-project runtime network configuration lives in `scaffold.toml` (the `[localnet]` and `[wallet]` sections). An earlier design considered env-file-based network configuration; that path is **deferred** — see the ADR "Network Configuration" entry for the rationale. Generated projects ship a `templates/default/.env.local` file that is bundled (key-only, redacted) into `lgs report` diagnostic tarballs but is **not** sourced by scaffold at runtime.
 3. The scaffolded project includes command references for build, deploy, and interaction steps.
 4. `logos-scaffold doctor` reports the `spel` repo presence and pin status, mirroring the existing LEZ checks, so drift from `DEFAULT_SPEL_PIN` is surfaced before it bites at deploy time.
 5. `scaffold.toml` files predating the `[repos.spel]` section produce a targeted error from the config loader pointing at `logos-scaffold init` as the fix; `init` is safe to re-run and back-fills the missing section without overwriting customized fields.
@@ -44,7 +44,7 @@
 - Local workflow does not require uploading source code, artifacts, or private keys to third-party services.
 - CLI interaction flow works with locally controlled wallet keys and does not require custodial key management.
 - Local development and testing can run fully offline from public networks.
-- DevNet interaction uses explicit wallet and RPC configuration so developers can avoid accidental cross-network key reuse.
+- **(deferred)** DevNet interaction uses explicit wallet and RPC configuration so developers can avoid accidental cross-network key reuse. — Tied to the deferred DevNet vertical slice (Functional 1).
 
 ### Dependencies
 
@@ -58,8 +58,8 @@
 #### Runtime Dependencies
 
 - Local network runtime availability for local deploy and interaction workflows.
-- DevNet RPC endpoint availability and stable chain configuration.
-- Deterministic local/DevNet account and chain configuration via environment files.
+- **(deferred)** DevNet RPC endpoint availability and stable chain configuration. — Tied to the deferred DevNet vertical slice (Functional 1).
+- **(deferred)** Deterministic local/DevNet account and chain configuration via environment files. — DevNet target is deferred; env-file-based runtime config was deferred in favor of `scaffold.toml` (see ADR "Network Configuration").
 
 #### Wallet Dependencies
 
@@ -203,3 +203,32 @@
 - `.#lgx` flake output on the project (or sub-flakes) — `.#lgx-portable`-only projects fail explicitly until they expose `.#lgx`.
 - `.#lgx-portable` flake output for any module the developer wants to test against a basecamp AppImage. Projects without it get a clear error from `build-portable`, not a silent miss.
 - Modules that bind sockets must honor external port override via env var (names chosen by each module) for multi-instance launch to be fully useful.
+
+## Deferred Items
+
+Items marked **(deferred)** above are committed to in this document but are
+not yet implemented in scaffold's source. They remain in this file so the
+project's stated direction is visible, but are tagged so contributors and
+reviewers can tell at a glance which lines describe shipped behavior and
+which describe future work.
+
+Currently deferred:
+
+- **DevNet vertical slice and DevNet-related plumbing** (Functional 1,
+  Functional 3 DevNet half, Reliability 1, the DevNet +/Privacy bullet, and
+  Runtime Dependencies entries 2–3). Today scaffold only targets the
+  standalone localnet flow; there is no `--network devnet` flag, no DevNet
+  endpoint constant, no DevNet entry in `[localnet]` config, and no DevNet
+  branch in `wallet topup`. Picking up DevNet later will require a tracking
+  issue covering at minimum: a network-selection CLI flag, a DevNet RPC
+  default, a DevNet branch for `wallet topup` (the current path always uses
+  the Piñata faucet), and a network-aware wallet-state separation strategy.
+- **Env-file-based runtime network configuration** (formerly Supportability
+  2). Scaffold currently uses `scaffold.toml` (the `[localnet]` and
+  `[wallet]` sections) as the sole source of truth for runtime network
+  parameters. See the ADR "Network Configuration" entry for the rationale.
+  The shipped `templates/default/.env.local` file is bundled into
+  `lgs report` diagnostic tarballs (key-only, redacted) but is not sourced
+  at runtime — `src/commands/localnet.rs` hardcodes `RUST_LOG=info` and
+  `RISC0_DEV_MODE=1` when spawning the sequencer, independent of
+  `.env.local`'s contents.

--- a/src/template/project.rs
+++ b/src/template/project.rs
@@ -359,6 +359,38 @@ mod tests {
     }
 
     #[test]
+    fn default_env_local_documents_that_scaffold_does_not_source_it() {
+        // `.env.local` is bundled (key-only, redacted) into `lgs report`
+        // but is not sourced by scaffold at runtime — `localnet.rs`
+        // hardcodes RUST_LOG / RISC0_DEV_MODE on sequencer spawn. The
+        // template carries a header comment so users who edit it do not
+        // expect their edits to change `lgs localnet start` behavior.
+        // Locking that contract here so future template edits do not
+        // silently strip the disclaimer.
+        let target = mk_temp_dir("env-local-comment");
+        let ctx = OverlayRenderContext {
+            crate_name: "my-app",
+            lez_pin: "abc123",
+            spel_tag: "v0.0.0-test",
+        };
+
+        apply_overlay(&target, "default", &ctx).expect("failed to apply default overlay");
+
+        let env_text = fs::read_to_string(target.join(".env.local"))
+            .expect("failed to read generated .env.local");
+        assert!(
+            env_text.contains("# This file is bundled"),
+            ".env.local should carry the diagnostic-bundle header comment, got: {env_text:?}"
+        );
+        assert!(
+            env_text.contains("NOT sourced by scaffold at runtime"),
+            ".env.local should call out non-sourcing explicitly, got: {env_text:?}"
+        );
+
+        fs::remove_dir_all(&target).expect("failed to cleanup temporary test directory");
+    }
+
+    #[test]
     fn render_fails_on_unresolved_placeholder() {
         let ctx = OverlayRenderContext {
             crate_name: "my-app",

--- a/templates/default/.env.local
+++ b/templates/default/.env.local
@@ -1,2 +1,10 @@
+# This file is bundled (key-only, redacted) into `lgs report` diagnostic
+# tarballs but is NOT sourced by scaffold at runtime. The values below
+# are kept here as the canonical defaults for documentation/diagnostic
+# purposes only; scaffold's `localnet start` hardcodes RUST_LOG=info and
+# RISC0_DEV_MODE=1 directly in src/commands/localnet.rs when spawning the
+# sequencer. Editing values here does not change `lgs localnet start`
+# behavior. See the ADR "Network Configuration" entry and the
+# "Deferred Items" section in FURPS.md for the rationale.
 RUST_LOG=info
 RISC0_DEV_MODE=1


### PR DESCRIPTION
## Description

`FURPS.md` and `ADR.md` commit to DevNet support and env-file-based runtime network configuration, but neither is implemented in `src/`. The shipped `templates/default/.env.local` is dead config from a runtime perspective — `src/commands/localnet.rs:205-206` hardcodes `RUST_LOG=info` and `RISC0_DEV_MODE=1` directly on sequencer spawn, independent of the file's contents (the only reader is `src/commands/report.rs`, which bundles a key-only redacted snapshot into the `lgs report` diagnostic tarball). The internal inconsistency misleads contributors about what's shipped, and the half-implemented `.env.local` misleads users who edit it expecting their changes to take effect.

This PR takes the de-scope path proposed in issue #128: bring the documentation in line with the code rather than promising functionality that isn't there.

## Solution

- `FURPS.md`: tag the DevNet- and env-file-related lines with `**(deferred)**` markers — Functional 1, the DevNet half of Functional 3, Reliability 1, the DevNet +/Privacy bullet, and Runtime Dependencies entries 2–3. Rewrite Supportability 2 to reflect that runtime network configuration lives in `scaffold.toml`. Add a "Deferred Items" subsection at the end of the file explaining the convention and listing what would be required to pick the deferred items back up.
- `ADR.md`: rewrite "Network Configuration" to state that `scaffold.toml` (the `[localnet]` and `[wallet]` sections) is the sole source of truth for runtime network parameters, record that env-file-based configuration was deferred, and point at the FURPS+ "Deferred Items" section for DevNet status. Keep the existing reasoning visible by recording it as the deferred alternative rather than deleting it.
- `templates/default/.env.local`: prepend a header comment explaining that scaffold does not source this file at runtime — it is bundled only for diagnostics — so users editing it do not expect their edits to change `lgs localnet start` behavior. The file's existing `RUST_LOG` and `RISC0_DEV_MODE` lines remain as the canonical default values. `src/commands/report.rs` already preserves `#`-prefixed lines verbatim through its key-only redaction loop, so the comment appears in the bundle as-is.
- `src/template/project.rs`: add `default_env_local_documents_that_scaffold_does_not_source_it`, a small test that locks the disclaimer into the generated template so future edits do not silently strip it.

No source/behavior changes — `localnet.rs` still spawns the sequencer with the same hardcoded env vars; `report.rs` still bundles the same key-only redacted snapshot. The existing byte-equality test (`static_files_match_template_content_after_overlay`) keeps passing because both the template and the `include_str!` baseline move together.

## Notes

- `cargo build` and `cargo test --lib` clean: 238 tests pass (up from 237; one new template test). The CLI integration test `report_skips_unreadable_optional_file_and_keeps_succeeding` also passes — it deliberately makes `.env.local` unreadable and exercises only the skip path, which my changes do not touch.
- The "Deferred Items" section in FURPS.md names the concrete work that would have to happen to ship DevNet later (network-selection CLI flag, DevNet endpoint default, DevNet branch in `wallet topup`, network-aware wallet-state separation). That paragraph deliberately stops short of a commitment — the door is left open for a future ADR to revisit whether DevNet's selection knob lives in `scaffold.toml`, an env file, or a CLI flag.
- Deliberately did not delete `templates/default/.env.local` outright. It has a real use today: `lgs report` parses it (key-only, redacted) so the diagnostic bundle can surface the canonical defaults a user saw at project-generation time. Deleting it would also break `static_files_match_template_content_after_overlay` and the gitignore-idempotency test that asserts `.env.local` lands in `.gitignore`. The annotation path is strictly less risk for the same readability win.

Closes #128

---
Run ID: 20260512-053012
Authored by: scaffold-wozos-issue-impl recurring task (claude-code worker)