### PR TITLE
fix(localnet): widen sequencer max_block_size so deploys don't crash the loop

### DIFF
--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -214,7 +214,7 @@ fn cmd_localnet_start(
         bail!("{message}");
     }
 
-    patch_sequencer_port(lez, localnet_port)?;
+    patch_sequencer_config(lez, localnet_port)?;
 
     // Use a path relative to lez (the child's cwd), not relative to the
     // parent's cwd.  `current_dir(lez)` applies before exec, so a parent-
@@ -490,24 +490,35 @@ fn build_status_report(
     }
 }
 
-/// Update the port in `sequencer_config.json` so the sequencer listens on the
-/// configured port.  The pinned LEZ version does not accept `--port` as a CLI
-/// flag — it reads the port from this file.
-fn patch_sequencer_port(lez: &Path, port: u16) -> DynResult<()> {
+/// Patch `sequencer_config.json` so the sequencer listens on the configured
+/// port and accepts a block size large enough for scaffold's bundled deploy
+/// flow. The pinned LEZ version does not accept `--port` as a CLI flag — it
+/// reads everything from this file.
+///
+/// Block-size bump: the upstream debug config caps `max_block_size` at 1 MiB,
+/// which a `lgs deploy` of the default template (5 risc0 guest ELFs ≈ 360 KiB
+/// each) overflows on the second block — and the pinned sequencer crashes
+/// rather than carrying the deferred tx forward. Until LEZ stops aborting on
+/// deferral, scaffold widens the limit so the documented first-success path
+/// fits in a single block.
+fn patch_sequencer_config(lez: &Path, port: u16) -> DynResult<()> {
     let config_path = lez.join(SEQUENCER_CONFIG_REL_PATH);
     let text = fs::read_to_string(&config_path)
         .with_context(|| format!("failed to read {}", config_path.display()))?;
     let mut doc: Value =
         serde_json::from_str(&text).context("failed to parse sequencer_config.json")?;
 
-    if let Some(obj) = doc.as_object_mut() {
-        obj.insert("port".to_string(), Value::Number(port.into()));
-    } else {
+    let Some(obj) = doc.as_object_mut() else {
         bail!(
             "sequencer_config.json is not a JSON object: {}",
             config_path.display()
         );
-    }
+    };
+    obj.insert("port".to_string(), Value::Number(port.into()));
+    obj.insert(
+        "max_block_size".to_string(),
+        Value::String("8 MiB".to_string()),
+    );
 
     let updated = serde_json::to_string_pretty(&doc).context("failed to serialize config")?;
     fs::write(&config_path, format!("{updated}\n"))

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -994,6 +994,11 @@ fn localnet_start_patches_config_and_uses_configured_port() {
         serde_json::Value::Number(localnet_port.into()),
         "expected port in sequencer_config.json to be patched to {localnet_port}, got: {patched_config}"
     );
+    assert_eq!(
+        config_json["max_block_size"],
+        serde_json::Value::String("8 MiB".to_string()),
+        "expected max_block_size in sequencer_config.json to be widened so multi-program deploys fit, got: {patched_config}"
+    );
 
     // Verify --port was NOT passed as a CLI arg
     let args = fs::read_to_string(&args_log).expect("read args log");


### PR DESCRIPTION
## Summary

The pinned LEZ standalone sequencer caps `max_block_size` at 1 MiB in its debug config, which fits roughly two risc0 guest ELFs (~360 KiB each). The default template ships five sample programs, so the very first post-deploy block overflows and the deferred-tx path takes the sequencer's main loop down:

```
WARN  sequencer_core] Transaction with hash … deferred to next block:
                      block size 1094408 bytes would exceed limit of 1048576 bytes
ERROR sequencer_service] Sequencer failed unexpectedly: Main loop exited unexpectedly
```

The crash leaves the localnet unreachable and breaks the documented first-success path before `lgs wallet topup` / examples can run.

## Fix

Until LEZ stops aborting on block-size deferral, scaffold widens the limit at `localnet start` time by patching `max_block_size` to `"8 MiB"` alongside the existing port patch in the pinned `sequencer_config.json`.

- `patch_sequencer_port` → `patch_sequencer_config` (it now writes more than one field).
- The existing `localnet_start_patches_config_and_uses_configured_port` integration test asserts both `port` and `max_block_size` land in `sequencer_config.json`.

## Test plan

- [x] `cargo test --release --test cli localnet_start_patches_config_and_uses_configured_port` — passes.
- [x] `cargo test --release --test cli localnet` — all 11 localnet integration tests pass.
- [x] `cargo test --release --lib commands::localnet` — all 10 localnet unit tests pass.
- [x] Manual e2e against the default `lgs new` template (D1 in DOGFOODING.md):
  - `lgs new lez-demo` (default template), `lgs build`, `lgs localnet start`
  - `lgs wallet topup` → preflight + auth-transfer init + pinata claim all confirm in successive blocks
  - `lgs deploy` deploys all 5 sample programs; sequencer keeps producing blocks instead of crashing
  - `cargo run --bin run_hello_world -- Public/…` submits successfully, sequencer validates and includes in the next block
  - `lgs wallet -- check-health` returns `All looks good!`
  - `lgs doctor` reports 21 PASS (only the pre-existing dirty-cache WARN remains, expected because we patch the sequencer config file in-place)