### PR TITLE
fix(run): skip IDL step for non-lez-framework projects

### DIFF
--- a/DOGFOODING.md
+++ b/DOGFOODING.md
@@ -61,6 +61,25 @@ Do not run project-scoped commands from the repository root unless the scenario 
 - Network access available for setup/build flows that fetch dependencies.
 - No preinstalled `wallet` binary is required. If one exists on `PATH`, do not treat it as the runtime under test for scaffold wallet scenarios.
 - Optional but supported: `LOGOS_SCAFFOLD_WALLET_PASSWORD` when validating password override behavior.
+- Sequencer runtime prerequisites (live outside the project tree but required from the first block onward):
+    - **risc0 toolchain** installed via `rzup` (https://risczero.com/install). The
+      pinned LEZ guest crates require a `risc0-rust` toolchain that supports
+      ruint ≥ 1.18 (verified working: `rzup install rust 1.91.1`). A too-old
+      toolchain (e.g., `1.88.0`) produces `ruint@... requires rustc 1.90` from
+      the guest build.
+    - **r0vm** discoverable by `risc0-zkvm`. Either install via
+      `rzup install r0vm` (lands under
+      `~/.risc0/extensions/v<ver>-cargo-risczero-<platform>/r0vm`) or set
+      `RISC0_SERVER_PATH` to a r0vm binary. Without it the sequencer
+      crashes on its first risc0 program execution with `ProgramExecutionFailed`
+      and `Main loop exited unexpectedly`.
+    - **logos-blockchain-circuits** release at `~/.logos-blockchain-circuits/`
+      (or `$LOGOS_BLOCKCHAIN_CIRCUITS`). Install with
+      `curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/main/scripts/setup-logos-blockchain-circuits.sh | bash`.
+      Without it the sequencer panics on the zk-signature path the first
+      time it tries to seal a block.
+  These are surfaced as `risc0 r0vm` and `logos-blockchain-circuits` rows in
+  `lgs doctor` — confirm both are PASS before running D1-style scenarios.
 - For `B`-series (basecamp) scenarios: Nix with flakes enabled, plus a module project on disk whose `flake.nix` exposes a `packages.<system>.lgx` output (e.g., a `tictactoe`-style project built against the `logos-module-builder` `tutorial-v1` convention). `docs/basecamp-module-requirements.md` (also reachable via `"$SCAFFOLD_BIN" basecamp docs`) is the canonical contract.
 
 The `lgs` binary is a short alias for `logos-scaffold` produced by the same crate; `"$SCAFFOLD_BIN"` and `lgs` are interchangeable in the commands below.
@@ -547,6 +566,20 @@ The `ls` step verifies that LEZ-specific directories were scaffolded before proc
 - If LEZ bootstrap behavior diverges from the default template in setup/localnet/doctor flows, capture the difference explicitly.
 - If `build` does not automatically trigger IDL + client generation for the LEZ template, record that as a regression.
 
+### Known Gap (current pins)
+
+The `lez-framework` pin (`jimmy-claw/lez-framework` rev `1e146970…`) referenced
+by the lez-framework template generates code that calls
+`nssa_core::program::write_nssa_outputs_with_chained_call`, which is not
+exposed by the scaffold-default LEZ pin (`35d8df0d…`). As a result `build`
+(and therefore L1–L4) currently fails with `error[E0425]: cannot find function
+write_nssa_outputs_with_chained_call`. The default-template scenarios are
+unaffected.
+
+Until the lez-framework macro and the LEZ pin are realigned, treat L1–L4 as
+expected-to-fail with the discovered compile error captured as evidence
+rather than re-attempting workarounds.
+
 ### Evidence to Capture
 
 - LEZ project creation output.
@@ -767,7 +800,9 @@ Check that no new directories were created by the `--help` invocations.
 
 ### Goal
 
-Validate that `create`/`new` handle the `--template`, `--vendor-deps`, `--lez-path` (legacy alias: `--lssa-path`), and `--cache-root` flags correctly, including error cases for invalid inputs.
+Validate that `create`/`new` handle the `--template`, `--vendor-deps`, and
+`--lez-path` (legacy alias: `--lssa-path`) flags correctly, including error
+cases for invalid inputs, and that the non-vendored cache root is XDG-resolved.
 
 ### Preconditions
 
@@ -784,8 +819,11 @@ cd "$SCRATCH_ROOT"
 "$SCAFFOLD_BIN" new dogfood-lez-explicit --template lez-framework
 ls -d dogfood-lez-explicit/idl dogfood-lez-explicit/crates/lez-client-gen
 "$SCAFFOLD_BIN" new dogfood-vendor --vendor-deps
-"$SCAFFOLD_BIN" new dogfood-cache --cache-root "$SCRATCH_ROOT/custom-cache"
-find "$SCRATCH_ROOT/custom-cache/repos/lez" -maxdepth 2 -mindepth 1 -type d | sort
+ls -d dogfood-vendor/.scaffold/repos/lez
+# Override the non-vendored cache root via XDG_CACHE_HOME:
+XDG_CACHE_HOME="$SCRATCH_ROOT/custom-cache" \
+  "$SCAFFOLD_BIN" new dogfood-cache
+find "$SCRATCH_ROOT/custom-cache/logos-scaffold/repos/lez" -maxdepth 2 -mindepth 1 -type d | sort
 grep -n "^\[wallet\]\|^home_dir\|^binary" dogfood-cache/scaffold.toml
 ```
 
@@ -794,13 +832,13 @@ grep -n "^\[wallet\]\|^home_dir\|^binary" dogfood-cache/scaffold.toml
 - Invalid `--template` name fails with a clear error listing the available templates (`default`, `lez-framework`).
 - `--template lez-framework` creates a project with LEZ-specific structure (same as L1).
 - `--vendor-deps` is accepted without error and creates a project that vendors the pinned LEZ repo under `.scaffold/repos/lez`.
-- `--cache-root` is honored and scaffold uses the specified directory for cache operations, with non-vendored LEZ clones isolated by pin under `<cache-root>/repos/lez/<pin>/`.
+- The non-vendored cache root resolves from `XDG_CACHE_HOME` (or `$HOME/.cache`), with LEZ clones isolated by pin under `<cache-root>/logos-scaffold/repos/lez/<pin>/`. There is **no** `--cache-root` CLI flag on `new`/`create`; control the location via `XDG_CACHE_HOME`.
 - Generated `scaffold.toml` includes `[wallet].home_dir` and does not include a deprecated `wallet.binary` field.
 
 ### Failure Signals / Common Pitfalls
 
 - If an invalid template name silently falls back to `default`, record that as a regression.
-- If `--vendor-deps` or `--cache-root` are silently ignored or produce an error, record the exact output.
+- If `--vendor-deps` is silently ignored or produces an error, record the exact output.
 - If `--lez-path` is tested and the path does not exist, verify the error message points to the bad path.
 - If non-vendored cache reuse collapses different LEZ pins into a single shared `repos/lez` checkout, record that as a cache-isolation regression.
 
@@ -808,8 +846,8 @@ grep -n "^\[wallet\]\|^home_dir\|^binary" dogfood-cache/scaffold.toml
 
 - Error output for invalid `--template`.
 - Creation output for `--template lez-framework` with directory listing.
-- Creation output for `--vendor-deps` and `--cache-root` if tested.
-- Directory listing proving the pin-isolated cache path.
+- Creation output for `--vendor-deps`.
+- Directory listing proving the pin-isolated cache path under `XDG_CACHE_HOME`.
 - `scaffold.toml` excerpt showing wallet home config without a wallet binary field.
 
 ### Execution Notes

--- a/src/cli_help.rs
+++ b/src/cli_help.rs
@@ -16,7 +16,9 @@ pub(crate) const EXAMPLES_CREATE: &str = r"Examples:
   logos-scaffold create my-app
   logos-scaffold new my-app --template default
   logos-scaffold create my-app --vendor-deps --lez-path /abs/path/to/lez
-  logos-scaffold create my-app --cache-root ~/.cache/logos-scaffold";
+
+To override the cache root for non-vendored projects, set XDG_CACHE_HOME or
+$HOME/.cache before running create/new (scaffold uses XDG-conformant paths).";
 
 pub(crate) const EXAMPLES_INIT: &str = r"Examples:
   logos-scaffold init

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -9,8 +9,8 @@ use crate::constants::{
     DEFAULT_LEZ, DEFAULT_SPEL, SEQUENCER_BIN_REL_PATH, SPEL_BIN_REL_PATH, WALLET_BIN_REL_PATH,
 };
 use crate::doctor_checks::{
-    check_binary, check_container_runtime, check_path, check_port_warn, check_repo,
-    check_standalone_support, one_line, print_rows,
+    check_binary, check_container_runtime, check_logos_blockchain_circuits, check_path,
+    check_port_warn, check_r0vm, check_repo, check_standalone_support, one_line, print_rows,
 };
 use crate::model::{CheckRow, CheckStatus, DoctorReport, DoctorSummary};
 use crate::process::{pid_running, run_capture, run_with_stdin, set_command_echo};
@@ -85,6 +85,13 @@ pub(crate) fn build_doctor_report() -> DynResult<DoctorReport> {
     rows.push(check_binary("ps", true));
     rows.push(check_binary("kill", true));
     rows.push(check_container_runtime());
+
+    // Sequencer runtime prereqs that live outside the project tree. Without
+    // these, the sequencer panics on the zk-signature path (circuits) or on
+    // its first risc0 program execution (r0vm) with opaque
+    // `ProgramExecutionFailed` / `Main loop exited unexpectedly` errors.
+    rows.push(check_r0vm());
+    rows.push(check_logos_blockchain_circuits());
 
     rows.push(check_repo("lez", &lez, &project.config.lez.pin));
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -14,7 +14,9 @@ use crate::commands::run_state::{
     RunDeployState,
 };
 use crate::commands::wallet::{cmd_wallet_topup_inner, TopupOutcome};
-use crate::constants::{DEFAULT_RUN_LOCALNET_TIMEOUT_SEC, SPEL_BIN_REL_PATH};
+use crate::constants::{
+    DEFAULT_RUN_LOCALNET_TIMEOUT_SEC, FRAMEWORK_KIND_LEZ_FRAMEWORK, SPEL_BIN_REL_PATH,
+};
 use crate::model::{LocalnetOwnership, Project};
 use crate::project::{load_project, resolve_repo_path, run_in_project_dir};
 use crate::DynResult;
@@ -53,23 +55,37 @@ fn run_pipeline_once(
     localnet_timeout_sec: u64,
 ) -> DynResult<()> {
     let has_hooks = !hooks.is_empty();
-    // Steps: build, build idl, localnet, topup, deploy, [+1 if hooks]
-    let total_steps: u32 = if has_hooks { 6 } else { 5 };
+    let needs_idl_step = project.config.framework.kind == FRAMEWORK_KIND_LEZ_FRAMEWORK;
+    // Steps: build, [build idl for lez-framework], localnet, topup, deploy, [+1 if hooks]
+    let pipeline_steps: u32 = if needs_idl_step { 5 } else { 4 };
+    let total_steps: u32 = if has_hooks {
+        pipeline_steps + 1
+    } else {
+        pipeline_steps
+    };
+    let mut step: u32 = 1;
 
     // Step 1: Build (chains setup internally)
-    println!("[1/{total_steps}] Building...");
+    println!("[{step}/{total_steps}] Building...");
     cmd_build_shortcut(None)?;
+    step += 1;
 
-    // Step 2: Build IDL (no-op for non-lez-framework projects)
-    println!("[2/{total_steps}] Building IDL...");
-    build_idl_for_current_project()?;
+    // Step 2 (lez-framework only): Build IDL. `build_idl_for_current_project`
+    // bails on non-lez-framework projects rather than silently no-op'ing, so
+    // gate the call here on the framework kind.
+    if needs_idl_step {
+        println!("[{step}/{total_steps}] Building IDL...");
+        build_idl_for_current_project()?;
+        step += 1;
+    }
 
-    // Step 3: Ensure localnet is running.
-    println!("[3/{total_steps}] Ensuring localnet...");
+    // Ensure localnet is running.
+    println!("[{step}/{total_steps}] Ensuring localnet...");
     ensure_localnet(project, localnet_timeout_sec)?;
+    step += 1;
 
-    // Step 4: Wallet topup
-    println!("[4/{total_steps}] Topping up wallet...");
+    // Wallet topup
+    println!("[{step}/{total_steps}] Topping up wallet...");
     let outcome = cmd_wallet_topup_inner(project, None, false)?;
     if let TopupOutcome::ConfirmationTimeout { message } = outcome {
         bail!(
@@ -78,8 +94,9 @@ fn run_pipeline_once(
              Hint: retry `logos-scaffold run` or run `logos-scaffold wallet topup` manually."
         );
     }
+    step += 1;
 
-    // Step 5: Deploy (idempotent: skip when guest .bin + IDL + deploy
+    // Deploy (idempotent: skip when guest .bin + IDL + deploy
     // config hashes match the prior deploy AND the sequencer is the same
     // instance that received it. A `lgs localnet stop && start` cycle
     // changes the sequencer PID and wipes on-chain state, so PID equality
@@ -92,11 +109,11 @@ fn run_pipeline_once(
     let prior = load_state(project);
     let deploy_skipped = if deploy_can_be_skipped(&current_hashes, current_pid, &prior) {
         println!(
-            "[5/{total_steps}] Deploy skipped (guest binaries + IDL + config + sequencer unchanged; delete `.scaffold/state/run_deploy.json` to force a re-deploy)"
+            "[{step}/{total_steps}] Deploy skipped (guest binaries + IDL + config + sequencer unchanged; delete `.scaffold/state/run_deploy.json` to force a re-deploy)"
         );
         true
     } else {
-        println!("[5/{total_steps}] Deploying programs...");
+        println!("[{step}/{total_steps}] Deploying programs...");
         cmd_deploy(None, None, false)?;
         save_state(
             project,
@@ -107,6 +124,7 @@ fn run_pipeline_once(
         )?;
         false
     };
+    step += 1;
 
     // Collect deployed-program metadata for hook env injection regardless
     // of whether deploy ran or was skipped — hooks address programs by
@@ -115,10 +133,10 @@ fn run_pipeline_once(
     // here so the per-hook loop doesn't multiply latency by hook count.
     let deployed = collect_deployed_programs(project, deploy_skipped)?;
 
-    // Step 6: Post-deploy hooks (or summary)
+    // Post-deploy hooks (or summary)
     if has_hooks {
         let n = hooks.len();
-        println!("[6/{total_steps}] Running {n} post-deploy hook(s)...");
+        println!("[{step}/{total_steps}] Running {n} post-deploy hook(s)...");
         check_env_var_suffix_collisions(&deployed.programs)?;
         warn_on_rewritten_program_names(&deployed.programs);
         for (i, hook) in hooks.iter().enumerate() {

--- a/src/doctor_checks.rs
+++ b/src/doctor_checks.rs
@@ -200,6 +200,107 @@ pub(crate) fn one_line(text: &str) -> String {
     text.replace('\n', " ").replace('\r', " ")
 }
 
+/// Probe whether the host environment has the LEZ sequencer's runtime
+/// prerequisites: a risc0 `r0vm` resolvable by `risc0-zkvm` (via
+/// `RISC0_SERVER_PATH`, the rzup extensions layout, or `r0vm` on `PATH`)
+/// and the `logos-blockchain-circuits` directory referenced by zksign.
+///
+/// These are not checked elsewhere because they live outside the project
+/// tree, but without them the sequencer panics on its first block-settlement
+/// path (zk signature) or its first risc0 program execution, producing
+/// opaque `ProgramExecutionFailed` / `Main loop exited unexpectedly` errors
+/// instead of an actionable message.
+pub(crate) fn check_r0vm() -> CheckRow {
+    if let Some(found) = locate_r0vm() {
+        return CheckRow {
+            status: CheckStatus::Pass,
+            name: "risc0 r0vm".to_string(),
+            detail: format!("found {}", found.display()),
+            remediation: None,
+        };
+    }
+    CheckRow {
+        status: CheckStatus::Fail,
+        name: "risc0 r0vm".to_string(),
+        detail: "r0vm not found via RISC0_SERVER_PATH, rzup, or PATH".to_string(),
+        remediation: Some(
+            "Install rzup (https://risczero.com/install) and run \
+             `rzup install r0vm`, or set RISC0_SERVER_PATH to a r0vm binary."
+                .to_string(),
+        ),
+    }
+}
+
+pub(crate) fn check_logos_blockchain_circuits() -> CheckRow {
+    let env_path = std::env::var("LOGOS_BLOCKCHAIN_CIRCUITS")
+        .ok()
+        .map(PathBuf::from);
+    let candidate = env_path.clone().unwrap_or_else(|| {
+        dirs_home()
+            .unwrap_or_default()
+            .join(".logos-blockchain-circuits")
+    });
+
+    if candidate.is_dir() {
+        return CheckRow {
+            status: CheckStatus::Pass,
+            name: "logos-blockchain-circuits".to_string(),
+            detail: format!("found {}", candidate.display()),
+            remediation: None,
+        };
+    }
+    let source = if env_path.is_some() {
+        "LOGOS_BLOCKCHAIN_CIRCUITS"
+    } else {
+        "~/.logos-blockchain-circuits"
+    };
+    CheckRow {
+        status: CheckStatus::Fail,
+        name: "logos-blockchain-circuits".to_string(),
+        detail: format!("missing {} ({})", candidate.display(), source),
+        remediation: Some(
+            "Install with `curl -sSL https://raw.githubusercontent.com/\
+             logos-blockchain/logos-blockchain/main/scripts/setup-logos-blockchain-circuits.sh | bash`, \
+             or set LOGOS_BLOCKCHAIN_CIRCUITS to an existing release directory."
+                .to_string(),
+        ),
+    }
+}
+
+fn dirs_home() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(PathBuf::from)
+}
+
+fn locate_r0vm() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("RISC0_SERVER_PATH") {
+        let path = PathBuf::from(p);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+    // rzup extensions layout: <RISC0_HOME>/extensions/v<ver>-cargo-risczero-<platform>/r0vm
+    // (R0Vm's parent component is CargoRiscZero, so the binary lives under
+    //  the cargo-risczero version dir, not a r0vm-* dir.)
+    if let Some(risc0_home) = std::env::var_os("RISC0_HOME")
+        .map(PathBuf::from)
+        .or_else(|| dirs_home().map(|h| h.join(".risc0")))
+    {
+        let ext = risc0_home.join("extensions");
+        if let Ok(entries) = fs::read_dir(&ext) {
+            for entry in entries.flatten() {
+                let name = entry.file_name().to_string_lossy().to_string();
+                if name.contains("-cargo-risczero-") || name.contains("-r0vm-") {
+                    let candidate = entry.path().join("r0vm");
+                    if candidate.is_file() {
+                        return Some(candidate);
+                    }
+                }
+            }
+        }
+    }
+    which("r0vm")
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4077,12 +4077,12 @@ fn run_fails_at_build_step_in_mock_project() {
         .arg("run")
         .assert()
         .failure()
-        .stdout(predicate::str::contains("[1/5] Building..."));
+        .stdout(predicate::str::contains("[1/4] Building..."));
 }
 
 #[test]
-fn run_with_post_deploy_hook_shows_6_steps_in_output() {
-    // When a post_deploy hook is configured, the step counter shows /6.
+fn run_with_post_deploy_hook_shows_5_steps_in_output() {
+    // Default-template pipeline is 4 steps; one post_deploy hook bumps it to 5.
     let temp = tempdir().expect("tempdir");
     setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));
     append_run_config(temp.path(), &["echo hello"]);
@@ -4092,12 +4092,14 @@ fn run_with_post_deploy_hook_shows_6_steps_in_output() {
         .arg("run")
         .assert()
         .failure() // still fails at build
-        .stdout(predicate::str::contains("[1/6] Building..."));
+        .stdout(predicate::str::contains("[1/5] Building..."));
 }
 
 #[test]
 fn run_with_multiple_post_deploy_hooks_uses_array_form() {
-    // Multiple hooks are configured as a TOML inline array; pipeline still has 6 steps.
+    // Multiple hooks are configured as a TOML inline array; hook stage is a
+    // single step regardless of hook count, so total stays at 5 for the
+    // default template.
     let temp = tempdir().expect("tempdir");
     setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));
     append_run_config(temp.path(), &["echo one", "echo two"]);
@@ -4107,12 +4109,12 @@ fn run_with_multiple_post_deploy_hooks_uses_array_form() {
         .arg("run")
         .assert()
         .failure() // still fails at build
-        .stdout(predicate::str::contains("[1/6] Building..."));
+        .stdout(predicate::str::contains("[1/5] Building..."));
 }
 
 #[test]
 fn run_no_post_deploy_flag_skips_configured_hooks() {
-    // --no-post-deploy must collapse total_steps back to 5 even when
+    // --no-post-deploy must collapse total_steps back to 4 even when
     // scaffold.toml configures hooks. The build still fails first, but the
     // step counter in stdout proves the override was honored.
     let temp = tempdir().expect("tempdir");
@@ -4125,13 +4127,13 @@ fn run_no_post_deploy_flag_skips_configured_hooks() {
         .arg("--no-post-deploy")
         .assert()
         .failure()
-        .stdout(predicate::str::contains("[1/5] Building..."));
+        .stdout(predicate::str::contains("[1/4] Building..."));
 }
 
 #[test]
 fn run_post_deploy_flag_overrides_configured_hooks() {
-    // --post-deploy replaces config hooks. With one config hook ([1/6]) and
-    // two flag overrides, the resulting step count stays at /6 — proving
+    // --post-deploy replaces config hooks. With one config hook ([1/5]) and
+    // two flag overrides, the resulting step count stays at /5 — proving
     // that the flag took effect and config wasn't merged on top.
     let temp = tempdir().expect("tempdir");
     setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));
@@ -4146,7 +4148,7 @@ fn run_post_deploy_flag_overrides_configured_hooks() {
         .arg("echo override-b")
         .assert()
         .failure()
-        .stdout(predicate::str::contains("[1/6] Building..."));
+        .stdout(predicate::str::contains("[1/5] Building..."));
 }
 
 fn append_run_config(project_root: &Path, post_deploy: &[&str]) {


### PR DESCRIPTION
### Description

While running the full DOGFOODING.md scenarios end-to-end, three first-success-path issues surfaced. This PR addresses them.

### What changed

[src/commands/run.rs](https://github.com/logos-co/scaffold/blob/claude/dogfooding-testing-PNh6z/src/commands/run.rs) — Gate the Building IDL… step on framework.kind == "lez-framework". build_idl_for_current_project bails on default-template projects rather than no-op'ing, so lgs run on the default template previously failed at step 2/5 with build idl is only supported for lez-framework projects. Step labels ([i/n]) now renumber dynamically so the user sees consecutive markers in both the default (4-step) and lez-framework (5-step) pipelines.
[src/doctor_checks.rs](https://github.com/logos-co/scaffold/blob/claude/dogfooding-testing-PNh6z/src/doctor_checks.rs) + [src/commands/doctor.rs](https://github.com/logos-co/scaffold/blob/claude/dogfooding-testing-PNh6z/src/commands/doctor.rs) — New risc0 r0vm and logos-blockchain-circuits doctor rows. Both are sequencer runtime prereqs that live outside the project tree; without them the sequencer panics on its first block-settlement (zk signature) or first risc0 program execution with opaque ProgramExecutionFailed / Main loop exited unexpectedly errors. Surfacing them at lgs doctor time with actionable install hints replaces a mid-run crash with a clean preflight failure.
[src/cli_help.rs](https://github.com/logos-co/scaffold/blob/claude/dogfooding-testing-PNh6z/src/cli_help.rs) — Drop the logos-scaffold create my-app --cache-root … example from create/new help. The flag was never wired up; the non-vendored cache root is XDG-resolved.
DOGFOODING.md — Add the runtime prereqs (rzup, risc0 rust, r0vm, logos-blockchain-circuits) to "Shared Preconditions". Capture the lez-framework-vs-LEZ-pin compile mismatch as a "Known Gap" under L1 so L1–L4 evidence is recorded the same way across runs. Rewrite E2 against the real new/create flag surface (no --cache-root; document XDG_CACHE_HOME instead).

### Test plan

D1–D7 pass end-to-end against a fresh lgs new dogfood-default project (including lgs run with and without [run].post_deploy hooks).
lgs doctor reports the two new rows with PASS when r0vm/circuits are installed and FAIL with the remediation strings when they're absent.
Existing unit tests in commands::run (42) and doctor_checks (3) pass; no new tests added since these are display/wiring changes.