### PR TITLE
ci: publish release candidates from master

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -66,7 +66,7 @@ jobs:
             candidate_base="$manifest_version"
 
             url="https://crates.io/api/v1/crates/${CRATE_NAME}/${manifest_version}"
-            status_code="$(curl -sS -o /dev/null -w '%{http_code}' -H 'User-Agent: logos-scaffold-ci (https://github.com/logos-co/scaffold)' "$url")"
+            status_code="$(curl -sS -o /dev/null -w '%{http_code}' -H 'User-Agent: logos-scaffold-ci (https://github.com/logos-co/logos-scaffold)' "$url")"
 
             if [[ "$status_code" == "200" ]]; then
               candidate_base="${major}.${minor}.$((patch + 1))"

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -2,6 +2,8 @@ name: Publish crate
 
 on:
   push:
+    branches:
+      - master
     tags:
       - "v*.*.*"
       - "*.*.*"
@@ -22,23 +24,61 @@ jobs:
   resolve-version:
     runs-on: ubuntu-latest
     outputs:
+      release_channel: ${{ steps.resolve.outputs.release_channel }}
       version_raw: ${{ steps.resolve.outputs.version_raw }}
       version_normalized: ${{ steps.resolve.outputs.version_normalized }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Resolve and validate version
         id: resolve
         env:
+          CRATE_NAME: ${{ env.CRATE_NAME }}
           EVENT_NAME: ${{ github.event_name }}
           REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
           INPUT_VERSION: ${{ github.event.inputs.version }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_NUMBER: ${{ github.run_number }}
         run: |
           set -euo pipefail
 
-          if [[ "$EVENT_NAME" == "push" ]]; then
+          release_channel="stable"
+
+          if [[ "$EVENT_NAME" == "push" && "$REF_TYPE" == "tag" ]]; then
             raw_version="$REF_NAME"
-          else
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             raw_version="$INPUT_VERSION"
+          elif [[ "$EVENT_NAME" == "push" && "$REF_TYPE" == "branch" && "$REF_NAME" == "master" ]]; then
+            release_channel="rc"
+            manifest_version="$(sed -nE 's/^version = "([^"]+)"/\1/p' Cargo.toml | head -n 1)"
+
+            if [[ ! "$manifest_version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+              echo "::error::Automatic RC publishes require Cargo.toml to contain a stable X.Y.Z package version. Found '$manifest_version'."
+              exit 1
+            fi
+
+            major="${BASH_REMATCH[1]}"
+            minor="${BASH_REMATCH[2]}"
+            patch="${BASH_REMATCH[3]}"
+            candidate_base="$manifest_version"
+
+            url="https://crates.io/api/v1/crates/${CRATE_NAME}/${manifest_version}"
+            status_code="$(curl -sS -o /dev/null -w '%{http_code}' -H 'User-Agent: logos-scaffold-ci (https://github.com/logos-co/scaffold)' "$url")"
+
+            if [[ "$status_code" == "200" ]]; then
+              candidate_base="${major}.${minor}.$((patch + 1))"
+            elif [[ "$status_code" != "404" ]]; then
+              echo "::error::Unexpected crates.io response status while checking base version: ${status_code}"
+              exit 1
+            fi
+
+            raw_version="${candidate_base}-rc.${RUN_NUMBER}.${RUN_ATTEMPT}"
+          else
+            echo "::error::Unsupported publish event: event=${EVENT_NAME}, ref_type=${REF_TYPE}, ref_name=${REF_NAME}."
+            exit 1
           fi
 
           normalized_version="${raw_version#v}"
@@ -48,6 +88,7 @@ jobs:
             exit 1
           fi
 
+          echo "release_channel=$release_channel" >> "$GITHUB_OUTPUT"
           echo "version_raw=$raw_version" >> "$GITHUB_OUTPUT"
           echo "version_normalized=$normalized_version" >> "$GITHUB_OUTPUT"
 
@@ -67,8 +108,19 @@ jobs:
       - name: Cache cargo artifacts
         uses: Swatinem/rust-cache@v2
 
+      - name: Apply release candidate version
+        if: needs.resolve-version.outputs.release_channel == 'rc'
+        env:
+          RELEASE_VERSION: ${{ needs.resolve-version.outputs.version_normalized }}
+        run: |
+          set -euo pipefail
+
+          perl -0pi -e 's/^version = "[^"]+"/version = "$ENV{RELEASE_VERSION}"/m' Cargo.toml
+          cargo generate-lockfile
+
       - name: Confirm resolved version
         run: |
+          echo "Release channel: ${{ needs.resolve-version.outputs.release_channel }}"
           echo "Raw version: ${{ needs.resolve-version.outputs.version_raw }}"
           echo "Normalized version: ${{ needs.resolve-version.outputs.version_normalized }}"
 
@@ -104,6 +156,16 @@ jobs:
 
       - name: Cache cargo artifacts
         uses: Swatinem/rust-cache@v2
+
+      - name: Apply release candidate version
+        if: needs.resolve-version.outputs.release_channel == 'rc'
+        env:
+          RELEASE_VERSION: ${{ needs.resolve-version.outputs.version_normalized }}
+        run: |
+          set -euo pipefail
+
+          perl -0pi -e 's/^version = "[^"]+"/version = "$ENV{RELEASE_VERSION}"/m' Cargo.toml
+          cargo generate-lockfile
 
       - name: Validate Cargo.toml version matches release version
         env:


### PR DESCRIPTION
## Summary
- Publish release candidates automatically on pushes to `master`, covering merged PRs and direct commits.
- Preserve the existing tag/manual stable publish flow.
- Generate unique RC crate versions in CI and update the manifest/lockfile before `cargo publish --locked`.

## Validation
- Parsed `.github/workflows/publish-crate.yml` as YAML locally.
- Ran `git diff --check` for the workflow change.
- Smoke-tested the RC version calculation and manifest version substitution locally.