### PR TITLE
Fix DEFAULT_SPEL pin to public rc5 commit

### DIFF
--- a/FURPS.md
+++ b/FURPS.md
@@ -53,7 +53,7 @@
 - Logos Core DevEx for overall developer journey alignment and terminology.
 - Logos Blockchain and Logos Execution Environment for functionality.
 - Wallet Module for interactions with Logos Execution Environment.
-- `logos-co/spel` CLI — vendored per project at a pinned commit (`DEFAULT_SPEL_PIN`, currently tag `v0.2.0`); supplies the `spel inspect` output that `deploy` parses for the program ID.
+- `logos-co/spel` CLI — vendored per project at a pinned commit (`DEFAULT_SPEL_PIN`, currently the public commit peeled from `v0.2.0-rc.5`); supplies the `spel inspect` output that `deploy` parses for the program ID.
 
 #### Runtime Dependencies
 

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -6,7 +6,7 @@ use anyhow::bail;
 use super::wallet_support::wallet_password;
 use crate::commands::wallet_support::WALLET_CONFIG_PRIMARY;
 use crate::constants::{
-    DEFAULT_LEZ, DEFAULT_SPEL, SEQUENCER_BIN_REL_PATH, SPEL_BIN_REL_PATH, WALLET_BIN_REL_PATH,
+    DEFAULT_LEZ, DEFAULT_SPEL_PIN, SEQUENCER_BIN_REL_PATH, SPEL_BIN_REL_PATH, WALLET_BIN_REL_PATH,
 };
 use crate::doctor_checks::{
     check_binary, check_container_runtime, check_path, check_port_warn, check_repo,
@@ -117,7 +117,7 @@ pub(crate) fn build_doctor_report() -> DynResult<DoctorReport> {
     rows.push(check_repo("spel", &spel, &project.config.spel.pin));
 
     rows.push(CheckRow {
-        status: if project.config.spel.pin == DEFAULT_SPEL.sha {
+        status: if project.config.spel.pin == DEFAULT_SPEL_PIN {
             CheckStatus::Pass
         } else {
             CheckStatus::Warn
@@ -125,14 +125,14 @@ pub(crate) fn build_doctor_report() -> DynResult<DoctorReport> {
         name: "spel pin matches scaffold default".to_string(),
         detail: format!(
             "configured pin={} expected={}",
-            project.config.spel.pin, DEFAULT_SPEL.sha
+            project.config.spel.pin, DEFAULT_SPEL_PIN
         ),
-        remediation: if project.config.spel.pin == DEFAULT_SPEL.sha {
+        remediation: if project.config.spel.pin == DEFAULT_SPEL_PIN {
             None
         } else {
             Some(format!(
                 "Set repos.spel.pin in scaffold.toml to {} and run `{}`",
-                DEFAULT_SPEL.sha, STEP_SETUP
+                DEFAULT_SPEL_PIN, STEP_SETUP
             ))
         },
     });

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -10,8 +10,8 @@ use crate::config::{
 };
 use crate::constants::{
     DEFAULT_BASECAMP_PIN, DEFAULT_FRAMEWORK_IDL_PATH, DEFAULT_FRAMEWORK_IDL_SPEC,
-    DEFAULT_FRAMEWORK_VERSION, DEFAULT_LEZ, DEFAULT_LGPM_PIN, DEFAULT_SPEL, FRAMEWORK_KIND_DEFAULT,
-    SCAFFOLD_TOML_SCHEMA_VERSION,
+    DEFAULT_FRAMEWORK_VERSION, DEFAULT_LEZ, DEFAULT_LGPM_PIN, DEFAULT_SPEL_PIN,
+    FRAMEWORK_KIND_DEFAULT, SCAFFOLD_TOML_SCHEMA_VERSION,
 };
 use crate::migrate::migrate_to_v0_2_0;
 use crate::model::{Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig, RunConfig};
@@ -216,7 +216,7 @@ fn fresh_default_config() -> Config {
         version: SCAFFOLD_TOML_SCHEMA_VERSION.to_string(),
         cache_root: String::new(),
         lez: default_lez_repo(DEFAULT_LEZ.sha),
-        spel: default_spel_repo(DEFAULT_SPEL.sha),
+        spel: default_spel_repo(DEFAULT_SPEL_PIN),
         basecamp_repo: Some(default_basecamp_repo(DEFAULT_BASECAMP_PIN)),
         lgpm_repo: Some(default_lgpm_repo(DEFAULT_LGPM_PIN)),
         wallet_home_dir: ".scaffold/wallet".to_string(),
@@ -254,7 +254,7 @@ mod tests {
 
         assert_eq!(cfg.version, SCAFFOLD_TOML_SCHEMA_VERSION);
         assert_eq!(cfg.lez.pin, DEFAULT_LEZ.sha);
-        assert_eq!(cfg.spel.pin, DEFAULT_SPEL.sha);
+        assert_eq!(cfg.spel.pin, DEFAULT_SPEL_PIN);
         assert_eq!(cfg.framework.kind, FRAMEWORK_KIND_DEFAULT);
         assert_eq!(cfg.wallet_home_dir, ".scaffold/wallet");
         assert_eq!(cfg.localnet.port, 3040);
@@ -500,7 +500,7 @@ pin = "{}"
 [wallet]
 home_dir = ".scaffold/wallet"
 "#,
-            LEZ_SOURCE, DEFAULT_LEZ.sha, SPEL_SOURCE, DEFAULT_SPEL.sha,
+            LEZ_SOURCE, DEFAULT_LEZ.sha, SPEL_SOURCE, DEFAULT_SPEL_PIN,
         );
         fs::write(target.join("scaffold.toml"), seed).expect("seed");
         cmd_init_at(target, "lgs", false, false).expect("migrate");
@@ -537,7 +537,7 @@ pin = "{}"
 [wallet]
 home_dir = ".scaffold/wallet"
 "#,
-            LEZ_SOURCE, DEFAULT_LEZ.sha, SPEL_SOURCE, DEFAULT_SPEL.sha,
+            LEZ_SOURCE, DEFAULT_LEZ.sha, SPEL_SOURCE, DEFAULT_SPEL_PIN,
         );
         fs::write(target.join("scaffold.toml"), seed).expect("seed");
         cmd_init_at(target, "lgs", false, false).expect("migrate");
@@ -570,7 +570,7 @@ pin = "{}"
 [wallet]
 home_dir = ".scaffold/wallet"
 "#,
-            LEZ_SOURCE, LEZ_SOURCE, DEFAULT_LEZ.sha, SPEL_SOURCE, DEFAULT_SPEL.sha,
+            LEZ_SOURCE, LEZ_SOURCE, DEFAULT_LEZ.sha, SPEL_SOURCE, DEFAULT_SPEL_PIN,
         );
         fs::write(target.join("scaffold.toml"), seed).expect("seed");
         cmd_init_at(target, "lgs", false, false).expect("migrate");

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -9,8 +9,8 @@ use crate::config::{
 };
 use crate::constants::{
     DEFAULT_BASECAMP_PIN, DEFAULT_FRAMEWORK_IDL_PATH, DEFAULT_FRAMEWORK_IDL_SPEC,
-    DEFAULT_FRAMEWORK_VERSION, DEFAULT_LEZ, DEFAULT_LGPM_PIN, DEFAULT_SPEL, FRAMEWORK_KIND_DEFAULT,
-    FRAMEWORK_KIND_LEZ_FRAMEWORK, LEZ_SOURCE, SCAFFOLD_TOML_SCHEMA_VERSION,
+    DEFAULT_FRAMEWORK_VERSION, DEFAULT_LEZ, DEFAULT_LGPM_PIN, DEFAULT_SPEL_PIN,
+    FRAMEWORK_KIND_DEFAULT, FRAMEWORK_KIND_LEZ_FRAMEWORK, LEZ_SOURCE, SCAFFOLD_TOML_SCHEMA_VERSION,
 };
 use crate::model::{Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig, RunConfig};
 use crate::project::default_cache_root;
@@ -107,7 +107,7 @@ pub(crate) fn cmd_new(cmd: NewCommand) -> DynResult<()> {
     let mut lez = default_lez_repo(DEFAULT_LEZ.sha);
     lez.source = lez_source;
     lez.path = lez_persisted_path;
-    let mut spel = default_spel_repo(DEFAULT_SPEL.sha);
+    let mut spel = default_spel_repo(DEFAULT_SPEL_PIN);
     spel.path = spel_persisted_path;
 
     let cfg = Config {
@@ -148,7 +148,6 @@ pub(crate) fn cmd_new(cmd: NewCommand) -> DynResult<()> {
     let overlay_ctx = OverlayRenderContext {
         crate_name: &crate_name,
         lez_pin: &cfg.lez.pin,
-        spel_tag: DEFAULT_SPEL.tag,
     };
     apply_overlay(&target, &template_variant, &overlay_ctx)?;
     if template_variant == FRAMEWORK_KIND_LEZ_FRAMEWORK {

--- a/src/config.rs
+++ b/src/config.rs
@@ -699,7 +699,7 @@ pub(crate) fn default_lgpm_repo(pin: &str) -> RepoRef {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::constants::{DEFAULT_BASECAMP_PIN, DEFAULT_LEZ, DEFAULT_LGPM_PIN, DEFAULT_SPEL};
+    use crate::constants::{DEFAULT_BASECAMP_PIN, DEFAULT_LEZ, DEFAULT_LGPM_PIN, DEFAULT_SPEL_PIN};
 
     fn base_config() -> Config {
         parse_config(&minimal_v0_2_0()).expect("parse minimal v0.2.0")
@@ -736,7 +736,7 @@ risc0_dev_mode = true
             lez_src = LEZ_SOURCE,
             lez_pin = DEFAULT_LEZ.sha,
             spel_src = SPEL_SOURCE,
-            spel_pin = DEFAULT_SPEL.sha,
+            spel_pin = DEFAULT_SPEL_PIN,
         )
     }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -18,24 +18,24 @@ pub(crate) struct GitRef {
     pub(crate) tag: &'static str,
 }
 
-// Cross-framework invariant: DEFAULT_SPEL must point at a spel commit
+// Cross-framework invariant: DEFAULT_SPEL_PIN must point at a spel commit
 // whose `spel-cli/Cargo.toml` vendors LEZ at the same ref as DEFAULT_LEZ.
 // Otherwise spel's sequencer-RPC client speaks a different protocol than
 // scaffold's own wallet/sequencer build. `check_spel_lez_alignment` in
 // `commands/doctor.rs` enforces this at runtime — re-run `doctor` after
 // bumping either pin.
 //
-// Special note on DEFAULT_SPEL: the unsuffixed `v0.2.0` tag (commit
-// `72fc22…`) is *older* than `v0.2.0-rc.5` (commit `ed3bbe…`). rc.5 is
-// the one we want because its vendored LEZ tag matches DEFAULT_LEZ.tag.
+// Special note on DEFAULT_SPEL_PIN: this is the public commit that the
+// `v0.2.0-rc.5` tag peels to on `logos-co/spel`. rc.5 is the spel release
+// whose vendored LEZ matches DEFAULT_LEZ.tag. We deliberately store the
+// commit only (not the tag) so the default cannot drift if the upstream
+// tag is ever moved or replaced. Migrating off RC-derived defaults is
+// tracked in <https://github.com/logos-co/scaffold/issues/170>.
 pub(crate) const DEFAULT_LEZ: GitRef = GitRef {
     sha: "35d8df0d031315219f94d1546ceb862b0e5b208f",
     tag: "v0.2.0-rc1",
 };
-pub(crate) const DEFAULT_SPEL: GitRef = GitRef {
-    sha: "ed3bbedb4b684645da05455d30a4a0be7cc4dfe0",
-    tag: "v0.2.0-rc.5",
-};
+pub(crate) const DEFAULT_SPEL_PIN: &str = "1db7c5f8af3165318f9046c13ab185e24773fd59";
 
 /// `logos-blockchain-circuits` GitHub release version that contains the
 /// proving/verification keys and witness generators every
@@ -172,3 +172,13 @@ pub(crate) const BASECAMP_PREINSTALLED_MODULES: &[&str] = &[
     "webview_app",
     "basecamp_main_ui",
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::DEFAULT_SPEL_PIN;
+
+    #[test]
+    fn default_spel_pin_is_public_rc5_peeled_commit() {
+        assert_eq!(DEFAULT_SPEL_PIN, "1db7c5f8af3165318f9046c13ab185e24773fd59");
+    }
+}

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -9,7 +9,7 @@ use anyhow::{anyhow, bail};
 use toml_edit::{value, DocumentMut, Item, Table};
 
 use crate::constants::{
-    BASECAMP_ATTR, BASECAMP_SOURCE, DEFAULT_BASECAMP_PIN, DEFAULT_LGPM_PIN, DEFAULT_SPEL,
+    BASECAMP_ATTR, BASECAMP_SOURCE, DEFAULT_BASECAMP_PIN, DEFAULT_LGPM_PIN, DEFAULT_SPEL_PIN,
     LGPM_ATTR, LGPM_SOURCE, SCAFFOLD_TOML_SCHEMA_VERSION,
 };
 use crate::model::{RepoBuild, RepoRef};
@@ -129,7 +129,7 @@ pub(crate) fn migrate_to_v0_2_0(doc: &mut DocumentMut) -> DynResult<MigrationRep
             .and_then(|t| t.get("path").and_then(Item::as_str))
             .unwrap_or("")
             .to_string();
-        let mut spel = crate::config::default_spel_repo(DEFAULT_SPEL.sha);
+        let mut spel = crate::config::default_spel_repo(DEFAULT_SPEL_PIN);
         if lez_path == ".scaffold/repos/lez" {
             spel.path = ".scaffold/repos/spel".to_string();
         }

--- a/src/template/project.rs
+++ b/src/template/project.rs
@@ -12,7 +12,6 @@ static TEMPLATES_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/templates");
 pub(crate) struct OverlayRenderContext<'a> {
     pub(crate) crate_name: &'a str,
     pub(crate) lez_pin: &'a str,
-    pub(crate) spel_tag: &'a str,
 }
 
 pub(crate) fn apply_overlay(
@@ -106,8 +105,7 @@ fn normalize_template_file_name(file_name: &std::ffi::OsStr) -> std::ffi::OsStri
 fn render_template_text(raw: &str, ctx: &OverlayRenderContext<'_>) -> DynResult<String> {
     let rendered = raw
         .replace("{{crate_name}}", ctx.crate_name)
-        .replace("{{lez_pin}}", ctx.lez_pin)
-        .replace("{{spel_tag}}", ctx.spel_tag);
+        .replace("{{lez_pin}}", ctx.lez_pin);
 
     if let Some(token) = find_unresolved_placeholder(&rendered) {
         bail!("unresolved template token `{token}`");
@@ -171,7 +169,6 @@ mod tests {
         let ctx = OverlayRenderContext {
             crate_name: "my-app",
             lez_pin: "abc123",
-            spel_tag: "v0.0.0-test",
         };
 
         apply_overlay(&target, "default", &ctx).expect("failed to apply default overlay");
@@ -209,7 +206,6 @@ mod tests {
         let ctx = OverlayRenderContext {
             crate_name: "my-app",
             lez_pin: "abc123",
-            spel_tag: "v0.0.0-test",
         };
 
         apply_overlay(&target, "lez-framework", &ctx).expect("failed to apply lez-framework");
@@ -245,7 +241,6 @@ mod tests {
         let ctx = OverlayRenderContext {
             crate_name: "example-name",
             lez_pin: "deadbeef",
-            spel_tag: "v0.0.0-test",
         };
 
         apply_overlay(&target, "default", &ctx).expect("failed to apply default overlay");
@@ -275,7 +270,6 @@ mod tests {
             let ctx = OverlayRenderContext {
                 crate_name: "my-app",
                 lez_pin: "abc123",
-                spel_tag: "v0.0.0-test",
             };
             apply_overlay(&target, variant, &ctx)
                 .unwrap_or_else(|e| panic!("apply_overlay({variant}) failed: {e}"));
@@ -301,7 +295,6 @@ mod tests {
         let ctx = OverlayRenderContext {
             crate_name: "my-app",
             lez_pin: "abc123",
-            spel_tag: "v0.0.0-test",
         };
 
         apply_overlay(&target, "default", &ctx).expect("failed to apply default overlay");
@@ -333,7 +326,6 @@ mod tests {
         let ctx = OverlayRenderContext {
             crate_name: "my-app",
             lez_pin: "abc123",
-            spel_tag: "v0.0.0-test",
         };
 
         apply_overlay(&target, "default", &ctx).expect("failed to apply default overlay");
@@ -373,34 +365,10 @@ mod tests {
     }
 
     #[test]
-    fn render_substitutes_spel_tag_placeholder() {
-        // Locks the {{spel_tag}} contract for the post-PR-19 follow-up that
-        // converts the lez-framework template's literal `tag = "v0.2.0"`
-        // lines into `tag = "{{spel_tag}}"`. Until then, no template file
-        // exercises this path — keep this test alive so the wiring doesn't
-        // bit-rot before the follow-up lands.
-        let ctx = OverlayRenderContext {
-            crate_name: "my-app",
-            lez_pin: "abc123",
-            spel_tag: "v0.2.0-rc.5",
-        };
-        let rendered = render_template_text(
-            "spel-framework = { git = \"...\", tag = \"{{spel_tag}}\" }",
-            &ctx,
-        )
-        .expect("substitution should succeed");
-        assert_eq!(
-            rendered,
-            "spel-framework = { git = \"...\", tag = \"v0.2.0-rc.5\" }"
-        );
-    }
-
-    #[test]
     fn render_fails_on_unresolved_placeholder() {
         let ctx = OverlayRenderContext {
             crate_name: "my-app",
             lez_pin: "abc123",
-            spel_tag: "v0.0.0-test",
         };
 
         let err = render_template_text("name = \"{{unknown_token}}\"", &ctx)


### PR DESCRIPTION
## Summary

Fix the broken `DEFAULT_SPEL` pin and tighten the way scaffold carries it.

The previous default SHA, `ed3bbedb4b684645da05455d30a4a0be7cc4dfe0`, is a GitHub PR merge commit for `logos-co/spel#164`. GitHub can resolve it, but it is not advertised by the normal public branch/tag refs that `scaffold setup` fetches from `logos-co/spel`, so cold setups against this default fail to resolve the pin.

This PR replaces it with `1db7c5f8af3165318f9046c13ab185e24773fd59`, the public commit that the existing `v0.2.0-rc.5` tag peels to. The effective SPel version scaffold defaults to is unchanged.

## What changed

- Replaced `DEFAULT_SPEL: GitRef { sha, tag }` in `src/constants.rs` with `DEFAULT_SPEL_PIN: &str = "1db7c5f8af3165318f9046c13ab185e24773fd59"`.
- Dropped the unused `{{spel_tag}}` template plumbing (`OverlayRenderContext.spel_tag`, the `.replace("{{spel_tag}}", …)` call, test fixtures, and the substitution-only test) — no template file ever consumed it.
- Updated all `DEFAULT_SPEL.sha` callsites in `commands/init.rs`, `commands/new.rs`, `commands/doctor.rs`, `migrate.rs`, and `config.rs` to `DEFAULT_SPEL_PIN`.
- Updated the regression test to assert the commit pin only.
- Updated `FURPS.md` wording from tag-based to commit-based.

`DEFAULT_LEZ` keeps its `GitRef { sha, tag }` shape — the LEZ tag is still consumed by `check_spel_lez_alignment` in `commands/doctor.rs` to read spel's vendored LEZ ref.

## Why commit-only

Carrying the mutable `v0.2.0-rc.5` tag in scaffold's defaults made the SPel default appear bump-able by retagging upstream — which would silently change scaffold's behaviour at every `lgs setup`. With a commit-only pin, the default cannot drift.

Per @fryorcraken's review on the previous revision of this PR.

## Scope

Narrow:

- Keeps the same effective SPel default (the commit `v0.2.0-rc.5` peels to).
- Does **not** bump SPel to a stable release.
- Does **not** bump LEZ or change `DEFAULT_LEZ`.
- Does **not** add CI guardrails.

Migrating off RC-derived defaults (matching SPEL + LEZ stable releases, the LEZ release prerequisite, the `lez-template` / `spel-template` decision, and CI guardrails for SPEL/LEZ alignment + pin reachability) is tracked separately in #170.

## Evidence

- `refs/tags/v0.2.0-rc.5` points to tag object `67a589f3ae5299f126a4e8cbf192d65c4189bb3f`.
- `refs/tags/v0.2.0-rc.5^{}` peels to commit `1db7c5f8af3165318f9046c13ab185e24773fd59`.
- `ed3bbedb4b684645da05455d30a4a0be7cc4dfe0` is the merge commit for `logos-co/spel#164`, not reachable from a public branch/tag head.

## Verification

- `cargo fmt --check`
- `cargo test default_spel_pin_is_public_rc5_peeled_commit`
- `cargo test --lib` — 334 passed
- `cargo check`
- Built `lgs` and confirmed `lgs init` writes `repos.spel.pin = "1db7c5f8af3165318f9046c13ab185e24773fd59"` into a generated `scaffold.toml`.
