### PR TITLE
docs(basecamp): bless hand-authored [modules.*] tables for drift-detection / declarative-only adoption

### DIFF
--- a/docs/basecamp-module-requirements.md
+++ b/docs/basecamp-module-requirements.md
@@ -34,7 +34,7 @@ role = "dependency"
 - **`role = "project"`** — a module the developer is building locally. `build-portable` attr-swaps these to `#lgx-portable`.
 - **`role = "dependency"`** — a runtime companion. `install` / `launch` load them into the profile; `build-portable` skips them (the target AppImage provides its own).
 
-`basecamp modules` is the sole writer of this section. The file stays human-editable — if you disagree with a generated entry, edit it directly.
+`basecamp modules` is the primary automated writer of this section, but the table is also fully hand-authorable. The file stays human-editable — edit a generated entry to correct it, or write the entire table by hand when `basecamp modules` is the wrong fit (see "Hand-authored declarative use" below).
 
 The pre-0.2.0 schema used `[basecamp.modules.<name>]`. Projects still on that layout are rejected at parse time with a hint pointing at `lgs init`; the section has moved to the top-level `[modules.<name>]` namespace.
 
@@ -142,6 +142,18 @@ role = "dependency"
 ```
 
 `basecamp modules` preserves the entry on every subsequent run — user intent wins over derived pins.
+
+### Hand-authored declarative use
+
+You can also author the entire `[modules.*]` table by hand, with no `lgs basecamp setup` or `lgs basecamp modules` invocation. `basecamp install`, `basecamp build-portable`, and `basecamp doctor` all read whatever the table captures and don't require an automated writer to have produced it.
+
+Concrete reasons to do this:
+
+- **Drift detection only.** A project that ships its own `install` / `launch` flow (e.g. a distributed-stack project blocked on `lgpm` ↔ `bin-macos-app` variant alignment) can still seed `[modules.*]` entries by hand purely to get `lgs basecamp doctor` drift warnings against pin updates upstream.
+- **CI / sandboxed environments** where `lgs basecamp setup` can't or shouldn't run, but the resolved module set is known.
+- **Forking an existing module's flake reference** before running `modules` for the first time.
+
+`basecamp modules` re-runs over a hand-authored table are still idempotent and preserve every entry — the automated and hand-authored modes mix freely.
 
 ## AppImage testing via `build-portable`
 


### PR DESCRIPTION
## What this changes

One paragraph addition + one sentence softening in `docs/basecamp-module-requirements.md` to bless hand-authored `[modules.*]` tables without `lgs basecamp setup` / `lgs basecamp modules`.

## Why

Surfaced during the `eth-lez-atomic-swaps` scaffold 0.1.1 → 0.2.0 upgrade. That project's `scaffold.toml` carries a hand-authored `[modules.*]` table purely for `lgs basecamp doctor` drift detection — its own `install` / `launch` flow stays in shell because of the [`lgpm` ↔ `bin-macos-app` variant mismatch](https://github.com/logos-co/logos-package-manager/issues/14). `lgs basecamp doctor` happily picked up the hand-authored entries and even flagged drift on `delivery_module`, so the use case clearly works — it just isn't documented.

The current wording on line 37 (`"basecamp modules` is the sole writer of this section"`) reads as discouraging hand-authoring from scratch, which conflicts with the actual behaviour.

## Changes

- Line 37: soften "sole writer" to "primary automated writer", with a forward-pointer to the new section.
- New `### Hand-authored declarative use` H3 under the existing "Explicit escape hatch" H2, calling out three concrete reasons hand-authoring is the right call: drift-detection-only, CI / sandboxed environments, and forking flake refs.

No behaviour change — purely documenting what already works.

## See also

- Originating tracker entry: [`eth-lez-atomic-swaps/docs/scaffold-upstream-tracker.md#tr-11`](https://github.com/logos-co/eth-lez-atomic-swaps/blob/master/docs/scaffold-upstream-tracker.md#tr-11).
- Cross-repo context: [`logos-package-manager#14`](https://github.com/logos-co/logos-package-manager/issues/14) (why some projects can't use `lgs basecamp install` end-to-end today).
- Companion umbrellas from same downstream: [`#171`](https://github.com/logos-co/scaffold/issues/171), [`#172`](https://github.com/logos-co/scaffold/issues/172), [`#173`](https://github.com/logos-co/scaffold/issues/173), [`#174`](https://github.com/logos-co/scaffold/issues/174).
