### PR TITLE
docs(basecamp): note that bin-macos-app --user-dir is orthogonal to scaffold's per-profile XDG isolation

### DIFF
--- a/docs/basecamp-module-requirements.md
+++ b/docs/basecamp-module-requirements.md
@@ -161,6 +161,8 @@ logos-scaffold basecamp build-portable
 
 `build-portable` does not touch profiles, `basecamp.state`, or the AppImage itself — it only produces artefacts. Load them into your AppImage in the printed order via its "install lgx" button; scaffold is intentionally unaware of the AppImage's install path.
 
+If you launch the AppImage with `--user-dir <path>` (the `bin-macos-app` flag that sets `LOGOS_USER_DIR`), the AppImage stores its state at `<path>` rather than its default XDG data root — orthogonal to scaffold's per-profile XDG isolation under `.scaffold/basecamp/profiles/{alice,bob}/`. The two are independent mechanisms at different layers: scaffold's profiles isolate dev-stack runs; `--user-dir` isolates a single AppImage launch's installed-modules + identity state.
+
 The `.scaffold/basecamp/portable/` directory is wiped and recreated on every `build-portable` run, so re-running after you've removed a module via `basecamp modules` doesn't leave stale symlinks behind.
 
 If a flake exposes only `lgx` (not `lgx-portable`), `build-portable` fails with a targeted hint — mirror of the `install` portable-only failure, in reverse.


### PR DESCRIPTION
## What this changes

Adds one paragraph to the `AppImage testing via build-portable` section of `docs/basecamp-module-requirements.md`, explaining the relationship between `bin-macos-app`'s first-class `--user-dir` flag and scaffold's per-profile XDG isolation under `.scaffold/basecamp/profiles/`.

## Why

Surfaced during `eth-lez-atomic-swaps`'s dogfooding pass against `bin-macos-app`. The two mechanisms exist at different layers and are easy to conflate when reading the basecamp + scaffold docs separately: `--user-dir` is an AppImage-launcher flag that picks where one AppImage instance stores state; scaffold's XDG-based isolation is how `lgs basecamp launch <profile>` keeps two dev-stack instances from colliding. They don't interact.

A repo-wide search confirmed `--user-dir`, `LOGOS_USER_DIR`, and `LOGOS_DATA_DIR` were not mentioned anywhere in scaffold's docs before this PR. This adds the first cross-reference.

Reduces churn for downstream multi-instance test harnesses (like `eth-lez-atomic-swaps`'s two-Basecamp launcher) that read both pieces of documentation and have to reconcile the two mechanisms.

## Changes

One paragraph appended to the `## AppImage testing via build-portable` section, right after the existing `scaffold is intentionally unaware of the AppImage's install path` sentence — that line is the natural anchor for the cross-reference.

No behaviour change — purely documentation.

## See also

- Originating tracker entry: [`eth-lez-atomic-swaps/docs/scaffold-upstream-tracker.md#tr-13`](https://github.com/logos-co/eth-lez-atomic-swaps/blob/master/docs/scaffold-upstream-tracker.md#tr-13).
- Originating dogfooding note: [`eth-lez-atomic-swaps/delivery-dogfooding.md#L418-L433`](https://github.com/logos-co/eth-lez-atomic-swaps/blob/master/delivery-dogfooding.md#L418-L433) ("`--user-dir` flag cleanly isolates Basecamp instances").
- Companion umbrella that introduces scaffold-side per-profile schema: [`#171`](https://github.com/logos-co/scaffold/issues/171).
