### PR TITLE
feat: perfrom sequencer simplification

### DIFF
--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -172,9 +172,14 @@ pub(crate) fn build_doctor_report() -> DynResult<DoctorReport> {
         "Run `logos-scaffold setup`",
     ));
 
+    // Probe the sequencer port the project actually uses (`[localnet] port`,
+    // default 3040). `deploy`/`wallet` derive the same address via
+    // `default_sequencer_http_url_for_project`, so a custom port keeps the
+    // diagnostic aligned with where those commands really connect.
+    let localnet_port = project.config.localnet.port;
     rows.push(check_port_warn(
-        "sequencer port 3040",
-        "127.0.0.1:3040",
+        &format!("sequencer port {localnet_port}"),
+        &format!("127.0.0.1:{localnet_port}"),
         "Run `logos-scaffold localnet start` (required before running example binaries)",
     ));
 
@@ -235,7 +240,9 @@ pub(crate) fn build_doctor_report() -> DynResult<DoctorReport> {
     let wallet_cfg = wallet_home.join(WALLET_CONFIG_PRIMARY);
     if wallet_cfg.exists() {
         let cfg_text = fs::read_to_string(&wallet_cfg)?;
-        if cfg_text.contains("127.0.0.1:3040") || cfg_text.contains("localhost:3040") {
+        let points_local = cfg_text.contains(&format!("127.0.0.1:{localnet_port}"))
+            || cfg_text.contains(&format!("localhost:{localnet_port}"));
+        if points_local {
             rows.push(CheckRow {
                 status: CheckStatus::Pass,
                 name: "wallet network config".to_string(),
@@ -247,10 +254,9 @@ pub(crate) fn build_doctor_report() -> DynResult<DoctorReport> {
                 status: CheckStatus::Warn,
                 name: "wallet network config".to_string(),
                 detail: "wallet may point to non-local sequencer".to_string(),
-                remediation: Some(
-                    "Set .scaffold/wallet/wallet_config.json sequencer_addr=http://127.0.0.1:3040"
-                        .to_string(),
-                ),
+                remediation: Some(format!(
+                    "Set .scaffold/wallet/wallet_config.json sequencer_addr=http://127.0.0.1:{localnet_port}"
+                )),
             });
         }
     } else {
@@ -301,8 +307,9 @@ pub(crate) fn build_doctor_report() -> DynResult<DoctorReport> {
                     rows.push(CheckRow {
                         status: CheckStatus::Warn,
                         name: "wallet usability".to_string(),
-                        detail: "wallet cannot reach local sequencer at http://127.0.0.1:3040"
-                            .to_string(),
+                        detail: format!(
+                            "wallet cannot reach local sequencer at http://127.0.0.1:{localnet_port}"
+                        ),
                         remediation: Some(
                             "Run `logos-scaffold localnet start` (required before running example binaries), then `logos-scaffold doctor`"
                                 .to_string(),

--- a/src/commands/run_state.rs
+++ b/src/commands/run_state.rs
@@ -21,16 +21,13 @@ use sha2::{Digest, Sha256};
 
 use crate::commands::deploy::{discover_deployable_programs, discover_program_binaries};
 use crate::commands::idl::sanitize_file_stem;
-use crate::commands::wallet_support::load_wallet_runtime;
+use crate::commands::wallet_support::{
+    default_sequencer_http_url_for_project, load_wallet_runtime,
+};
 use crate::constants::FRAMEWORK_KIND_LEZ_FRAMEWORK;
 use crate::model::Project;
 use crate::state::read_localnet_state;
 use crate::DynResult;
-
-/// Fallback sequencer address when the wallet config doesn't pin one and
-/// the wallet runtime isn't loadable yet. Mirrors `cmd_deploy`'s default
-/// so the cache key matches the address `cmd_deploy` would actually use.
-const DEFAULT_SEQUENCER_ADDR: &str = "http://127.0.0.1:3040";
 
 const RUN_DEPLOY_STATE_REL: &str = ".scaffold/state/run_deploy.json";
 const LOCALNET_STATE_REL: &str = ".scaffold/state/localnet.state";
@@ -149,15 +146,17 @@ fn config_digest(project: &Project) -> String {
 }
 
 /// Resolve the sequencer address `cmd_deploy` would use for this project.
-/// Falls back to `DEFAULT_SEQUENCER_ADDR` when the wallet runtime isn't
-/// loadable (e.g. on a fresh project before `lgs setup` ran). The
-/// fallback matches `cmd_deploy`'s own default, so cache and deploy stay
-/// in lockstep.
+/// Falls back to the project's localnet sequencer URL (derived from
+/// `[localnet] port`) when the wallet runtime isn't loadable (e.g. on a
+/// fresh project before `lgs setup` ran). The fallback calls the same
+/// `default_sequencer_http_url_for_project` that `cmd_deploy` uses, so a
+/// custom `localnet.port` keeps the cache key and the address `cmd_deploy`
+/// actually targets in lockstep.
 fn resolved_sequencer_addr(project: &Project) -> String {
     load_wallet_runtime(project)
         .ok()
         .and_then(|w| w.sequencer_addr)
-        .unwrap_or_else(|| DEFAULT_SEQUENCER_ADDR.to_string())
+        .unwrap_or_else(|| default_sequencer_http_url_for_project(project))
 }
 
 pub(crate) fn load_state(project: &Project) -> RunDeployState {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -887,6 +887,64 @@ fn doctor_uses_password_env_override_for_wallet_health() {
 }
 
 #[test]
+fn doctor_sequencer_port_and_wallet_network_track_custom_localnet_port() {
+    // PR #84 made deploy/wallet derive the sequencer URL from `[localnet]
+    // port`. Doctor's port probe and wallet-network heuristic must track the
+    // same configured port rather than a hardcoded 3040 — otherwise a project
+    // on a non-default port gets a misleading "sequencer port 3040" row and a
+    // false "wallet may point to non-local sequencer" warning.
+    let temp = tempdir().expect("tempdir");
+    let lez_path = temp.path().join("lez");
+    fs::create_dir_all(&lez_path).expect("create lez path");
+    write_wallet_stub(&lez_path);
+    let port = unused_local_port();
+    write_scaffold_toml_with_localnet(temp.path(), &lez_path, Some(port), Some(true));
+    write_wallet_config(temp.path(), Some(&format!("http://127.0.0.1:{port}")));
+
+    let assert = Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .arg("doctor")
+        .arg("--json")
+        .assert();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8 stdout");
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+    let checks = value
+        .get("checks")
+        .and_then(serde_json::Value::as_array)
+        .expect("checks array");
+
+    // The sequencer-port row must name the configured port, not 3040.
+    let port_check = checks
+        .iter()
+        .find(|c| {
+            c.get("name")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|n| n.starts_with("sequencer port "))
+        })
+        .expect("sequencer port check present");
+    assert_eq!(
+        port_check.get("name").and_then(serde_json::Value::as_str),
+        Some(format!("sequencer port {port}").as_str()),
+        "port check must name the configured localnet port, got: {port_check}"
+    );
+
+    // Wallet config points at the configured port, so the network heuristic
+    // must Pass rather than warn about a non-local sequencer.
+    let wallet_net = checks
+        .iter()
+        .find(|c| {
+            c.get("name").and_then(serde_json::Value::as_str) == Some("wallet network config")
+        })
+        .expect("wallet network config check present");
+    assert_eq!(
+        wallet_net.get("status").and_then(serde_json::Value::as_str),
+        Some("pass"),
+        "wallet config on the configured localnet port must pass, got: {wallet_net}"
+    );
+}
+
+#[test]
 fn localnet_start_fails_when_process_exits_before_ready() {
     let temp = tempdir().expect("tempdir");
     let lez_path = temp.path().join("lez");


### PR DESCRIPTION
### Description

Made `deploy/wallet` derive the sequencer URL from [localnet] port, but a few surfaces stayed hardcoded to 3040. This finishes the job so a project on a custom port behaves consistently.

- run cache: resolved_sequencer_addr now falls back to the same default_sequencer_http_url_for_project as cmd_deploy (restores the cache-key lockstep its doc comment claimed); drops the redundant DEFAULT_SEQUENCER_ADDR constant
- doctor: sequencer-port probe, wallet-network heuristic, and "cannot reach" message now track the configured port instead of literal 3040
- tests: adds a regression test asserting doctor names the configured port and passes the wallet-network check when the wallet points at it
- verified: cargo fmt --check, cargo build, full suite green (341 unit + 159 integration)