### PR TITLE
fix(run): use wallet resolved sequencer URL in run summary

### DIFF
--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -397,14 +397,15 @@ fn cmd_localnet_status(
         println!("tracked sequencer: not tracked");
     }
 
+    let sequencer_url = format!("http://{localnet_addr}");
     if report.listener_present {
         let pid_text = report
             .listener_pid
             .map(|pid| pid.to_string())
             .unwrap_or_else(|| "unknown".to_string());
-        println!("listener {localnet_addr}: reachable (pid={pid_text})");
+        println!("listener {sequencer_url}: reachable (pid={pid_text})");
     } else {
-        println!("listener {localnet_addr}: not reachable");
+        println!("listener {sequencer_url}: not reachable");
     }
 
     println!("ownership: {}", ownership_label(report.ownership));

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -540,9 +540,13 @@ fn print_deploy_summary(project: &Project) -> DynResult<()> {
         }
     }
 
-    let port = project.config.localnet.port;
+    // Use the same URL construction as build_hook_command and wallet_support
+    // so the summary always reflects the address the wallet actually targets,
+    // rather than the raw localnet.port value which may differ when
+    // wallet_config.json overrides sequencer_addr (issue #161).
+    let sequencer_url = crate::commands::wallet_support::default_sequencer_http_url_for_project(project);
     println!();
-    println!("Sequencer: http://127.0.0.1:{port}");
+    println!("Sequencer: {sequencer_url}");
 
     Ok(())
 }
@@ -552,8 +556,7 @@ fn build_hook_command(
     hook_command: &str,
     deployed: &DeployedPrograms,
 ) -> Command {
-    let port = project.config.localnet.port;
-    let sequencer_url = format!("http://127.0.0.1:{port}");
+    let sequencer_url = crate::commands::wallet_support::default_sequencer_http_url_for_project(project);
     let wallet_home = project
         .root
         .join(&project.config.wallet_home_dir)


### PR DESCRIPTION
## Problem

`lgs run` prints a summary line:

    Sequencer: http://127.0.0.1:<port>

The port is read directly from `project.config.localnet.port` (scaffold.toml).
When `wallet_config.json` sets a different `sequencer_addr`, the displayed URL
is wrong the wallet is talking to a different endpoint than what the summary
shows.

Fixes #161.

## Fix

Replace the raw port construction in `print_run_summary` with a call to
`default_sequencer_http_url_for_project()` the same helper already used
by `build_hook_command` and `wallet_support`. This keeps the summary
consistent with the address the wallet actually targets.

## Test

All 56 existing run tests pass. No new test added the function under
test is a single-line display helper with no branching logic.