### PR TITLE
fix(run): warn when vendored spel binary is absent before extracting program IDs

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -383,6 +383,17 @@ fn collect_deployed_programs(project: &Project, skipped: bool) -> DynResult<Depl
         .context("failed to resolve spel repo path for run post-deploy env")?;
     let spel_bin = spel_repo.join(SPEL_BIN_REL_PATH);
 
+    // Warn early when the vendored spel binary has not been built yet.
+    // extract_program_id() spawns spel_bin and returns None on any failure,
+    // so a missing binary silently leaves SCAFFOLD_PROGRAM_ID unset — which
+    // causes post-deploy hooks to fail in confusing ways (issue #160).
+    if !spel_bin.is_file() {
+        eprintln!(
+            "warning: vendored spel binary not found at {}.              SCAFFOLD_PROGRAM_ID will be unset for all programs.              Run `lgs setup` to build spel.",
+            spel_bin.display()
+        );
+    }
+
     let mut out = Vec::new();
     for stem in programs {
         let Some(bin_path) = binaries.get(&stem).cloned() else {


### PR DESCRIPTION
## Problem

When `lgs setup` has not been run (or spel failed to build), the vendored
spel binary does not exist. `extract_program_id()` calls
`Command::new(spel_bin).spawn().ok()?` which silently returns `None` on
any spawn failure including a missing binary.

The result: `SCAFFOLD_PROGRAM_ID` is silently unset for every program,
and post-deploy hooks fail with no actionable error message.

Fixes #160.

## Fix

Before the per-program loop in `collect_deployed_programs`, check
`spel_bin.is_file()`. If the binary is missing, emit a warning on stderr
that names the missing path and tells the user to run `lgs setup`.

The existing behaviour for a present-but-failing spel binary is unchanged.

## Test

All 56 existing run tests pass. The warning path is not exercised by
existing tests a missing spel binary in the test environment would
require a setup fixture outside the scope of this fix.