### PR TITLE
feat(wallet): add --json output to `wallet list` and `wallet topup`

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -410,6 +410,9 @@ enum WalletSubcommand {
 struct WalletListArgs {
     #[arg(long)]
     long: bool,
+    /// Emit accounts as a JSON object instead of forwarding the wallet's text.
+    #[arg(long)]
+    json: bool,
 }
 
 #[derive(Debug, clap::Args)]
@@ -420,6 +423,9 @@ struct WalletTopupArgs {
     address_flag: Option<String>,
     #[arg(long)]
     dry_run: bool,
+    /// Emit the topup outcome as a JSON object instead of human-readable text.
+    #[arg(long)]
+    json: bool,
 }
 
 #[derive(Debug, clap::Args)]
@@ -623,7 +629,10 @@ pub(crate) fn run(args: Vec<String>) -> DynResult<()> {
         }
         Some(Commands::Wallet(args)) => {
             let action = match args.command {
-                WalletSubcommand::List(args) => WalletAction::List { long: args.long },
+                WalletSubcommand::List(args) => WalletAction::List {
+                    long: args.long,
+                    json: args.json,
+                },
                 WalletSubcommand::Topup(args) => WalletAction::Topup {
                     address: merge_optional_address(
                         args.address,
@@ -631,6 +640,7 @@ pub(crate) fn run(args: Vec<String>) -> DynResult<()> {
                         "wallet topup",
                     )?,
                     dry_run: args.dry_run,
+                    json: args.json,
                 },
                 WalletSubcommand::Default(args) => match args.command {
                     WalletDefaultSubcommand::Set(set) => WalletAction::DefaultSet {

--- a/src/cli_help.rs
+++ b/src/cli_help.rs
@@ -92,6 +92,7 @@ Environment:
 pub(crate) const EXAMPLES_WALLET_LIST: &str = r"Examples:
   logos-scaffold wallet list
   logos-scaffold wallet list --long
+  logos-scaffold wallet list --json
 
 Passthrough (inner wallet CLI):
   logos-scaffold wallet -- --help
@@ -105,6 +106,7 @@ pub(crate) const EXAMPLES_WALLET_TOPUP: &str = r"Examples:
   logos-scaffold wallet topup Public/6iArKUXxhUJqS7kCaPNhwMWt3ro71PDyBj7jwAyE2VQV
   logos-scaffold wallet topup --address Public/6iArKUXxhUJqS7kCaPNhwMWt3ro71PDyBj7jwAyE2VQV
   logos-scaffold wallet topup --dry-run
+  logos-scaffold wallet topup --json
 
 Exit codes:
   0  topup confirmed.

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -544,7 +544,8 @@ fn print_deploy_summary(project: &Project) -> DynResult<()> {
     // so the summary always reflects the address the wallet actually targets,
     // rather than the raw localnet.port value which may differ when
     // wallet_config.json overrides sequencer_addr (issue #161).
-    let sequencer_url = crate::commands::wallet_support::default_sequencer_http_url_for_project(project);
+    let sequencer_url =
+        crate::commands::wallet_support::default_sequencer_http_url_for_project(project);
     println!();
     println!("Sequencer: {sequencer_url}");
 
@@ -556,7 +557,8 @@ fn build_hook_command(
     hook_command: &str,
     deployed: &DeployedPrograms,
 ) -> Command {
-    let sequencer_url = crate::commands::wallet_support::default_sequencer_http_url_for_project(project);
+    let sequencer_url =
+        crate::commands::wallet_support::default_sequencer_http_url_for_project(project);
     let wallet_home = project
         .root
         .join(&project.config.wallet_home_dir)

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -142,7 +142,7 @@ fn run_pipeline_once(project: &Project, params: &PipelineParams) -> DynResult<()
 
     // Step 4: Wallet topup
     println!("[4/{total_steps}] Topping up wallet...");
-    let outcome = cmd_wallet_topup_inner(project, None, false)?;
+    let outcome = cmd_wallet_topup_inner(project, None, false, false)?;
     if let TopupOutcome::ConfirmationTimeout { message } = outcome {
         bail!(
             "{message}\n\

--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -88,6 +88,13 @@ fn cmd_wallet_list(project: &crate::model::Project, long: bool, json: bool) -> D
             .context("failed to execute wallet list command")?;
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        // Always emit a number: a wallet killed by a signal has no exit code,
+        // so map that to the shell convention `128 + signal` (else -1) rather
+        // than letting `exit_code` serialize as `null`.
+        let exit_code = output.status.code().unwrap_or_else(|| {
+            use std::os::unix::process::ExitStatusExt;
+            output.status.signal().map(|s| 128 + s).unwrap_or(-1)
+        });
         let accounts: Vec<&str> = stdout
             .lines()
             .map(str::trim)
@@ -95,7 +102,7 @@ fn cmd_wallet_list(project: &crate::model::Project, long: bool, json: bool) -> D
             .collect();
         let report = json!({
             "command": rendered_command,
-            "exit_code": output.status.code(),
+            "exit_code": exit_code,
             "accounts": accounts,
             "stdout": stdout,
             "stderr": stderr,
@@ -159,6 +166,9 @@ fn emit_topup_error_json(reason: &str, message: &str, address: &str, network: &s
         "address": address,
         "method": "pinata faucet claim",
         "network": network,
+        // Always present (null here) so the object shape is stable across
+        // every `status` and consumers don't need per-status conditional keys.
+        "tx": serde_json::Value::Null,
         "message": message,
     });
     if let Ok(text) = serde_json::to_string_pretty(&report) {
@@ -216,6 +226,8 @@ pub(crate) fn cmd_wallet_topup_inner(
                 "address": resolved_to,
                 "method": "pinata faucet claim",
                 "network": sequencer_addr,
+                // Stable shape: no tx exists for a dry run, but keep the key.
+                "tx": serde_json::Value::Null,
                 "wallet_home": wallet_home,
             });
             println!("{}", serde_json::to_string_pretty(&report)?);

--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -1,8 +1,9 @@
 use std::process::Command;
 
 use anyhow::{bail, Context};
+use serde_json::json;
 
-use crate::process::{render_command, run_forwarded, run_with_stdin};
+use crate::process::{render_command, run_forwarded, run_with_stdin, EchoGuard};
 use crate::project::load_project;
 use crate::DynResult;
 
@@ -28,6 +29,7 @@ pub(crate) enum TopupOutcome {
 pub(crate) enum WalletAction {
     List {
         long: bool,
+        json: bool,
     },
     Proxy {
         args: Vec<String>,
@@ -35,6 +37,7 @@ pub(crate) enum WalletAction {
     Topup {
         address: Option<String>,
         dry_run: bool,
+        json: bool,
     },
     DefaultSet {
         address: String,
@@ -45,14 +48,18 @@ pub(crate) fn cmd_wallet(action: WalletAction) -> DynResult<()> {
     let project = load_project()?;
 
     match action {
-        WalletAction::List { long } => cmd_wallet_list(&project, long),
+        WalletAction::List { long, json } => cmd_wallet_list(&project, long, json),
         WalletAction::Proxy { args } => cmd_wallet_proxy(&project, &args),
-        WalletAction::Topup { address, dry_run } => cmd_wallet_topup(&project, address, dry_run),
+        WalletAction::Topup {
+            address,
+            dry_run,
+            json,
+        } => cmd_wallet_topup(&project, address, dry_run, json),
         WalletAction::DefaultSet { address } => cmd_wallet_default_set(&project, &address),
     }
 }
 
-fn cmd_wallet_list(project: &crate::model::Project, long: bool) -> DynResult<()> {
+fn cmd_wallet_list(project: &crate::model::Project, long: bool, json: bool) -> DynResult<()> {
     let wallet = load_wallet_runtime(project)?;
 
     let mut command = Command::new(&wallet.wallet_binary);
@@ -66,6 +73,35 @@ fn cmd_wallet_list(project: &crate::model::Project, long: bool) -> DynResult<()>
 
     if long {
         command.arg("--long");
+    }
+
+    if json {
+        // Capture the inner wallet output and re-emit a structured envelope so
+        // consumers can read `exit_code` instead of guessing success from text.
+        // `accounts` is the best-effort line split; `stdout`/`stderr` keep the
+        // raw output for callers that need the wallet's own formatting.
+        let output = command
+            .output()
+            .context("failed to execute wallet list command")?;
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let accounts: Vec<&str> = stdout
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .collect();
+        let report = json!({
+            "command": "account list",
+            "exit_code": output.status.code(),
+            "accounts": accounts,
+            "stdout": stdout,
+            "stderr": stderr,
+        });
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        if !output.status.success() {
+            bail!("wallet account list failed");
+        }
+        return Ok(());
     }
 
     run_forwarded(&mut command, "wallet account list")
@@ -100,10 +136,21 @@ fn cmd_wallet_topup(
     project: &crate::model::Project,
     address: Option<String>,
     dry_run: bool,
+    json: bool,
 ) -> DynResult<()> {
-    match cmd_wallet_topup_inner(project, address, dry_run)? {
+    match cmd_wallet_topup_inner(project, address, dry_run, json)? {
         TopupOutcome::Success => Ok(()),
         TopupOutcome::ConfirmationTimeout { message } => bail!("{message}"),
+    }
+}
+
+/// Print `{ "status": "error", "reason": …, "message": … }` to stdout. Used in
+/// `--json` mode right before a `bail!` so machine consumers get a categorized
+/// reason instead of substring-matching the wallet's stderr.
+fn emit_topup_error_json(reason: &str, message: &str) {
+    let report = json!({ "status": "error", "reason": reason, "message": message });
+    if let Ok(text) = serde_json::to_string_pretty(&report) {
+        println!("{text}");
     }
 }
 
@@ -111,7 +158,11 @@ pub(crate) fn cmd_wallet_topup_inner(
     project: &crate::model::Project,
     address: Option<String>,
     dry_run: bool,
+    json: bool,
 ) -> DynResult<TopupOutcome> {
+    // In JSON mode, keep stdout clean: suppress the `$ <cmd>` echoes so the
+    // only thing on stdout is the structured object we emit at the end.
+    let _echo_guard = json.then(EchoGuard::suppress);
     let wallet = load_wallet_runtime(project)?;
     let default_address = read_default_wallet_address(&project.root)?;
     let resolved_to = resolve_wallet_address(address.as_deref(), default_address.as_deref())?;
@@ -147,6 +198,17 @@ pub(crate) fn cmd_wallet_topup_inner(
         .arg(&resolved_to);
 
     if dry_run {
+        if json {
+            let report = json!({
+                "status": "dry_run",
+                "address": resolved_to,
+                "method": "pinata faucet claim",
+                "network": sequencer_addr,
+                "wallet_home": wallet_home,
+            });
+            println!("{}", serde_json::to_string_pretty(&report)?);
+            return Ok(TopupOutcome::Success);
+        }
         println!("dry-run: wallet topup command will not be executed");
         println!("NSSA_WALLET_HOME_DIR={wallet_home}");
         println!("$ {}", render_command(&preflight_command));
@@ -168,12 +230,24 @@ pub(crate) fn cmd_wallet_topup_inner(
         let summary = summarize_command_failure(&preflight_output.stdout, &preflight_output.stderr);
         let combined = format!("{}\n{}", preflight_output.stdout, preflight_output.stderr);
         if is_connectivity_failure(&combined) {
+            if json {
+                emit_topup_error_json(
+                    "connectivity",
+                    &format!("wallet topup failed during account preflight: {summary}"),
+                );
+            }
             bail!(
                 "wallet topup failed during account preflight: {summary}\n{}",
                 sequencer_unreachable_hint(&sequencer_addr)
             );
         }
 
+        if json {
+            emit_topup_error_json(
+                "preflight",
+                &format!("wallet topup failed while checking account initialization: {summary}"),
+            );
+        }
         bail!(
             "wallet topup failed while checking account initialization: {summary}\nHint: verify the destination with `logos-scaffold wallet -- account get --account-id {resolved_to}`."
         );
@@ -181,9 +255,11 @@ pub(crate) fn cmd_wallet_topup_inner(
 
     let preflight_combined = format!("{}\n{}", preflight_output.stdout, preflight_output.stderr);
     if is_uninitialized_account_output(&preflight_combined) {
-        println!(
-            "wallet topup preflight: destination is uninitialized; running auth-transfer init"
-        );
+        if !json {
+            println!(
+                "wallet topup preflight: destination is uninitialized; running auth-transfer init"
+            );
+        }
         let init_output = run_with_stdin(init_command, password_input.clone())
             .context("failed to execute wallet topup init command")?;
 
@@ -191,14 +267,30 @@ pub(crate) fn cmd_wallet_topup_inner(
             let summary = summarize_command_failure(&init_output.stdout, &init_output.stderr);
             let combined = format!("{}\n{}", init_output.stdout, init_output.stderr);
             if is_connectivity_failure(&combined) {
+                if json {
+                    emit_topup_error_json(
+                        "connectivity",
+                        &format!("wallet topup failed during account initialization: {summary}"),
+                    );
+                }
                 bail!(
                     "wallet topup failed during account initialization: {summary}\n{}",
                     sequencer_unreachable_hint(&sequencer_addr)
                 );
             }
             if is_already_initialized_failure(&combined) {
-                println!("wallet topup preflight: destination already initialized; continuing");
+                if !json {
+                    println!("wallet topup preflight: destination already initialized; continuing");
+                }
             } else {
+                if json {
+                    emit_topup_error_json(
+                        "init",
+                        &format!(
+                            "wallet topup failed while initializing destination wallet: {summary}"
+                        ),
+                    );
+                }
                 bail!("wallet topup failed while initializing destination wallet: {summary}");
             }
         }
@@ -211,6 +303,9 @@ pub(crate) fn cmd_wallet_topup_inner(
         let summary = summarize_command_failure(&output.stdout, &output.stderr);
         let combined = format!("{}\n{}", output.stdout, output.stderr);
         if is_connectivity_failure(&combined) {
+            if json {
+                emit_topup_error_json("connectivity", &format!("wallet topup failed: {summary}"));
+            }
             bail!(
                 "wallet topup failed: {summary}\n{}",
                 sequencer_unreachable_hint(&sequencer_addr)
@@ -223,18 +318,45 @@ pub(crate) fn cmd_wallet_topup_inner(
                 &output.stdout,
                 &output.stderr,
             );
+            if json {
+                let report = json!({
+                    "status": "pending",
+                    "address": resolved_to,
+                    "method": "pinata faucet claim",
+                    "network": sequencer_addr,
+                    "tx": extract_tx_identifier(&output.stdout, &output.stderr),
+                    "message": message,
+                });
+                println!("{}", serde_json::to_string_pretty(&report)?);
+            }
             return Ok(TopupOutcome::ConfirmationTimeout { message });
+        }
+        if json {
+            emit_topup_error_json("failed", &format!("wallet topup failed: {summary}"));
         }
         bail!(
             "wallet topup failed: {summary}\nHint: run `logos-scaffold wallet list` to inspect addresses, then retry with `--address` or set a default wallet."
         );
     }
 
+    let tx = extract_tx_identifier(&output.stdout, &output.stderr);
+    if json {
+        let report = json!({
+            "status": "success",
+            "address": resolved_to,
+            "method": "pinata faucet claim",
+            "network": sequencer_addr,
+            "tx": tx,
+        });
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(TopupOutcome::Success);
+    }
+
     println!("wallet topup complete");
     println!("  Address: {resolved_to}");
     println!("  Method: pinata faucet claim");
     println!("  Network: local sequencer ({sequencer_addr})");
-    if let Some(tx) = extract_tx_identifier(&output.stdout, &output.stderr) {
+    if let Some(tx) = tx {
         println!("  Tx: {tx}");
     }
 

--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -80,6 +80,9 @@ fn cmd_wallet_list(project: &crate::model::Project, long: bool, json: bool) -> D
         // consumers can read `exit_code` instead of guessing success from text.
         // `accounts` is the best-effort line split; `stdout`/`stderr` keep the
         // raw output for callers that need the wallet's own formatting.
+        // `command` is the actual rendered invocation (binary + args, so it
+        // reflects `--long`) rather than a hard-coded label.
+        let rendered_command = render_command(&command);
         let output = command
             .output()
             .context("failed to execute wallet list command")?;
@@ -91,7 +94,7 @@ fn cmd_wallet_list(project: &crate::model::Project, long: bool, json: bool) -> D
             .filter(|line| !line.is_empty())
             .collect();
         let report = json!({
-            "command": "account list",
+            "command": rendered_command,
             "exit_code": output.status.code(),
             "accounts": accounts,
             "stdout": stdout,
@@ -144,11 +147,20 @@ fn cmd_wallet_topup(
     }
 }
 
-/// Print `{ "status": "error", "reason": …, "message": … }` to stdout. Used in
-/// `--json` mode right before a `bail!` so machine consumers get a categorized
-/// reason instead of substring-matching the wallet's stderr.
-fn emit_topup_error_json(reason: &str, message: &str) {
-    let report = json!({ "status": "error", "reason": reason, "message": message });
+/// Print the structured error object to stdout. Used in `--json` mode right
+/// before a `bail!` so machine consumers get a categorized `reason` instead of
+/// substring-matching the wallet's stderr — and the same `address` / `method`
+/// / `network` context the success / dry_run / pending objects carry, so error
+/// handling isn't missing what was attempted.
+fn emit_topup_error_json(reason: &str, message: &str, address: &str, network: &str) {
+    let report = json!({
+        "status": "error",
+        "reason": reason,
+        "address": address,
+        "method": "pinata faucet claim",
+        "network": network,
+        "message": message,
+    });
     if let Ok(text) = serde_json::to_string_pretty(&report) {
         println!("{text}");
     }
@@ -234,6 +246,8 @@ pub(crate) fn cmd_wallet_topup_inner(
                 emit_topup_error_json(
                     "connectivity",
                     &format!("wallet topup failed during account preflight: {summary}"),
+                    &resolved_to,
+                    &sequencer_addr,
                 );
             }
             bail!(
@@ -246,6 +260,8 @@ pub(crate) fn cmd_wallet_topup_inner(
             emit_topup_error_json(
                 "preflight",
                 &format!("wallet topup failed while checking account initialization: {summary}"),
+                &resolved_to,
+                &sequencer_addr,
             );
         }
         bail!(
@@ -271,6 +287,8 @@ pub(crate) fn cmd_wallet_topup_inner(
                     emit_topup_error_json(
                         "connectivity",
                         &format!("wallet topup failed during account initialization: {summary}"),
+                        &resolved_to,
+                        &sequencer_addr,
                     );
                 }
                 bail!(
@@ -289,6 +307,8 @@ pub(crate) fn cmd_wallet_topup_inner(
                         &format!(
                             "wallet topup failed while initializing destination wallet: {summary}"
                         ),
+                        &resolved_to,
+                        &sequencer_addr,
                     );
                 }
                 bail!("wallet topup failed while initializing destination wallet: {summary}");
@@ -304,7 +324,12 @@ pub(crate) fn cmd_wallet_topup_inner(
         let combined = format!("{}\n{}", output.stdout, output.stderr);
         if is_connectivity_failure(&combined) {
             if json {
-                emit_topup_error_json("connectivity", &format!("wallet topup failed: {summary}"));
+                emit_topup_error_json(
+                    "connectivity",
+                    &format!("wallet topup failed: {summary}"),
+                    &resolved_to,
+                    &sequencer_addr,
+                );
             }
             bail!(
                 "wallet topup failed: {summary}\n{}",
@@ -332,7 +357,12 @@ pub(crate) fn cmd_wallet_topup_inner(
             return Ok(TopupOutcome::ConfirmationTimeout { message });
         }
         if json {
-            emit_topup_error_json("failed", &format!("wallet topup failed: {summary}"));
+            emit_topup_error_json(
+                "failed",
+                &format!("wallet topup failed: {summary}"),
+                &resolved_to,
+                &sequencer_addr,
+            );
         }
         bail!(
             "wallet topup failed: {summary}\nHint: run `logos-scaffold wallet list` to inspect addresses, then retry with `--address` or set a default wallet."

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1291,6 +1291,20 @@ fn wallet_topup_json_connectivity_failure_categorizes_reason() {
         value.get("reason").and_then(|v| v.as_str()),
         Some("connectivity")
     );
+    // Error objects carry the same attempt context as success/pending, so
+    // consumers don't lose what was attempted on failure.
+    assert!(value
+        .get("address")
+        .and_then(|v| v.as_str())
+        .is_some_and(|s| s.contains("Public/")));
+    assert_eq!(
+        value.get("method").and_then(|v| v.as_str()),
+        Some("pinata faucet claim")
+    );
+    assert_eq!(
+        value.get("network").and_then(|v| v.as_str()),
+        Some("http://127.0.0.1:3040")
+    );
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1170,6 +1170,130 @@ fn wallet_list_proxies_account_list() {
 }
 
 #[test]
+fn wallet_list_json_emits_structured_envelope() {
+    let temp = tempdir().expect("tempdir");
+    setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));
+
+    let assert = Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .args(["wallet", "list", "--json"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8 stdout");
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+
+    assert_eq!(value.get("exit_code").and_then(|v| v.as_i64()), Some(0));
+    let accounts = value
+        .get("accounts")
+        .and_then(|v| v.as_array())
+        .expect("accounts array");
+    assert_eq!(accounts.len(), 2, "stub lists two accounts: {stdout}");
+    assert!(accounts.iter().any(|a| a
+        .as_str()
+        .is_some_and(|s| s.contains("Preconfigured Public/"))));
+}
+
+#[test]
+fn wallet_topup_json_dry_run_is_structured() {
+    let temp = tempdir().expect("tempdir");
+    setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));
+
+    let assert = Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .args([
+            "wallet",
+            "topup",
+            "--address",
+            VALID_PUBLIC_ADDRESS,
+            "--dry-run",
+            "--json",
+        ])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8 stdout");
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+
+    assert_eq!(
+        value.get("status").and_then(|v| v.as_str()),
+        Some("dry_run")
+    );
+    assert!(value
+        .get("address")
+        .and_then(|v| v.as_str())
+        .is_some_and(|s| s.contains("Public/")));
+    assert_eq!(
+        value.get("method").and_then(|v| v.as_str()),
+        Some("pinata faucet claim")
+    );
+}
+
+#[test]
+fn wallet_topup_json_success_reports_tx() {
+    let temp = tempdir().expect("tempdir");
+    setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));
+
+    let assert = Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .args([
+            "wallet",
+            "topup",
+            "--address",
+            VALID_PUBLIC_ADDRESS,
+            "--json",
+        ])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8 stdout");
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+
+    assert_eq!(
+        value.get("status").and_then(|v| v.as_str()),
+        Some("success")
+    );
+    assert_eq!(
+        value.get("tx").and_then(|v| v.as_str()),
+        Some("pinata-topup-hash"),
+        "stub emits tx_hash=pinata-topup-hash"
+    );
+    // stdout must be a single clean JSON object — no `$ <cmd>` echo lines.
+    assert!(
+        stdout.trim_start().starts_with('{'),
+        "json mode must not echo commands before the object: {stdout}"
+    );
+}
+
+#[test]
+fn wallet_topup_json_connectivity_failure_categorizes_reason() {
+    let temp = tempdir().expect("tempdir");
+    setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));
+
+    let assert = Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .env("TOPUP_FAIL_CONNECT", "1")
+        .args([
+            "wallet",
+            "topup",
+            "--address",
+            VALID_PUBLIC_ADDRESS,
+            "--json",
+        ])
+        .assert()
+        .failure();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8 stdout");
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+
+    assert_eq!(value.get("status").and_then(|v| v.as_str()), Some("error"));
+    assert_eq!(
+        value.get("reason").and_then(|v| v.as_str()),
+        Some("connectivity")
+    );
+}
+
+#[test]
 fn wallet_passthrough_account_list_works() {
     let temp = tempdir().expect("tempdir");
     setup_wallet_project(temp.path(), Some("http://127.0.0.1:3040"));

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1227,6 +1227,8 @@ fn wallet_topup_json_dry_run_is_structured() {
         value.get("method").and_then(|v| v.as_str()),
         Some("pinata faucet claim")
     );
+    // Stable schema: `tx` key is always present (null for a dry run).
+    assert!(value.get("tx").is_some_and(serde_json::Value::is_null));
 }
 
 #[test]
@@ -1305,6 +1307,8 @@ fn wallet_topup_json_connectivity_failure_categorizes_reason() {
         value.get("network").and_then(|v| v.as_str()),
         Some("http://127.0.0.1:3040")
     );
+    // Stable schema: `tx` is always present (null in the error case).
+    assert!(value.get("tx").is_some_and(serde_json::Value::is_null));
 }
 
 #[test]


### PR DESCRIPTION
### Problem / Description
`wallet list` and `wallet topup` print human-readable text only. Application code that drives scaffold has to scrape stdout and infer error types from stderr substrings (`"already initialized"`, `"connection refused"`, …). `localnet status --json` and `doctor --json` already set the structured-output precedent; wallet didn't follow it.

### Solution
Add `--json` to both commands:

- **`wallet list --json`** — emits an envelope `{ command, exit_code, accounts, stdout, stderr }`, so consumers read `exit_code` instead of guessing success from text while still keeping the raw wallet output.
- **`wallet topup --json`** — emits a structured outcome with a stable `status` (`success` | `dry_run` | `pending` | `error`) and, on failure, a categorized `reason` (`connectivity` | `preflight` | `init` | `failed`), plus `address`, `method`, `network`, and `tx`. Command echoes are suppressed in JSON mode so stdout is a single clean object; the process still exits non-zero on failure/timeout.

Plain-text output is unchanged when `--json` is omitted. Adds 4 integration tests and `--help` examples.

The optional `wallet balance` subcommand floated in the issue is intentionally left as a follow-up — it needs a parse of the inner wallet's balance format that can't be exercised against a stub here.

Closes #23.