### PR TITLE
feat(idl): hash-based short-circuit for `build idl`

### DIFF
--- a/src/commands/idl.rs
+++ b/src/commands/idl.rs
@@ -1,11 +1,15 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use anyhow::{anyhow, bail};
+use anyhow::{anyhow, bail, Context};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use walkdir::WalkDir;
 
 use crate::circuits::ensure_circuits_for_subprocess;
 use crate::constants::FRAMEWORK_KIND_LEZ_FRAMEWORK;
+use crate::model::Project;
 use crate::process::run_capture;
 use crate::project::{load_project, resolve_cache_root, run_in_project_dir};
 use crate::state::write_text;
@@ -15,6 +19,21 @@ const IDL_BEGIN_PREFIX: &str = "--- LSSA IDL BEGIN ";
 const IDL_END_PREFIX: &str = "--- LSSA IDL END ";
 const IDL_MARKER_SUFFIX: &str = " ---";
 
+/// Cache file recording the fingerprint of the inputs that produced the IDL,
+/// alongside the list of output `.json` files written. Lives in the same
+/// `.scaffold/state/` neighbourhood as `run_deploy.json`.
+pub(crate) const IDL_STATE_REL: &str = ".scaffold/state/idl_build.json";
+
+/// Persisted IDL-build fingerprint. `input_hash` covers every project `.rs`
+/// source, `Cargo.lock` (which pins the IDL-emitting proc-macro), and the
+/// `[framework.idl]` config; `outputs` are the file names written so a cache
+/// hit can verify they still exist before skipping the rebuild.
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct IdlBuildState {
+    input_hash: String,
+    outputs: Vec<String>,
+}
+
 pub(crate) fn cmd_idl(args: &[String]) -> DynResult<()> {
     if args.is_empty() {
         bail!("usage: logos-scaffold build idl [project-path]");
@@ -23,13 +42,22 @@ pub(crate) fn cmd_idl(args: &[String]) -> DynResult<()> {
     match args[0].as_str() {
         "build" => {
             let project_dir = parse_optional_project_path(&args[1..], "logos-scaffold build idl")?;
-            run_in_project_dir(project_dir.as_deref(), build_idl_for_current_project)
+            // Explicit `build idl` regenerates unconditionally (force = true):
+            // it's the documented "regenerate the IDL" escape hatch, so it
+            // must not silently short-circuit on the cache.
+            run_in_project_dir(project_dir.as_deref(), || build_idl_inner(true))
         }
         other => Err(anyhow!("unknown idl command: {other}")),
     }
 }
 
+/// Cache-aware IDL build used by the `build` / `run` pipelines. Short-circuits
+/// when inputs are unchanged; see `build_idl_inner`.
 pub(crate) fn build_idl_for_current_project() -> DynResult<()> {
+    build_idl_inner(false)
+}
+
+fn build_idl_inner(force: bool) -> DynResult<()> {
     let project = load_project()?;
     if project.config.framework.kind != FRAMEWORK_KIND_LEZ_FRAMEWORK {
         // Explicit `build idl` only applies to lez-framework projects. The
@@ -47,6 +75,23 @@ pub(crate) fn build_idl_for_current_project() -> DynResult<()> {
     }
 
     let idl_dir = project.root.join(&project.config.framework.idl.path);
+
+    // Hash-based short-circuit: the `cargo test __lssa_idl_print` invocation
+    // below dominates `lgs run` wall time (~30s) even when it re-emits an IDL
+    // whose inputs are byte-identical. When the fingerprint matches the prior
+    // build AND every output file is still on disk, skip the rebuild.
+    let input_hash = compute_idl_input_hash(&project)?;
+    if !force {
+        if let Some(state) = load_idl_state(&project) {
+            if state.input_hash == input_hash && outputs_present(&idl_dir, &state.outputs) {
+                println!(
+                    "IDL up-to-date (skipped); inputs unchanged. Force a rebuild with `lgs build idl` or `lgs run --reset`."
+                );
+                return Ok(());
+            }
+        }
+    }
+
     fs::create_dir_all(&idl_dir)?;
     clear_existing_json_files(&idl_dir)?;
 
@@ -73,15 +118,136 @@ pub(crate) fn build_idl_for_current_project() -> DynResult<()> {
     }
 
     blocks.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut outputs = Vec::new();
     for (name, json_text) in blocks {
         let canonical = canonical_json(&json_text)?;
         let file_name = format!("{}.json", sanitize_file_stem(&name));
-        let path = idl_dir.join(file_name);
+        let path = idl_dir.join(&file_name);
         write_text(&path, &canonical)?;
         println!("Wrote IDL {}", path.display());
+        outputs.push(file_name);
     }
 
+    // Record the fingerprint last, after every output landed. A crash
+    // mid-write leaves no/old state, so the next build re-runs rather than
+    // trusting a half-written IDL set.
+    save_idl_state(
+        &project,
+        &IdlBuildState {
+            input_hash,
+            outputs,
+        },
+    )?;
+
     Ok(())
+}
+
+/// SHA-256 over the inputs that determine the IDL output: every `.rs` source
+/// in the project (target / hidden / vendor dirs excluded), `Cargo.lock` (so a
+/// `cargo update` that bumps the IDL-emitting proc-macro busts the cache even
+/// when guest sources are byte-identical), and the `[framework.idl]` config.
+fn compute_idl_input_hash(project: &Project) -> DynResult<String> {
+    let root = &project.root;
+    let mut entries: Vec<(String, Vec<u8>)> = Vec::new();
+    for entry in WalkDir::new(root)
+        .into_iter()
+        .filter_entry(|e| keep_for_idl_hash(e, root))
+    {
+        let entry = entry.with_context(|| format!("walk {}", root.display()))?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "rs") {
+            let rel = path
+                .strip_prefix(root)
+                .unwrap_or(path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            let bytes = fs::read(path).with_context(|| format!("read {}", path.display()))?;
+            entries.push((rel, bytes));
+        }
+    }
+    // Deterministic order so the digest is stable regardless of FS traversal.
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut hasher = Sha256::new();
+    for (rel, bytes) in &entries {
+        hasher.update(rel.as_bytes());
+        hasher.update(b"\x00");
+        hasher.update(bytes);
+        hasher.update(b"\x00");
+    }
+    if let Ok(lock) = fs::read(root.join("Cargo.lock")) {
+        hasher.update(b"cargo.lock\x00");
+        hasher.update(&lock);
+    }
+    hasher.update(b"idlcfg\x00");
+    hasher.update(project.config.framework.idl.spec.as_bytes());
+    hasher.update(b"\x00");
+    hasher.update(project.config.framework.idl.path.as_bytes());
+
+    Ok(hex_encode(&hasher.finalize()))
+}
+
+/// `filter_entry` predicate: keep the root, every file, and any directory that
+/// isn't a build/vendor/hidden dir. Pruning here (rather than post-filtering)
+/// means `walkdir` never descends into `target/`, `node_modules/`, `result/`,
+/// `.scaffold/`, or `.git/`.
+fn keep_for_idl_hash(entry: &walkdir::DirEntry, root: &Path) -> bool {
+    if entry.path() == root {
+        return true;
+    }
+    if entry.file_type().is_dir() {
+        let name = entry.file_name().to_string_lossy();
+        if name.starts_with('.') || matches!(name.as_ref(), "target" | "node_modules" | "result") {
+            return false;
+        }
+    }
+    true
+}
+
+fn outputs_present(idl_dir: &Path, outputs: &[String]) -> bool {
+    !outputs.is_empty() && outputs.iter().all(|name| idl_dir.join(name).exists())
+}
+
+fn load_idl_state(project: &Project) -> Option<IdlBuildState> {
+    let path = project.root.join(IDL_STATE_REL);
+    let bytes = fs::read(&path).ok()?;
+    match serde_json::from_slice(&bytes) {
+        Ok(state) => Some(state),
+        Err(err) => {
+            eprintln!(
+                "warning: ignoring malformed IDL cache at {} ({err}); IDL will rebuild",
+                path.display()
+            );
+            None
+        }
+    }
+}
+
+fn save_idl_state(project: &Project, state: &IdlBuildState) -> DynResult<()> {
+    let path = project.root.join(IDL_STATE_REL);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    let text = serde_json::to_string_pretty(state).context("serialize idl_build.json")?;
+    // Atomic write: stage to a sibling tempfile, then rename. A SIGINT
+    // between write and rename leaves the prior cache intact rather than
+    // truncating it. Same parent dir keeps rename(2) atomic.
+    let tmp = path.with_file_name("idl_build.json.tmp");
+    fs::write(&tmp, &text).with_context(|| format!("write {}", tmp.display()))?;
+    fs::rename(&tmp, &path)
+        .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
 }
 
 fn parse_optional_project_path(args: &[String], usage_label: &str) -> DynResult<Option<PathBuf>> {
@@ -199,7 +365,8 @@ fn parse_marker<'a>(line: &'a str, prefix: &str) -> Option<&'a str> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_idl_blocks;
+    use super::*;
+    use std::collections::BTreeMap;
 
     #[test]
     fn parses_idl_blocks() {
@@ -213,5 +380,149 @@ ignored
         assert_eq!(blocks.len(), 1);
         assert_eq!(blocks[0].0, "token_program");
         assert_eq!(blocks[0].1, r#"{"a":1}"#);
+    }
+
+    fn make_test_project(root: std::path::PathBuf) -> Project {
+        use crate::model::{
+            Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig, RepoRef, RunConfig,
+        };
+        Project {
+            root,
+            config: Config {
+                version: "0.2.0".to_string(),
+                cache_root: ".scaffold/cache".to_string(),
+                lez: RepoRef::default(),
+                spel: RepoRef::default(),
+                basecamp_repo: None,
+                lgpm_repo: None,
+                wallet_home_dir: ".scaffold/wallet".to_string(),
+                framework: FrameworkConfig {
+                    kind: FRAMEWORK_KIND_LEZ_FRAMEWORK.to_string(),
+                    version: "0.1.0".to_string(),
+                    idl: FrameworkIdlConfig {
+                        spec: "lssa-idl/0.1.0".to_string(),
+                        path: "idl".to_string(),
+                    },
+                },
+                localnet: LocalnetConfig {
+                    port: 3040,
+                    risc0_dev_mode: true,
+                },
+                modules: BTreeMap::new(),
+                run: RunConfig::default(),
+                basecamp: None,
+            },
+        }
+    }
+
+    fn write(root: &Path, rel: &str, contents: &[u8]) {
+        let path = root.join(rel);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn idl_hash_is_stable_when_nothing_changes() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        write(
+            temp.path(),
+            "methods/guest/src/bin/counter.rs",
+            b"fn main() {}\n",
+        );
+        let project = make_test_project(temp.path().to_path_buf());
+        let a = compute_idl_input_hash(&project).expect("hash a");
+        let b = compute_idl_input_hash(&project).expect("hash b");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn idl_hash_changes_when_a_source_file_changes() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let rel = "methods/guest/src/bin/counter.rs";
+        write(temp.path(), rel, b"fn main() {}\n");
+        let project = make_test_project(temp.path().to_path_buf());
+        let before = compute_idl_input_hash(&project).expect("before");
+        // Edit a guest source that feeds the IDL.
+        write(temp.path(), rel, b"fn main() { /* changed */ }\n");
+        let after = compute_idl_input_hash(&project).expect("after");
+        assert_ne!(before, after, "editing a guest source must bust the cache");
+    }
+
+    #[test]
+    fn idl_hash_changes_when_cargo_lock_changes() {
+        // Acceptance: bumping the IDL-emitting macro's pin (which lands in
+        // Cargo.lock) re-runs the IDL even if guest sources are identical.
+        let temp = tempfile::tempdir().expect("tempdir");
+        write(
+            temp.path(),
+            "methods/guest/src/bin/counter.rs",
+            b"fn main() {}\n",
+        );
+        write(temp.path(), "Cargo.lock", b"# v1\n");
+        let project = make_test_project(temp.path().to_path_buf());
+        let before = compute_idl_input_hash(&project).expect("before");
+        write(temp.path(), "Cargo.lock", b"# v2 (macro pin bumped)\n");
+        let after = compute_idl_input_hash(&project).expect("after");
+        assert_ne!(before, after, "Cargo.lock change must bust the cache");
+    }
+
+    #[test]
+    fn idl_hash_ignores_target_and_hidden_dirs() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        write(
+            temp.path(),
+            "methods/guest/src/bin/counter.rs",
+            b"fn main() {}\n",
+        );
+        let project = make_test_project(temp.path().to_path_buf());
+        let before = compute_idl_input_hash(&project).expect("before");
+        // Build artifacts and scaffold state must not affect the fingerprint.
+        write(temp.path(), "target/debug/build/gen.rs", b"// generated\n");
+        write(temp.path(), "methods/target/x/riscv.rs", b"// generated\n");
+        write(temp.path(), ".scaffold/state/note.rs", b"// state\n");
+        let after = compute_idl_input_hash(&project).expect("after");
+        assert_eq!(before, after, "target/.scaffold .rs must be excluded");
+    }
+
+    #[test]
+    fn idl_state_round_trips() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = make_test_project(temp.path().to_path_buf());
+        let state = IdlBuildState {
+            input_hash: "deadbeef".to_string(),
+            outputs: vec!["counter.json".to_string()],
+        };
+        save_idl_state(&project, &state).expect("save");
+        let loaded = load_idl_state(&project).expect("load");
+        assert_eq!(loaded.input_hash, "deadbeef");
+        assert_eq!(loaded.outputs, vec!["counter.json".to_string()]);
+        // No leftover tempfile.
+        assert!(!temp
+            .path()
+            .join(".scaffold/state/idl_build.json.tmp")
+            .exists());
+    }
+
+    #[test]
+    fn outputs_present_requires_every_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let idl_dir = temp.path().join("idl");
+        fs::create_dir_all(&idl_dir).unwrap();
+        fs::write(idl_dir.join("counter.json"), b"{}").unwrap();
+        let outputs = vec!["counter.json".to_string()];
+        assert!(outputs_present(&idl_dir, &outputs));
+        // A second expected file that's missing flips it to false.
+        let two = vec!["counter.json".to_string(), "token.json".to_string()];
+        assert!(!outputs_present(&idl_dir, &two));
+        // Empty outputs never count as a fresh cache.
+        assert!(!outputs_present(&idl_dir, &[]));
+    }
+
+    #[test]
+    fn malformed_idl_cache_is_ignored() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = make_test_project(temp.path().to_path_buf());
+        write(temp.path(), ".scaffold/state/idl_build.json", b"{not json");
+        assert!(load_idl_state(&project).is_none());
     }
 }

--- a/src/commands/idl.rs
+++ b/src/commands/idl.rs
@@ -178,9 +178,20 @@ fn compute_idl_input_hash(project: &Project) -> DynResult<String> {
         hasher.update(bytes);
         hasher.update(b"\x00");
     }
-    if let Ok(lock) = fs::read(root.join("Cargo.lock")) {
-        hasher.update(b"cargo.lock\x00");
-        hasher.update(&lock);
+    // Cargo.lock is part of the cache key. A missing lock is fine (absent), but
+    // any other read error (permissions, I/O) must surface — silently ignoring
+    // it would fold an empty value into the digest and risk a false cache hit
+    // that skips a needed rebuild.
+    let lock_path = root.join("Cargo.lock");
+    match fs::read(&lock_path) {
+        Ok(lock) => {
+            hasher.update(b"cargo.lock\x00");
+            hasher.update(&lock);
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(e).with_context(|| format!("read {}", lock_path.display()));
+        }
     }
     hasher.update(b"idlcfg\x00");
     hasher.update(project.config.framework.idl.spec.as_bytes());
@@ -208,7 +219,9 @@ fn keep_for_idl_hash(entry: &walkdir::DirEntry, root: &Path) -> bool {
 }
 
 fn outputs_present(idl_dir: &Path, outputs: &[String]) -> bool {
-    !outputs.is_empty() && outputs.iter().all(|name| idl_dir.join(name).exists())
+    // `is_file()` (not `exists()`): a directory named `<stem>.json` must not
+    // count as a valid cached output and short-circuit the rebuild.
+    !outputs.is_empty() && outputs.iter().all(|name| idl_dir.join(name).is_file())
 }
 
 fn load_idl_state(project: &Project) -> Option<IdlBuildState> {
@@ -516,6 +529,9 @@ ignored
         assert!(!outputs_present(&idl_dir, &two));
         // Empty outputs never count as a fresh cache.
         assert!(!outputs_present(&idl_dir, &[]));
+        // A *directory* named like an output must not count as present.
+        fs::create_dir_all(idl_dir.join("dir.json")).unwrap();
+        assert!(!outputs_present(&idl_dir, &["dir.json".to_string()]));
     }
 
     #[test]

--- a/src/commands/idl.rs
+++ b/src/commands/idl.rs
@@ -25,9 +25,10 @@ const IDL_MARKER_SUFFIX: &str = " ---";
 pub(crate) const IDL_STATE_REL: &str = ".scaffold/state/idl_build.json";
 
 /// Persisted IDL-build fingerprint. `input_hash` covers every project `.rs`
-/// source, `Cargo.lock` (which pins the IDL-emitting proc-macro), and the
-/// `[framework.idl]` config; `outputs` are the file names written so a cache
-/// hit can verify they still exist before skipping the rebuild.
+/// source and `Cargo.toml` manifest, `Cargo.lock` (which pins the IDL-emitting
+/// proc-macro), and the `[framework.idl]` config; `outputs` are the file names
+/// written so a cache hit can verify they still exist before skipping the
+/// rebuild.
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct IdlBuildState {
     input_hash: String,
@@ -143,12 +144,19 @@ fn build_idl_inner(force: bool) -> DynResult<()> {
 }
 
 /// SHA-256 over the inputs that determine the IDL output: every `.rs` source
-/// in the project (target / hidden / vendor dirs excluded), `Cargo.lock` (so a
-/// `cargo update` that bumps the IDL-emitting proc-macro busts the cache even
-/// when guest sources are byte-identical), and the `[framework.idl]` config.
+/// and every `Cargo.toml` manifest in the project (target / hidden / vendor
+/// dirs excluded), `Cargo.lock` (so a `cargo update` that bumps the
+/// IDL-emitting proc-macro busts the cache even when guest sources are
+/// byte-identical), and the `[framework.idl]` config. Manifests are included
+/// because a `Cargo.toml` feature-flag / dependency / proc-macro change can
+/// alter what `cargo test __lssa_idl_print` emits without touching any `.rs`
+/// file or `Cargo.lock`.
 fn compute_idl_input_hash(project: &Project) -> DynResult<String> {
     let root = &project.root;
-    let mut entries: Vec<(String, Vec<u8>)> = Vec::new();
+    // Collect just the input paths (no file bytes), sort for a stable digest,
+    // then stream each file into the hasher one at a time — peak memory is a
+    // single file rather than the whole source tree.
+    let mut files: Vec<(String, std::path::PathBuf)> = Vec::new();
     for entry in WalkDir::new(root)
         .into_iter()
         .filter_entry(|e| keep_for_idl_hash(e, root))
@@ -158,24 +166,26 @@ fn compute_idl_input_hash(project: &Project) -> DynResult<String> {
             continue;
         }
         let path = entry.path();
-        if path.extension().is_some_and(|ext| ext == "rs") {
+        let is_rs = path.extension().is_some_and(|ext| ext == "rs");
+        let is_manifest = path.file_name().is_some_and(|n| n == "Cargo.toml");
+        if is_rs || is_manifest {
             let rel = path
                 .strip_prefix(root)
                 .unwrap_or(path)
                 .to_string_lossy()
                 .replace('\\', "/");
-            let bytes = fs::read(path).with_context(|| format!("read {}", path.display()))?;
-            entries.push((rel, bytes));
+            files.push((rel, path.to_path_buf()));
         }
     }
     // Deterministic order so the digest is stable regardless of FS traversal.
-    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    files.sort_by(|a, b| a.0.cmp(&b.0));
 
     let mut hasher = Sha256::new();
-    for (rel, bytes) in &entries {
+    for (rel, abs) in &files {
         hasher.update(rel.as_bytes());
         hasher.update(b"\x00");
-        hasher.update(bytes);
+        let bytes = fs::read(abs).with_context(|| format!("read {}", abs.display()))?;
+        hasher.update(&bytes);
         hasher.update(b"\x00");
     }
     // Cargo.lock is part of the cache key. A missing lock is fine (absent), but
@@ -211,7 +221,12 @@ fn keep_for_idl_hash(entry: &walkdir::DirEntry, root: &Path) -> bool {
     }
     if entry.file_type().is_dir() {
         let name = entry.file_name().to_string_lossy();
-        if name.starts_with('.') || matches!(name.as_ref(), "target" | "node_modules" | "result") {
+        if name.starts_with('.')
+            || matches!(
+                name.as_ref(),
+                "target" | "node_modules" | "result" | "vendor"
+            )
+        {
             return false;
         }
     }
@@ -480,7 +495,29 @@ ignored
     }
 
     #[test]
-    fn idl_hash_ignores_target_and_hidden_dirs() {
+    fn idl_hash_changes_when_cargo_toml_changes() {
+        // A Cargo.toml feature/dep/proc-macro change can alter the emitted IDL
+        // without touching any .rs file or Cargo.lock — it must bust the cache.
+        let temp = tempfile::tempdir().expect("tempdir");
+        write(
+            temp.path(),
+            "methods/guest/src/bin/counter.rs",
+            b"fn main() {}\n",
+        );
+        write(temp.path(), "Cargo.toml", b"[package]\nname='x'\n");
+        let project = make_test_project(temp.path().to_path_buf());
+        let before = compute_idl_input_hash(&project).expect("before");
+        write(
+            temp.path(),
+            "Cargo.toml",
+            b"[package]\nname='x'\n\n[features]\nidl-extra=[]\n",
+        );
+        let after = compute_idl_input_hash(&project).expect("after");
+        assert_ne!(before, after, "Cargo.toml change must bust the cache");
+    }
+
+    #[test]
+    fn idl_hash_ignores_target_hidden_and_vendor_dirs() {
         let temp = tempfile::tempdir().expect("tempdir");
         write(
             temp.path(),
@@ -489,12 +526,18 @@ ignored
         );
         let project = make_test_project(temp.path().to_path_buf());
         let before = compute_idl_input_hash(&project).expect("before");
-        // Build artifacts and scaffold state must not affect the fingerprint.
+        // Build artifacts, scaffold state, and vendored sources must not affect
+        // the fingerprint (vendor/ can be large + is not project source).
         write(temp.path(), "target/debug/build/gen.rs", b"// generated\n");
         write(temp.path(), "methods/target/x/riscv.rs", b"// generated\n");
         write(temp.path(), ".scaffold/state/note.rs", b"// state\n");
+        write(temp.path(), "vendor/somecrate/src/lib.rs", b"// vendored\n");
+        write(temp.path(), "vendor/somecrate/Cargo.toml", b"[package]\n");
         let after = compute_idl_input_hash(&project).expect("after");
-        assert_eq!(before, after, "target/.scaffold .rs must be excluded");
+        assert_eq!(
+            before, after,
+            "target/.scaffold/vendor must be excluded from the fingerprint"
+        );
     }
 
     #[test]

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -10,7 +10,7 @@ use crate::commands::build::cmd_build_shortcut;
 use crate::commands::deploy::{
     cmd_deploy, discover_deployable_programs, discover_program_binaries, extract_program_id,
 };
-use crate::commands::idl::build_idl_for_current_project;
+use crate::commands::idl::{build_idl_for_current_project, IDL_STATE_REL};
 use crate::commands::localnet::{
     build_localnet_status_for_project, cmd_localnet, cmd_localnet_reset, LocalnetAction,
 };
@@ -108,6 +108,22 @@ fn run_pipeline_once(project: &Project, params: &PipelineParams) -> DynResult<()
         eprintln!(
             "warning: scaffold.toml requested reset = true; step 3 will wipe sequencer state + wallet. Pass --no-reset to override."
         );
+    }
+
+    // A reset means "start fresh": clear the IDL cache *before* the IDL
+    // step (step 2) so it re-runs this invocation. The deploy cache is
+    // cleared later in step 3, after the on-chain wipe. Tolerate a missing
+    // file (no prior run).
+    if effective_reset {
+        let idl_state = project.root.join(IDL_STATE_REL);
+        match std::fs::remove_file(&idl_state) {
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(e)
+                    .with_context(|| format!("clear stale IDL cache at {}", idl_state.display()));
+            }
+        }
     }
 
     // Step 1: Build (chains setup internally)

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -560,7 +560,8 @@ fn print_deploy_summary(project: &Project) -> DynResult<()> {
     // so the summary always reflects the address the wallet actually targets,
     // rather than the raw localnet.port value which may differ when
     // wallet_config.json overrides sequencer_addr (issue #161).
-    let sequencer_url = crate::commands::wallet_support::default_sequencer_http_url_for_project(project);
+    let sequencer_url =
+        crate::commands::wallet_support::default_sequencer_http_url_for_project(project);
     println!();
     println!("Sequencer: {sequencer_url}");
 
@@ -572,7 +573,8 @@ fn build_hook_command(
     hook_command: &str,
     deployed: &DeployedPrograms,
 ) -> Command {
-    let sequencer_url = crate::commands::wallet_support::default_sequencer_http_url_for_project(project);
+    let sequencer_url =
+        crate::commands::wallet_support::default_sequencer_http_url_for_project(project);
     let wallet_home = project
         .root
         .join(&project.config.wallet_home_dir)


### PR DESCRIPTION
### Problem / Description
With the deploy cache in place, a no-change `lgs run` against a real Phase-1 project spends ~30s of its ~35s in step `[2/5] Building IDL`, which calls `cargo test --workspace __lssa_idl_print` unconditionally and re-prints an IDL whose inputs haven't changed.

### Solution
Add a hash-based short-circuit to `build_idl_for_current_project`, mirroring the deploy cache:

- Fingerprint the IDL inputs into a SHA-256 stored at `.scaffold/state/idl_build.json`: every project `.rs` source (excluding `target/`, `.scaffold/`, and other build/vendor dirs), `Cargo.lock` (which pins the IDL-emitting proc-macro, so a `cargo update` busts the cache even when guest sources are byte-identical), and the `[framework.idl]` config. The state also records the output `.json` file names.
- On entry, when the fingerprint matches the prior build **and** every recorded output still exists on disk, skip the `cargo test` invocation and print `IDL up-to-date (skipped)`.
- Explicit `lgs build idl` always regenerates (force); the `build` / `run` pipelines use the cache.
- `lgs run --reset` clears the IDL cache (before the IDL step, so it re-runs that invocation) alongside the deploy cache.
- Atomic tempfile+rename writes and malformed-cache fallback, same as `run_deploy.json`.

### Acceptance mapping
- no-change `lgs run` collapses (IDL step skipped) ✔
- `lgs run --reset` clears both caches ✔
- editing a guest source re-runs IDL (covered by `idl_hash_changes_when_a_source_file_changes`) ✔
- bumping the IDL macro's pin re-runs even with identical sources, via Cargo.lock (`idl_hash_changes_when_cargo_lock_changes`) ✔

### Tests / verification
7 unit tests cover hash stability, change detection (source + Cargo.lock), `target/`+`.scaffold/` exclusion, state round-trip, output-presence, and malformed-cache fallback. The full `cargo test __lssa_idl_print` path needs a real lez-framework workspace + circuits release (not reproducible in CI here), so the cache decision logic is unit-tested directly. The framework-gate behavior is unchanged (`build_idl_fails_loudly_on_default_framework` still green).

Closes #134.