### PR TITLE
feat(run): `[run.watch]` include/exclude globs + `--watch-debounce-ms`

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,29 @@ lgs run --no-post-deploy                                 # skip all hooks
 `--post-deploy` and `--no-post-deploy` conflict with each other and
 both override whatever `[run].post_deploy` defines.
 
+#### Watch mode
+
+`lgs run --watch` re-runs the pipeline on each filesystem change (localnet
+is reused; reset is skipped on re-runs). Scope what counts as a change with
+`[run.watch]` and tune the coalescing window:
+
+```toml
+[run.watch]
+include = ["programs/**/guest/**", "contracts/**/*.sol"]
+exclude = ["**/*.md", "Cargo.lock"]
+debounce_ms = 1500
+```
+
+A changed path triggers a re-run **iff** it matches at least one `include`
+glob (or `include` is unset, meaning "any path") **and** matches zero
+`exclude` globs — `exclude` always wins. Globs are project-relative,
+gitignore-style: `**` spans path segments, `*`/`?` match within a segment,
+and a slash-less pattern (`Cargo.lock`) matches at any depth. `.scaffold`,
+`target`, `.git`, and the IDL output dir are always ignored regardless of
+these filters. Override the debounce per invocation with
+`lgs run --watch --watch-debounce-ms 1500` (CLI wins over
+`[run.watch].debounce_ms`, which wins over the 500ms default).
+
 Checkpoint commands:
 
 ```bash

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -315,7 +315,8 @@ struct RunArgs {
     watch: bool,
     /// Override the `--watch` debounce window (milliseconds) for this
     /// invocation. Defaults to `[run.watch].debounce_ms`, else 500.
-    #[arg(long, value_name = "MS")]
+    /// Only meaningful with `--watch`, so it requires it.
+    #[arg(long, value_name = "MS", requires = "watch")]
     watch_debounce_ms: Option<u64>,
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -313,6 +313,10 @@ struct RunArgs {
     /// Localnet is reused; reset is skipped on re-runs.
     #[arg(long)]
     watch: bool,
+    /// Override the `--watch` debounce window (milliseconds) for this
+    /// invocation. Defaults to `[run.watch].debounce_ms`, else 500.
+    #[arg(long, value_name = "MS")]
+    watch_debounce_ms: Option<u64>,
 }
 
 #[derive(Debug, clap::Args)]
@@ -686,6 +690,7 @@ pub(crate) fn run(args: Vec<String>) -> DynResult<()> {
                 post_deploy_override: post_deploy,
                 localnet_timeout_sec: args.localnet_timeout,
                 watch: args.watch,
+                watch_debounce_ms: args.watch_debounce_ms,
             })
         }
         Some(Commands::Report(args)) => cmd_report(args.out, args.tail),

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -385,30 +385,68 @@ fn glob_match(pattern: &str, path: &str) -> bool {
     match_segments(&pat_segs, &path_segs)
 }
 
+/// Iterative two-pointer match of pattern segments against path segments,
+/// where `**` matches zero or more whole segments and any other segment must
+/// match exactly one path segment via `segment_match`. Linear-time
+/// (O(pat·path)) with single-star backtracking — so a pattern carrying several
+/// `**` can't trigger exponential recursive blowup in the watch loop.
 fn match_segments(pat: &[&str], path: &[&str]) -> bool {
-    match pat.split_first() {
-        None => path.is_empty(),
-        Some((&"**", rest)) => {
-            // `**` matches zero or more path segments.
-            (0..=path.len()).any(|i| match_segments(rest, &path[i..]))
-        }
-        Some((seg, rest)) => {
-            !path.is_empty()
-                && segment_match(seg.as_bytes(), path[0].as_bytes())
-                && match_segments(rest, &path[1..])
+    let (mut p, mut s) = (0usize, 0usize);
+    // Position of the most recent `**` and the path index it started at.
+    let mut star: Option<usize> = None;
+    let mut star_s = 0usize;
+    while s < path.len() {
+        if p < pat.len() && pat[p] == "**" {
+            star = Some(p);
+            star_s = s;
+            p += 1;
+        } else if p < pat.len() && segment_match(pat[p].as_bytes(), path[s].as_bytes()) {
+            p += 1;
+            s += 1;
+        } else if let Some(sp) = star {
+            // Backtrack: let the last `**` swallow one more path segment.
+            p = sp + 1;
+            star_s += 1;
+            s = star_s;
+        } else {
+            return false;
         }
     }
+    // Trailing `**`s match the empty remainder.
+    while p < pat.len() && pat[p] == "**" {
+        p += 1;
+    }
+    p == pat.len()
 }
 
-/// `*` (any run within a segment) / `?` (single char) matcher. Never crosses a
-/// `/` because it only ever sees one already-split path segment.
+/// Iterative `*` (any run within a segment) / `?` (single char) matcher. Never
+/// crosses a `/` (it only ever sees one already-split path segment). Uses the
+/// same single-star-backtrack scheme so a segment with many `*`s can't trigger
+/// exponential backtracking.
 fn segment_match(pat: &[u8], seg: &[u8]) -> bool {
-    match pat.split_first() {
-        None => seg.is_empty(),
-        Some((&b'*', rest)) => (0..=seg.len()).any(|i| segment_match(rest, &seg[i..])),
-        Some((&b'?', rest)) => !seg.is_empty() && segment_match(rest, &seg[1..]),
-        Some((c, rest)) => seg.first() == Some(c) && segment_match(rest, &seg[1..]),
+    let (mut p, mut s) = (0usize, 0usize);
+    let mut star: Option<usize> = None;
+    let mut star_s = 0usize;
+    while s < seg.len() {
+        if p < pat.len() && (pat[p] == b'?' || pat[p] == seg[s]) {
+            p += 1;
+            s += 1;
+        } else if p < pat.len() && pat[p] == b'*' {
+            star = Some(p);
+            star_s = s;
+            p += 1;
+        } else if let Some(sp) = star {
+            p = sp + 1;
+            star_s += 1;
+            s = star_s;
+        } else {
+            return false;
+        }
     }
+    while p < pat.len() && pat[p] == b'*' {
+        p += 1;
+    }
+    p == pat.len()
 }
 
 fn reseed_after_wipe(project: &Project) -> DynResult<()> {
@@ -727,6 +765,22 @@ mod tests {
         // `**` also matches zero segments between fixed parts.
         assert!(glob_match("programs/**/guest/**", "programs/guest/x.rs"));
         assert!(!glob_match("programs/**/guest/**", "src/main.rs"));
+    }
+
+    #[test]
+    fn glob_handles_multiple_stars_without_blowup() {
+        // Multiple `**` across segments and multiple `*` within a segment must
+        // resolve correctly under the iterative matcher (and not hang).
+        assert!(glob_match("**/a/**/b/**", "x/a/y/z/b/c/d"));
+        assert!(!glob_match("**/a/**/b/**", "x/a/y/z/c"));
+        assert!(glob_match("src/*a*b*.rs", "src/xxaxxbxx.rs"));
+        assert!(!glob_match("src/*a*b*.rs", "src/xxbxxaxx.rs"));
+        // A long segment against many `*` should be fast (linear), not
+        // exponential — exercised here purely for correctness.
+        assert!(glob_match(
+            "**/*x*x*x*x*x*",
+            "deep/path/xxxxxxxxxxxxxxxxxxxx"
+        ));
     }
 
     #[test]

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -262,8 +262,12 @@ fn watch_loop(project: &Project, params: &PipelineParams, debounce_ms: u64) -> D
     // iteration. Without ignoring that directory, those writes fire
     // their own notify events → infinite loop. Resolve once before
     // entering the loop. Use the project-relative form so we match
-    // both canonical and non-canonical event paths.
-    let idl_rel = PathBuf::from(&project.config.framework.idl.path);
+    // both canonical and non-canonical event paths — and normalize an
+    // absolute `framework.idl.path` that points inside the project to its
+    // relative form, or the `rel.starts_with(idl_rel)` ignore check (which
+    // compares against the project-relative event path) would never match
+    // and watch mode would loop forever on IDL write-backs.
+    let idl_rel = normalize_idl_rel(&project.config.framework.idl.path, &project.root);
     let watch_ctx = WatchIgnore {
         idl_rel,
         include: project.config.run.watch.include.clone(),
@@ -303,6 +307,19 @@ fn watch_loop(project: &Project, params: &PipelineParams, debounce_ms: u64) -> D
     }
 
     Ok(())
+}
+
+/// Resolve `framework.idl.path` to the project-relative form the watch ignore
+/// check compares against. A relative config value is used as-is; an absolute
+/// value pointing inside the project root is rewritten relative to it (so the
+/// `rel.starts_with(idl_rel)` ignore matches and watch mode doesn't loop on IDL
+/// write-backs). An absolute value outside the project passes through unchanged.
+fn normalize_idl_rel(idl_path: &str, root: &Path) -> PathBuf {
+    let configured = PathBuf::from(idl_path);
+    configured
+        .strip_prefix(root)
+        .map(Path::to_path_buf)
+        .unwrap_or(configured)
 }
 
 struct WatchIgnore {
@@ -855,6 +872,27 @@ mod tests {
         assert!(!is_ignored_path(root, &ctx, &root.join("src/main.rs")));
         // ...while a path outside the include set is ignored.
         assert!(is_ignored_path(root, &ctx, &root.join("docs/readme.md")));
+    }
+
+    #[test]
+    fn normalize_idl_rel_handles_relative_and_absolute_paths() {
+        let root = Path::new("/proj");
+        // Relative config value is used as-is.
+        assert_eq!(normalize_idl_rel("idl", root), PathBuf::from("idl"));
+        // Absolute value inside the project is rewritten relative to root, so
+        // the ignore check matches the project-relative event path.
+        let ctx = WatchIgnore {
+            idl_rel: normalize_idl_rel("/proj/idl", root),
+            include: vec![],
+            exclude: vec![],
+        };
+        assert_eq!(ctx.idl_rel, PathBuf::from("idl"));
+        assert!(is_ignored_path(root, &ctx, &root.join("idl/counter.json")));
+        // Absolute value outside the project passes through unchanged.
+        assert_eq!(
+            normalize_idl_rel("/elsewhere/idl", root),
+            PathBuf::from("/elsewhere/idl")
+        );
     }
 
     fn make_test_project(root: PathBuf) -> Project {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -657,7 +657,8 @@ fn print_deploy_summary(project: &Project) -> DynResult<()> {
     // so the summary always reflects the address the wallet actually targets,
     // rather than the raw localnet.port value which may differ when
     // wallet_config.json overrides sequencer_addr (issue #161).
-    let sequencer_url = crate::commands::wallet_support::default_sequencer_http_url_for_project(project);
+    let sequencer_url =
+        crate::commands::wallet_support::default_sequencer_http_url_for_project(project);
     println!();
     println!("Sequencer: {sequencer_url}");
 
@@ -669,7 +670,8 @@ fn build_hook_command(
     hook_command: &str,
     deployed: &DeployedPrograms,
 ) -> Command {
-    let sequencer_url = crate::commands::wallet_support::default_sequencer_http_url_for_project(project);
+    let sequencer_url =
+        crate::commands::wallet_support::default_sequencer_http_url_for_project(project);
     let wallet_home = project
         .root
         .join(&project.config.wallet_home_dir)

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -42,6 +42,8 @@ pub(crate) struct RunInvocation {
     pub(crate) post_deploy_override: Option<Vec<String>>,
     pub(crate) localnet_timeout_sec: Option<u64>,
     pub(crate) watch: bool,
+    /// Per-invocation override of the `--watch` debounce window (ms).
+    pub(crate) watch_debounce_ms: Option<u64>,
 }
 
 pub(crate) fn cmd_run(inv: RunInvocation) -> DynResult<()> {
@@ -78,7 +80,13 @@ pub(crate) fn cmd_run(inv: RunInvocation) -> DynResult<()> {
             // never reset the localnet again — that would clobber the state
             // hook code is verifying.
             params.reset_override = Some(false);
-            watch_loop(&project, &params)?;
+            // CLI flag wins over `[run.watch].debounce_ms`, which wins over
+            // the built-in default.
+            let debounce_ms = inv
+                .watch_debounce_ms
+                .or(project.config.run.watch.debounce_ms)
+                .unwrap_or(WATCH_DEBOUNCE_MS);
+            watch_loop(&project, &params, debounce_ms)?;
         }
 
         Ok(())
@@ -240,7 +248,7 @@ fn reset_for_run(project: &Project, verify_timeout_sec: u64) -> DynResult<()> {
 /// `wallet.state` is byte-equivalent to a fresh `lgs setup`. Extracted as
 /// its own helper so the byte-equivalence test can drive it directly
 /// without booting a real sequencer.
-fn watch_loop(project: &Project, params: &PipelineParams) -> DynResult<()> {
+fn watch_loop(project: &Project, params: &PipelineParams, debounce_ms: u64) -> DynResult<()> {
     let (tx, rx) = mpsc::channel();
     let mut watcher = notify::recommended_watcher(move |res| {
         let _ = tx.send(res);
@@ -256,11 +264,15 @@ fn watch_loop(project: &Project, params: &PipelineParams) -> DynResult<()> {
     // entering the loop. Use the project-relative form so we match
     // both canonical and non-canonical event paths.
     let idl_rel = PathBuf::from(&project.config.framework.idl.path);
-    let watch_ctx = WatchIgnore { idl_rel };
+    let watch_ctx = WatchIgnore {
+        idl_rel,
+        include: project.config.run.watch.include.clone(),
+        exclude: project.config.run.watch.exclude.clone(),
+    };
 
     println!();
     println!(
-        "===> watching {} for changes (Ctrl-C to exit)",
+        "===> watching {} for changes (debounce {debounce_ms}ms, Ctrl-C to exit)",
         project.root.display()
     );
 
@@ -280,7 +292,7 @@ fn watch_loop(project: &Project, params: &PipelineParams) -> DynResult<()> {
             continue;
         }
         // Debounce: sleep then drain the rest of the burst.
-        std::thread::sleep(Duration::from_millis(WATCH_DEBOUNCE_MS));
+        std::thread::sleep(Duration::from_millis(debounce_ms));
         while rx.try_recv().is_ok() {}
         println!();
         println!("===> change detected, re-running pipeline");
@@ -295,6 +307,10 @@ fn watch_loop(project: &Project, params: &PipelineParams) -> DynResult<()> {
 
 struct WatchIgnore {
     idl_rel: PathBuf,
+    /// `[run.watch].include` globs. Empty → match any path.
+    include: Vec<String>,
+    /// `[run.watch].exclude` globs. Always win over `include`.
+    exclude: Vec<String>,
 }
 
 fn is_watched_event(project: &Project, ctx: &WatchIgnore, event: &notify::Event) -> bool {
@@ -324,6 +340,8 @@ fn is_ignored_path(project_root: &Path, ctx: &WatchIgnore, path: &Path) -> bool 
         // — this is a notify event from outside the watched directory.
         return true;
     };
+    // Built-in ignores always win: these guard against the IDL/deploy
+    // write-back loop and obvious noise, and are not user-overridable.
     for component in rel.components() {
         let s = component.as_os_str().to_string_lossy();
         if matches!(s.as_ref(), ".scaffold" | "target" | ".git") {
@@ -333,7 +351,64 @@ fn is_ignored_path(project_root: &Path, ctx: &WatchIgnore, path: &Path) -> bool 
     if rel.starts_with(&ctx.idl_rel) {
         return true;
     }
-    false
+
+    // User `[run.watch]` filters. A path is *ignored* when it doesn't
+    // trigger a re-run under the include/exclude resolution rules.
+    let rel_str = rel.to_string_lossy().replace('\\', "/");
+    !watch_path_triggers(&rel_str, &ctx.include, &ctx.exclude)
+}
+
+/// Apply the `[run.watch]` resolution rules to a project-relative path:
+/// triggers a re-run iff it matches at least one `include` glob (or
+/// `include` is empty) AND matches zero `exclude` globs. `exclude` wins.
+fn watch_path_triggers(rel: &str, include: &[String], exclude: &[String]) -> bool {
+    if exclude.iter().any(|g| glob_match(g, rel)) {
+        return false;
+    }
+    include.is_empty() || include.iter().any(|g| glob_match(g, rel))
+}
+
+/// Minimal gitignore-style glob match against a `/`-separated, project-relative
+/// path. `**` spans zero or more path segments; `*` and `?` match within a
+/// single segment. A pattern containing no `/` matches at any depth (so
+/// `Cargo.lock` ≡ `**/Cargo.lock`).
+fn glob_match(pattern: &str, path: &str) -> bool {
+    let anchored;
+    let pattern = if pattern.contains('/') {
+        pattern
+    } else {
+        anchored = format!("**/{pattern}");
+        &anchored
+    };
+    let pat_segs: Vec<&str> = pattern.split('/').filter(|s| !s.is_empty()).collect();
+    let path_segs: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+    match_segments(&pat_segs, &path_segs)
+}
+
+fn match_segments(pat: &[&str], path: &[&str]) -> bool {
+    match pat.split_first() {
+        None => path.is_empty(),
+        Some((&"**", rest)) => {
+            // `**` matches zero or more path segments.
+            (0..=path.len()).any(|i| match_segments(rest, &path[i..]))
+        }
+        Some((seg, rest)) => {
+            !path.is_empty()
+                && segment_match(seg.as_bytes(), path[0].as_bytes())
+                && match_segments(rest, &path[1..])
+        }
+    }
+}
+
+/// `*` (any run within a segment) / `?` (single char) matcher. Never crosses a
+/// `/` because it only ever sees one already-split path segment.
+fn segment_match(pat: &[u8], seg: &[u8]) -> bool {
+    match pat.split_first() {
+        None => seg.is_empty(),
+        Some((&b'*', rest)) => (0..=seg.len()).any(|i| segment_match(rest, &seg[i..])),
+        Some((&b'?', rest)) => !seg.is_empty() && segment_match(rest, &seg[1..]),
+        Some((c, rest)) => seg.first() == Some(c) && segment_match(rest, &seg[1..]),
+    }
 }
 
 fn reseed_after_wipe(project: &Project) -> DynResult<()> {
@@ -642,6 +717,86 @@ mod tests {
         Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig, Project, RepoRef, RunConfig,
     };
     use std::path::PathBuf;
+
+    #[test]
+    fn glob_double_star_spans_segments() {
+        assert!(glob_match(
+            "programs/**/guest/**",
+            "programs/lez-htlc/methods/guest/src/lib.rs"
+        ));
+        // `**` also matches zero segments between fixed parts.
+        assert!(glob_match("programs/**/guest/**", "programs/guest/x.rs"));
+        assert!(!glob_match("programs/**/guest/**", "src/main.rs"));
+    }
+
+    #[test]
+    fn glob_single_star_stays_within_a_segment() {
+        assert!(glob_match("**/*.md", "docs/readme.md"));
+        assert!(glob_match("**/*.md", "readme.md"));
+        // `*` must not cross a `/`: `*.sol` can't match a nested path here.
+        assert!(!glob_match("contracts/*.sol", "contracts/sub/a.sol"));
+        assert!(glob_match("contracts/*.sol", "contracts/a.sol"));
+    }
+
+    #[test]
+    fn glob_slashless_pattern_matches_at_any_depth() {
+        assert!(glob_match("Cargo.lock", "Cargo.lock"));
+        assert!(glob_match("Cargo.lock", "crates/foo/Cargo.lock"));
+        assert!(!glob_match("Cargo.lock", "Cargo.toml"));
+    }
+
+    #[test]
+    fn glob_question_mark_matches_one_char() {
+        assert!(glob_match("src/a?.rs", "src/ab.rs"));
+        assert!(!glob_match("src/a?.rs", "src/abc.rs"));
+    }
+
+    #[test]
+    fn watch_resolution_exclude_wins_over_include() {
+        let include = vec!["programs/**".to_string()];
+        let exclude = vec!["**/*.md".to_string()];
+        // matches include, not excluded → triggers
+        assert!(watch_path_triggers(
+            "programs/htlc/guest/lib.rs",
+            &include,
+            &exclude
+        ));
+        // matches include AND exclude → excluded wins, no trigger
+        assert!(!watch_path_triggers(
+            "programs/htlc/README.md",
+            &include,
+            &exclude
+        ));
+        // outside include set → no trigger
+        assert!(!watch_path_triggers("src/main.rs", &include, &exclude));
+    }
+
+    #[test]
+    fn watch_resolution_empty_include_means_any_path() {
+        let exclude = vec!["**/target/**".to_string()];
+        assert!(watch_path_triggers("src/main.rs", &[], &exclude));
+        assert!(!watch_path_triggers("a/target/debug/x", &[], &exclude));
+        // No filters at all → everything triggers (default behaviour).
+        assert!(watch_path_triggers("anything/at/all.rs", &[], &[]));
+    }
+
+    #[test]
+    fn is_ignored_path_keeps_builtin_ignores_with_filters() {
+        let ctx = WatchIgnore {
+            idl_rel: PathBuf::from("idl"),
+            include: vec!["src/**".to_string()],
+            exclude: vec![],
+        };
+        let root = Path::new("/proj");
+        // Built-in ignores apply even though they'd match neither filter.
+        assert!(is_ignored_path(root, &ctx, &root.join("target/debug/x")));
+        assert!(is_ignored_path(root, &ctx, &root.join(".scaffold/state/x")));
+        assert!(is_ignored_path(root, &ctx, &root.join("idl/counter.json")));
+        // An included source path is watched (not ignored)...
+        assert!(!is_ignored_path(root, &ctx, &root.join("src/main.rs")));
+        // ...while a path outside the include set is ignored.
+        assert!(is_ignored_path(root, &ctx, &root.join("docs/readme.md")));
+    }
 
     fn make_test_project(root: PathBuf) -> Project {
         Project {

--- a/src/config.rs
+++ b/src/config.rs
@@ -181,6 +181,12 @@ fn parse_glob_list(item: Option<&Item>, key: &str) -> DynResult<Vec<String>> {
         let s = v
             .as_str()
             .ok_or_else(|| anyhow!("invalid scaffold.toml: [{key}] entries must be strings"))?;
+        // Reject empty patterns: an empty glob normalizes to a match-all
+        // (`**/`), so an empty `exclude` entry would silently suppress *every*
+        // watch trigger. Fail fast with a targeted error instead.
+        if s.is_empty() {
+            bail!("invalid scaffold.toml: [{key}] entries must not be empty");
+        }
         out.push(s.to_string());
     }
     Ok(out)
@@ -1098,6 +1104,15 @@ role = "project"
             vec!["**/*.md".to_string(), "Cargo.lock".to_string()]
         );
         assert_eq!(cfg.run.watch.debounce_ms, Some(1500));
+    }
+
+    #[test]
+    fn parse_config_run_watch_rejects_empty_glob() {
+        // An empty pattern normalizes to match-all; an empty `exclude` would
+        // silently suppress every watch trigger, so it's rejected at parse.
+        let toml = minimal_v0_2_0() + "[run.watch]\nexclude = [\"\"]\n";
+        let err = parse_config(&toml).unwrap_err();
+        assert!(err.to_string().contains("must not be empty"), "{err}");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,7 +29,7 @@ use crate::constants::{
 };
 use crate::model::{
     BasecampConfig, Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig, ModuleEntry,
-    ModuleRole, RepoBuild, RepoRef, RunConfig, RunProfile,
+    ModuleRole, RepoBuild, RepoRef, RunConfig, RunProfile, WatchConfig,
 };
 use crate::DynResult;
 
@@ -131,6 +131,8 @@ fn parse_run(doc: &DocumentMut) -> DynResult<RunConfig> {
         }
     }
 
+    let watch = parse_run_watch(run_table)?;
+
     Ok(RunConfig {
         default_profile,
         inline: RunProfile {
@@ -138,7 +140,50 @@ fn parse_run(doc: &DocumentMut) -> DynResult<RunConfig> {
             post_deploy: inline_post_deploy,
         },
         profiles,
+        watch,
     })
+}
+
+fn parse_run_watch(run_table: &Table) -> DynResult<WatchConfig> {
+    let Some(watch_table) = run_table.get("watch").and_then(Item::as_table) else {
+        return Ok(WatchConfig::default());
+    };
+    let include = parse_glob_list(watch_table.get("include"), "run.watch.include")?;
+    let exclude = parse_glob_list(watch_table.get("exclude"), "run.watch.exclude")?;
+    let debounce_ms = match watch_table.get("debounce_ms") {
+        None => None,
+        Some(item) => {
+            let n = item.as_integer().ok_or_else(|| {
+                anyhow!("invalid scaffold.toml: [run.watch].debounce_ms must be an integer")
+            })?;
+            if n < 0 {
+                bail!("invalid scaffold.toml: [run.watch].debounce_ms must be non-negative");
+            }
+            Some(n as u64)
+        }
+    };
+    Ok(WatchConfig {
+        include,
+        exclude,
+        debounce_ms,
+    })
+}
+
+fn parse_glob_list(item: Option<&Item>, key: &str) -> DynResult<Vec<String>> {
+    let Some(item) = item else {
+        return Ok(Vec::new());
+    };
+    let arr = item
+        .as_array()
+        .ok_or_else(|| anyhow!("invalid scaffold.toml: [{key}] must be an array of strings"))?;
+    let mut out = Vec::with_capacity(arr.len());
+    for v in arr.iter() {
+        let s = v
+            .as_str()
+            .ok_or_else(|| anyhow!("invalid scaffold.toml: [{key}] entries must be strings"))?;
+        out.push(s.to_string());
+    }
+    Ok(out)
 }
 
 fn parse_post_deploy(item: Option<&Item>) -> DynResult<Vec<String>> {
@@ -525,7 +570,8 @@ fn write_run_config(doc: &mut DocumentMut, run: &RunConfig) -> DynResult<()> {
     let has_inline = run.inline.reset || !run.inline.post_deploy.is_empty();
     let has_default_profile = run.default_profile.is_some();
     let has_profiles = !run.profiles.is_empty();
-    if !has_inline && !has_default_profile && !has_profiles {
+    let has_watch = run.watch != WatchConfig::default();
+    if !has_inline && !has_default_profile && !has_profiles && !has_watch {
         return Ok(());
     }
 
@@ -568,7 +614,31 @@ fn write_run_config(doc: &mut DocumentMut, run: &RunConfig) -> DynResult<()> {
             }
         }
     }
+
+    if has_watch {
+        for g in run.watch.include.iter().chain(run.watch.exclude.iter()) {
+            check_toml_value("run.watch", g)?;
+        }
+        let watch_table = ensure_subtable(doc, "run", "watch");
+        if !run.watch.include.is_empty() {
+            watch_table["include"] = string_array(&run.watch.include);
+        }
+        if !run.watch.exclude.is_empty() {
+            watch_table["exclude"] = string_array(&run.watch.exclude);
+        }
+        if let Some(ms) = run.watch.debounce_ms {
+            watch_table["debounce_ms"] = value(ms as i64);
+        }
+    }
     Ok(())
+}
+
+fn string_array(items: &[String]) -> Item {
+    let mut arr = toml_edit::Array::new();
+    for it in items {
+        arr.push(it.as_str());
+    }
+    value(arr)
 }
 
 fn post_deploy_value(hooks: &[String]) -> Item {
@@ -1012,6 +1082,41 @@ role = "project"
         let prof = cfg.run.profiles.get("e2e").expect("e2e present");
         assert!(prof.reset);
         assert_eq!(prof.post_deploy, vec!["scripts/e2e.sh".to_string()]);
+    }
+
+    #[test]
+    fn parse_config_with_run_watch_section() {
+        let toml = minimal_v0_2_0()
+            + "[run.watch]\ninclude = [\"programs/**/guest/**\"]\nexclude = [\"**/*.md\", \"Cargo.lock\"]\ndebounce_ms = 1500\n";
+        let cfg = parse_config(&toml).expect("parse");
+        assert_eq!(
+            cfg.run.watch.include,
+            vec!["programs/**/guest/**".to_string()]
+        );
+        assert_eq!(
+            cfg.run.watch.exclude,
+            vec!["**/*.md".to_string(), "Cargo.lock".to_string()]
+        );
+        assert_eq!(cfg.run.watch.debounce_ms, Some(1500));
+    }
+
+    #[test]
+    fn parse_config_run_watch_rejects_negative_debounce() {
+        let toml = minimal_v0_2_0() + "[run.watch]\ndebounce_ms = -5\n";
+        let err = parse_config(&toml).unwrap_err();
+        assert!(err.to_string().contains("debounce_ms"), "{err}");
+    }
+
+    #[test]
+    fn run_watch_round_trips_through_parse_serialize() {
+        let toml = minimal_v0_2_0()
+            + "[run.watch]\ninclude = [\"src/**\"]\nexclude = [\"**/target/**\"]\ndebounce_ms = 750\n";
+        let cfg1 = parse_config(&toml).expect("parse");
+        let serialized = serialize_config(&cfg1).expect("serialize");
+        let cfg2 = parse_config(&serialized).expect("re-parse");
+        assert_eq!(cfg2.run.watch.include, vec!["src/**".to_string()]);
+        assert_eq!(cfg2.run.watch.exclude, vec!["**/target/**".to_string()]);
+        assert_eq!(cfg2.run.watch.debounce_ms, Some(750));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -148,8 +148,8 @@ fn parse_run_watch(run_table: &Table) -> DynResult<WatchConfig> {
     let Some(watch_table) = run_table.get("watch").and_then(Item::as_table) else {
         return Ok(WatchConfig::default());
     };
-    let include = parse_glob_list(watch_table.get("include"), "run.watch.include")?;
-    let exclude = parse_glob_list(watch_table.get("exclude"), "run.watch.exclude")?;
+    let include = parse_glob_list(watch_table.get("include"), "[run.watch].include")?;
+    let exclude = parse_glob_list(watch_table.get("exclude"), "[run.watch].exclude")?;
     let debounce_ms = match watch_table.get("debounce_ms") {
         None => None,
         Some(item) => {
@@ -169,23 +169,26 @@ fn parse_run_watch(run_table: &Table) -> DynResult<WatchConfig> {
     })
 }
 
+/// `key` is the field label already formatted as `[table].field` (e.g.
+/// `[run.watch].include`), so error messages point at the actual key instead of
+/// a `[run.watch.include]`-looking pseudo-table.
 fn parse_glob_list(item: Option<&Item>, key: &str) -> DynResult<Vec<String>> {
     let Some(item) = item else {
         return Ok(Vec::new());
     };
     let arr = item
         .as_array()
-        .ok_or_else(|| anyhow!("invalid scaffold.toml: [{key}] must be an array of strings"))?;
+        .ok_or_else(|| anyhow!("invalid scaffold.toml: {key} must be an array of strings"))?;
     let mut out = Vec::with_capacity(arr.len());
     for v in arr.iter() {
         let s = v
             .as_str()
-            .ok_or_else(|| anyhow!("invalid scaffold.toml: [{key}] entries must be strings"))?;
+            .ok_or_else(|| anyhow!("invalid scaffold.toml: {key} entries must be strings"))?;
         // Reject empty patterns: an empty glob normalizes to a match-all
         // (`**/`), so an empty `exclude` entry would silently suppress *every*
         // watch trigger. Fail fast with a targeted error instead.
         if s.is_empty() {
-            bail!("invalid scaffold.toml: [{key}] entries must not be empty");
+            bail!("invalid scaffold.toml: {key} entries must not be empty");
         }
         out.push(s.to_string());
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -284,6 +284,27 @@ pub(crate) struct RunConfig {
     pub(crate) inline: RunProfile,
     /// Named profiles parsed from `[run.profiles.<name>]` sub-sections.
     pub(crate) profiles: std::collections::BTreeMap<String, RunProfile>,
+    /// `[run.watch]` — filters and debounce for `lgs run --watch`.
+    pub(crate) watch: WatchConfig,
+}
+
+/// `[run.watch]` — controls which filesystem changes trigger a `--watch`
+/// re-run, and how long to coalesce a burst of saves.
+///
+/// Resolution for a changed path: it triggers a re-run iff it matches at
+/// least one `include` glob (or `include` is empty, meaning "any path") AND
+/// matches zero `exclude` globs. `exclude` always wins. Globs are
+/// project-relative, gitignore-style (`**` spans path segments, `*`/`?`
+/// match within a segment; a slash-less pattern matches at any depth).
+/// Built-in ignores (`.scaffold`, `target`, `.git`, the IDL output dir)
+/// always apply regardless of these filters.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct WatchConfig {
+    pub(crate) include: Vec<String>,
+    pub(crate) exclude: Vec<String>,
+    /// Debounce window in milliseconds. `None` → built-in default (500ms).
+    /// Overridden per-invocation by `--watch-debounce-ms`.
+    pub(crate) debounce_ms: Option<u64>,
 }
 
 impl RunConfig {


### PR DESCRIPTION
### Problem / Description
`lgs run --watch` re-runs the full pipeline on any filesystem change with a fixed 500ms debounce. On a real project a hot orchestrator-side edit (or a `README.md` save) triggers a full re-deploy, and there's no way to scope what's watched or tune the coalescing window.

### Solution
Two additions, both opt-in (default `--watch` behaviour is unchanged when `[run.watch]` is absent):

**`[run.watch]` glob filters**
```toml
[run.watch]
include = ["programs/**/guest/**", "contracts/**/*.sol"]
exclude = ["**/*.md", "Cargo.lock"]
debounce_ms = 1500
```
A changed path triggers a re-run **iff** it matches at least one `include` glob (or `include` is unset → "any path") **and** matches zero `exclude` globs — `exclude` always wins. Globs are project-relative, gitignore-style: `**` spans path segments, `*`/`?` match within a segment, and a slash-less pattern (`Cargo.lock`) matches at any depth. The built-in ignores (`.scaffold`, `target`, `.git`, the IDL output dir) still always apply regardless of these filters.

**`--watch-debounce-ms <MS>`** overrides the debounce per invocation; `[run.watch].debounce_ms` persists it project-wide. Resolution: CLI flag > config > 500ms default.

### Implementation notes
- The glob matcher is dependency-free (a small recursive segment matcher) to keep the published crate's dependency tree minimal.
- `[run.watch]` parses, validates (`debounce_ms` must be a non-negative integer), and round-trips through serialize so config rewrites preserve it.

### Acceptance mapping
- `[run.watch]` schema with `include` / `exclude` / `debounce_ms` ✔
- `--watch-debounce-ms` flag ✔
- resolution rules documented (README + `WatchConfig` doc comment + `--help`) ✔
- default behaviour unchanged when `[run.watch]` absent ✔

### Tests
10 unit tests: glob `**`/`*`/`?`/slash-less semantics, the include/exclude/exclude-wins resolution, built-in ignores layered with filters, `[run.watch]` parse + negative-debounce rejection + parse/serialize round-trip. The watch loop itself (filesystem events) isn't integration-tested — the testable filter/debounce decisions are unit-tested directly.

Closes #175.