### PR TITLE
fix(basecamp): set per-profile `TMPDIR` on launch to prevent cross-profile SIGSEGV

### DIFF
--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -386,6 +386,18 @@ fn launch_env(profile_dir: &Path, profile_name: &str) -> BTreeMap<String, OsStri
         "XDG_CACHE_HOME".into(),
         profile_dir.join("xdg-cache").into_os_string(),
     );
+    // Per-profile TMPDIR (#89): liblogos_core binds each `logos_host`'s
+    // QLocalServer socket at a hardcoded `logos_token_<module>` name under
+    // `QStandardPaths::TempLocation` (== TMPDIR, else /tmp). Without a
+    // per-profile TMPDIR, concurrent `launch alice` / `launch bob` collide on
+    // `/tmp/logos_token_<module>`; the second bind unlinks the first, and the
+    // first profile's Qt RemoteObjects replica then derefs a dangling
+    // QMetaObject on its next socket read → SIGSEGV. A distinct temp root per
+    // profile removes the race without any upstream change.
+    env.insert(
+        "TMPDIR".into(),
+        profile_dir.join("xdg-tmp").into_os_string(),
+    );
     env.insert("LOGOS_PROFILE".into(), profile_name.into());
     env
 }
@@ -2679,6 +2691,13 @@ fn seed_profiles(profiles_root: &Path, names: &[&str]) -> DynResult<Vec<String>>
             fs::create_dir_all(&path)
                 .with_context(|| format!("create profile dir {}", path.display()))?;
         }
+        // Per-profile temp root for the launch-time `TMPDIR` export (#89).
+        // Flat — no BASECAMP_XDG_APP_SUBPATH suffix: Qt's
+        // `QLocalServer::listen("logos_token_…")` writes a socket file
+        // directly under the temp root.
+        let tmp_dir = profile_dir.join("xdg-tmp");
+        fs::create_dir_all(&tmp_dir)
+            .with_context(|| format!("create profile dir {}", tmp_dir.display()))?;
         seeded.push(name.to_string());
     }
     Ok(seeded)
@@ -3058,6 +3077,9 @@ mod tests {
                 let dir = root.join(name).join(xdg).join(BASECAMP_XDG_APP_SUBPATH);
                 assert!(dir.is_dir(), "expected XDG subdir at {}", dir.display());
             }
+            // #89: per-profile temp root, created flat (no app subpath).
+            let tmp = root.join(name).join("xdg-tmp");
+            assert!(tmp.is_dir(), "expected temp dir at {}", tmp.display());
         }
     }
 
@@ -3077,7 +3099,22 @@ mod tests {
             env.get("XDG_CACHE_HOME").unwrap(),
             &OsString::from("/p/alice/xdg-cache")
         );
+        // #89: per-profile TMPDIR prevents the cross-profile QLocalServer
+        // socket-name collision that SIGSEGVs Qt RemoteObjects.
+        assert_eq!(
+            env.get("TMPDIR").unwrap(),
+            &OsString::from("/p/alice/xdg-tmp")
+        );
         assert_eq!(env.get("LOGOS_PROFILE").unwrap(), &OsString::from("alice"));
+    }
+
+    #[test]
+    fn launch_env_tmpdir_is_distinct_per_profile() {
+        // The whole point of #89: alice and bob must not share a temp root,
+        // or their `logos_token_<module>` sockets collide.
+        let alice = launch_env(Path::new("/p/alice"), "alice");
+        let bob = launch_env(Path::new("/p/bob"), "bob");
+        assert_ne!(alice.get("TMPDIR"), bob.get("TMPDIR"));
     }
 
     #[test]

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -544,7 +544,8 @@ fn print_deploy_summary(project: &Project) -> DynResult<()> {
     // so the summary always reflects the address the wallet actually targets,
     // rather than the raw localnet.port value which may differ when
     // wallet_config.json overrides sequencer_addr (issue #161).
-    let sequencer_url = crate::commands::wallet_support::default_sequencer_http_url_for_project(project);
+    let sequencer_url =
+        crate::commands::wallet_support::default_sequencer_http_url_for_project(project);
     println!();
     println!("Sequencer: {sequencer_url}");
 
@@ -556,7 +557,8 @@ fn build_hook_command(
     hook_command: &str,
     deployed: &DeployedPrograms,
 ) -> Command {
-    let sequencer_url = crate::commands::wallet_support::default_sequencer_http_url_for_project(project);
+    let sequencer_url =
+        crate::commands::wallet_support::default_sequencer_http_url_for_project(project);
     let wallet_home = project
         .root
         .join(&project.config.wallet_home_dir)


### PR DESCRIPTION
### Problem / Description
Running `lgs basecamp launch alice` and `launch bob` concurrently on the same host crashes one or both basecamp processes with `SIGSEGV` inside Qt RemoteObjects' `onClientRead`. Root cause: `liblogos_core` binds each `logos_host`'s `QLocalServer` socket at a hardcoded `logos_token_<module>` name resolved through `QStandardPaths::TempLocation` (== `TMPDIR`, else `/tmp`). `launch` exports per-profile `XDG_CONFIG/DATA/CACHE_HOME` but **not** `TMPDIR`, so both profiles bind `/tmp/logos_token_<module>`; the second bind unlinks the first, and the first profile's replica then derefs a dangling `QMetaObject` on its next socket read.

This violates scaffold's FURPS §B3 non-collision contract for things it controls via env.

### Solution
- `launch_env`: export `TMPDIR=<profile>/xdg-tmp`.
- `seed_profiles`: create `<profile>/xdg-tmp` (flat — no `BASECAMP_XDG_APP_SUBPATH` suffix, since Qt writes the socket file directly under the temp root).

Each profile now binds a distinct socket path, removing the race without any upstream basecamp/Qt change. (The upstream replica-derefs-after-peer-disconnect bug still belongs in basecamp/Qt; this fixes the part scaffold owns.)

### Tests
- `launch_env` test extended to assert `TMPDIR == <profile>/xdg-tmp`, plus a new test asserting alice/bob get distinct temp roots.
- `seed_profiles` test extended to assert `xdg-tmp` is created per profile.

The concurrent-launch SIGSEGV repro requires the basecamp Qt binary + two profiles loading a shared module (not reproducible headlessly in CI); the fix is the env/dir change verified by the unit tests above, exactly as proposed in the issue.

Closes #89.