### PR TITLE
fix(templates): sign the hello_world claiming transaction (#70)

### DIFF
--- a/templates/default/src/bin/run_hello_world.rs
+++ b/templates/default/src/bin/run_hello_world.rs
@@ -1,4 +1,4 @@
-use anyhow::Context;
+use anyhow::{Context, anyhow};
 use clap::Parser;
 use example_program_deployment_methods::HELLO_WORLD_ELF;
 use nssa::{
@@ -27,10 +27,26 @@ async fn main() -> anyhow::Result<()> {
     let program = load_program(cli.program_path.as_deref(), HELLO_WORLD_ELF, "hello_world")?;
     let account_id = parse_account_id(&cli.account_id)?;
 
+    // The hello_world program claims an uninitialized input account with
+    // `Claim::Authorized`, so the first transaction against a fresh account
+    // must be authorized by that account's key. Submitting it unsigned (empty
+    // witness set / nonces) makes the sequencer reject the claim with
+    // `InvalidProgramBehaviour`. Sign with the account's own signing key and
+    // its current nonce, the same way the authorized example does.
+    let signing_key = wallet_core
+        .storage()
+        .user_data
+        .get_pub_account_signing_key(account_id)
+        .ok_or_else(|| anyhow!("input account must be a self-owned public account"))?;
+
     let greeting: Vec<u8> = vec![72, 111, 108, 97, 32, 109, 117, 110, 100, 111, 33];
-    let message = Message::try_new(program.id(), vec![account_id], vec![], greeting)
+    let nonces = wallet_core
+        .get_accounts_nonces(vec![account_id])
+        .await
+        .context("failed to query account nonce from sequencer")?;
+    let message = Message::try_new(program.id(), vec![account_id], nonces, greeting)
         .context("failed to build hello_world transaction message")?;
-    let witness_set = WitnessSet::for_message(&message, &[]);
+    let witness_set = WitnessSet::for_message(&message, &[signing_key]);
     let tx = PublicTransaction::new(message, witness_set);
 
     let response = wallet_core


### PR DESCRIPTION
### Problem / Description
The first `run_hello_world` against a fresh account fails — the sequencer rejects the transaction with `InvalidProgramBehaviour`. Root cause confirmed from the guest source: `hello_world` claims an uninitialized input account with

```rust
AccountPostState::new_claimed_if_default(post_account, Claim::Authorized)
```

`Claim::Authorized` means the claim must be authorized by that account's key. But `run_hello_world.rs` built the transaction with an **empty** witness set and **empty** nonces:

```rust
let message = Message::try_new(program.id(), vec![account_id], vec![], greeting)?;
let witness_set = WitnessSet::for_message(&message, &[]);
```

so the claim is unauthorized and the sequencer rejects it.

### Solution
Sign the transaction with the account's own signing key and its current nonce — the same way the already-working `run_hello_world_with_authorization` example does against this exact LEZ pin:

```rust
let signing_key = wallet_core.storage().user_data
    .get_pub_account_signing_key(account_id)
    .ok_or_else(|| anyhow!("input account must be a self-owned public account"))?;
let nonces = wallet_core.get_accounts_nonces(vec![account_id]).await?;
let message = Message::try_new(program.id(), vec![account_id], nonces, greeting)?;
let witness_set = WitnessSet::for_message(&message, &[signing_key]);
```

### Verification
- **Root cause** verified by reading the `hello_world` guest (`Claim::Authorized` on the default-account claim) — it's exactly the reporter's `InvalidProgramBehaviour` symptom.
- The fix is byte-for-byte the signing pattern of the working `run_hello_world_with_authorization` runner, which compiles and runs against the pinned LEZ commit.
- scaffold's full test suite stays green (the template render-fidelity test compares rendered output to the template source).

A full deploy+run dogfood was attempted: I built the entire standalone LEZ stack (sequencer + wallet + spel) from the pinned commits in this environment, but building the **guest** ELF needs the risc0 Rust toolchain via `rzup`, whose downloads are blocked by this sandbox's TLS-intercepting proxy (every rustls-based client rejects the proxy CA; `r0vm`, needed for execution, hits the same wall). That's an environment/infra limit, not a code issue — the fix above is verified by source analysis and the working analog.

### Scope
The basic public `run_hello_world` runner only (the reporter's repro). The tail-call / PDA / private variants use different authorization models and are intentionally left for separate assessment.

Closes #70.