### PR TITLE
fix(setup): always use sha2 for SHA256 verification in prebuilt download

### DIFF
--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write;
 use std::path::Path;
 use std::process::Command;
 
@@ -343,26 +344,11 @@ fn try_download_prebuilt(lez: &Path, pin: &str) -> crate::DynResult<bool> {
 }
 
 fn sha256_hex(data: &[u8]) -> String {
-    // Simple SHA256 using the sha2 crate via workspace dependency
-    // Falls back gracefully if not available
-    #[cfg(feature = "sha2")]
-    {
-        use sha2::{Digest, Sha256};
-        let hash = Sha256::digest(data);
-        let mut s = String::new();
-        for byte in hash {
-            write!(s, "{byte:02x}").unwrap();
-        }
-        s
+    use sha2::{Digest, Sha256};
+    let hash = Sha256::digest(data);
+    let mut s = String::new();
+    for byte in hash {
+        write!(s, "{byte:02x}").unwrap();
     }
-    #[cfg(not(feature = "sha2"))]
-    {
-        // Without sha2, compute a simple checksum for basic integrity
-        let mut h: u64 = 0xcbf29ce484222325;
-        for &b in data {
-            h ^= b as u64;
-            h = h.wrapping_mul(0x100000001b3);
-        }
-        format!("{h:016x}")
-    }
+    s
 }


### PR DESCRIPTION
## Problem

`sha256_hex()` introduced in #85 uses `#[cfg(feature = "sha2")]` to
conditionally compile the real SHA256 path. However `sha2` is a direct
dependency in `Cargo.toml`, not a cargo feature so the `cfg` gate is
never true and the code always falls through to the FNV-1a fallback.

FNV-1a produces a 16-character hex string which can never match a real
SHA256 checksum. The integrity check in `try_download_prebuilt()` silently
passes without ever verifying the binary.

## Fix

Remove the dead `cfg(feature = "sha2")` / `cfg(not(...))` gates and call
`sha2::Sha256` directly. Also add the missing `use std::fmt::Write` import
required by `write!()`.

## Test

All 6 existing setup tests pass. The sha2 code path now compiles and
executes on every build.