### PR TITLE
refactor: remove AI-generated slop across modules

### DIFF
--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -28,7 +28,6 @@ use crate::state::{read_basecamp_state, write_basecamp_state};
 use crate::DynResult;
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // Fields wired up in later phases
 pub(crate) enum BasecampAction {
     Setup,
     Modules {
@@ -1084,14 +1083,7 @@ fn run_build_portable_nix(
 ) -> DynResult<Vec<PathBuf>> {
     println!("building {flake_ref}");
     let mut cmd = Command::new("nix");
-    match &inv.cwd_override {
-        Some(cwd) => {
-            cmd.current_dir(cwd);
-        }
-        None => {
-            cmd.current_dir(project_root);
-        }
-    }
+    cmd.current_dir(inv.cwd_override.as_deref().unwrap_or(project_root));
     for a in &inv.args {
         cmd.arg(a);
     }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -134,15 +134,15 @@ fn run_pipeline_once(project: &Project, params: &PipelineParams) -> DynResult<()
         }
     }
 
-    // Step 1: Build (chains setup internally)
+    // Build (chains setup internally)
     println!("[1/{total_steps}] Building...");
     cmd_build_shortcut(None, false)?;
 
-    // Step 2: Build IDL (no-op for non-lez-framework projects)
+    // Build IDL (no-op for non-lez-framework projects)
     println!("[2/{total_steps}] Building IDL...");
     build_idl_for_current_project()?;
 
-    // Step 3: Reset OR ensure localnet.
+    // Reset OR ensure localnet.
     if effective_reset {
         println!("[3/{total_steps}] Resetting localnet (wipes sequencer + wallet)...");
         reset_for_run(project, params.localnet_timeout_sec)?;
@@ -164,7 +164,7 @@ fn run_pipeline_once(project: &Project, params: &PipelineParams) -> DynResult<()
         ensure_localnet(project, params.localnet_timeout_sec)?;
     }
 
-    // Step 4: Wallet topup
+    // Wallet topup
     println!("[4/{total_steps}] Topping up wallet...");
     let outcome = cmd_wallet_topup_inner(project, None, false, false)?;
     if let TopupOutcome::ConfirmationTimeout { message } = outcome {
@@ -175,7 +175,7 @@ fn run_pipeline_once(project: &Project, params: &PipelineParams) -> DynResult<()
         );
     }
 
-    // Step 5: Deploy (idempotent: skip when guest .bin + IDL + deploy
+    // Deploy (idempotent: skip when guest .bin + IDL + deploy
     // config hashes match the prior deploy AND the sequencer is the same
     // instance that received it. A `lgs localnet stop && start` cycle
     // changes the sequencer PID and wipes on-chain state, so PID equality
@@ -211,7 +211,7 @@ fn run_pipeline_once(project: &Project, params: &PipelineParams) -> DynResult<()
     // here so the per-hook loop doesn't multiply latency by hook count.
     let deployed = collect_deployed_programs(project, deploy_skipped)?;
 
-    // Step 6: Post-deploy hooks (or summary)
+    // Post-deploy hooks (or summary)
     if has_hooks {
         let n = params.hooks.len();
         println!("[6/{total_steps}] Running {n} post-deploy hook(s)...");

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -376,26 +376,12 @@ fn try_download_prebuilt(lez: &Path, pin: &str) -> crate::DynResult<bool> {
 }
 
 fn sha256_hex(data: &[u8]) -> String {
-    // Simple SHA256 using the sha2 crate via workspace dependency
-    // Falls back gracefully if not available
-    #[cfg(feature = "sha2")]
-    {
-        use sha2::{Digest, Sha256};
-        let hash = Sha256::digest(data);
-        let mut s = String::new();
-        for byte in hash {
-            write!(s, "{byte:02x}").unwrap();
-        }
-        s
+    use sha2::{Digest, Sha256};
+    use std::fmt::Write;
+    let hash = Sha256::digest(data);
+    let mut s = String::with_capacity(hash.len() * 2);
+    for byte in hash {
+        let _ = write!(s, "{byte:02x}");
     }
-    #[cfg(not(feature = "sha2"))]
-    {
-        // Without sha2, compute a simple checksum for basic integrity
-        let mut h: u64 = 0xcbf29ce484222325;
-        for &b in data {
-            h ^= b as u64;
-            h = h.wrapping_mul(0x100000001b3);
-        }
-        format!("{h:016x}")
-    }
+    s
 }

--- a/src/commands/wallet_support.rs
+++ b/src/commands/wallet_support.rs
@@ -68,7 +68,7 @@ fn read_wallet_config(wallet_home: &Path) -> DynResult<(PathBuf, Value)> {
         // Legacy: older `setup` runs wrote "config.json" instead of
         // "wallet_config.json". Re-run `logos-scaffold setup` to migrate.
         eprintln!(
-            "warning: found legacy wallet config '{}';              re-run `logos-scaffold setup` to migrate to '{}'.",
+            "warning: found legacy wallet config '{}'; re-run `logos-scaffold setup` to migrate to '{}'.",
             WALLET_CONFIG_FALLBACK,
             WALLET_CONFIG_PRIMARY,
         );

--- a/src/config.rs
+++ b/src/config.rs
@@ -611,12 +611,9 @@ pub(crate) fn serialize_config(cfg: &Config) -> DynResult<String> {
             ModuleRole::Project => "project",
             ModuleRole::Dependency => "dependency",
         };
-        let path = format!("modules.{name}");
         let table = ensure_subtable(&mut doc, "modules", name);
         table["flake"] = value(&entry.flake);
         table["role"] = value(role_str);
-        // Defensive: the function's check above already covered both fields.
-        let _ = path;
     }
 
     // [wallet]


### PR DESCRIPTION
## What

A module-by-module sweep of this Rust CLI to remove AI-generated slop. All edits are minimal and behavior-preserving, **except one real bug fix** (`setup.rs`). Verified with `cargo check` (clean, no warnings) and `cargo test --no-run` (all targets compile).

### Bug fix
- **`src/commands/setup.rs` — `sha256_hex` never computed SHA-256.** `sha2` is a plain, non-optional dependency and the crate has **no `[features]` table**, so `#[cfg(feature = "sha2")]` was *always false* and the FNV-1a fallback was what compiled. The function returned a 16-char non-SHA digest, so prebuilt `sequencer_service` verification (`setup.rs:348`) compared it against a published 64-char `.sha256` and **always mismatched → `bail!`**, silently breaking the `--prebuilt` path whenever a checksum file existed. Now uses `sha2` unconditionally, matching the project's existing hex-encode idiom (`run_state.rs::hex_encode`).

### Slop cleanup (no behavior change)
- **`src/config.rs`** — removed a dead `let path = format!("modules.{name}");` binding that was only consumed by `let _ = path;` (plus its "Defensive:" comment).
- **`src/commands/basecamp.rs`** — removed `#[allow(dead_code)] // Fields wired up in later phases` on `BasecampAction` (all variants are constructed; compiles clean without it); collapsed a verbose two-arm `cwd_override` match into `as_deref().unwrap_or(project_root)`, matching the idiom the file's own tests already use.
- **`src/commands/run.rs`** — stripped redundant `// Step N:` comment prefixes that just duplicate the user-facing `[N/total_steps]` progress prints; all explanatory text preserved.
- **`src/commands/wallet_support.rs`** — collapsed a stray run of spaces in the legacy wallet-config warning string.

## Notes on what was *not* changed
The codebase is otherwise well-maintained. Several flagged "redundant" defensive checks (e.g. `.exists()` after a non-empty-path guard in `basecamp.rs`) were verified to be **legitimate** — a non-empty path string doesn't guarantee the binary is on disk — and were intentionally left as-is. Idiomatic nested `if let` optional-chaining (no let-chains on rustc 1.81) and the well-documented non-cryptographic `fnv1a_64` helper were also left untouched.

https://claude.ai/code/session_01KutAyMX3auZUKhuHHp5xXq
