### PR TITLE
fix(run): skip IDL build for non-lez-framework projects

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -20,7 +20,9 @@ use crate::commands::run_state::{
 };
 use crate::commands::setup::ensure_default_wallet_seeded;
 use crate::commands::wallet::{cmd_wallet_topup_inner, TopupOutcome};
-use crate::constants::{DEFAULT_RUN_LOCALNET_TIMEOUT_SEC, SPEL_BIN_REL_PATH};
+use crate::constants::{
+    DEFAULT_RUN_LOCALNET_TIMEOUT_SEC, FRAMEWORK_KIND_LEZ_FRAMEWORK, SPEL_BIN_REL_PATH,
+};
 use crate::model::{LocalnetOwnership, Project, RunProfile};
 use crate::project::{load_project, resolve_repo_path, run_in_project_dir};
 use crate::state::prepare_wallet_home;
@@ -138,9 +140,19 @@ fn run_pipeline_once(project: &Project, params: &PipelineParams) -> DynResult<()
     println!("[1/{total_steps}] Building...");
     cmd_build_shortcut(None, false)?;
 
-    // Step 2: Build IDL (no-op for non-lez-framework projects)
+    // Step 2: Build IDL (no-op for non-lez-framework projects). `build_idl_for_current_project`
+    // deliberately bails when typed directly against a non-lez-framework project, so the
+    // pipeline must gate on framework kind here the same way `lgs build` does — otherwise
+    // `lgs run` aborts at this step for every `default`-template project.
     println!("[2/{total_steps}] Building IDL...");
-    build_idl_for_current_project()?;
+    if project.config.framework.kind == FRAMEWORK_KIND_LEZ_FRAMEWORK {
+        build_idl_for_current_project()?;
+    } else {
+        println!(
+            "Skipping IDL build for framework kind `{}`",
+            project.config.framework.kind
+        );
+    }
 
     // Step 3: Reset OR ensure localnet.
     if effective_reset {


### PR DESCRIPTION
## Summary

`lgs run` aborted at step `[2/N] Building IDL...` for **every default-template project**:

```
error: `build idl` is only supported for `lez-framework` projects (current framework.kind = `default`).
Use `logos-scaffold build` for the framework-agnostic build, or set `framework.kind = "lez-framework"` in scaffold.toml.
```

`run_pipeline_once` called `build_idl_for_current_project()` unconditionally, but that
function deliberately **bails** for non-`lez-framework` projects. `lgs build` already gates
the IDL/client step on `framework.kind`; the `run` pipeline now does the same, matching the
step's own `// no-op for non-lez-framework projects` comment. Default-template `run` now
proceeds through localnet → topup → deploy → post-deploy hooks.

## Root cause

`src/commands/build.rs` gates IDL/client generation on `framework.kind`, but
`src/commands/run.rs` did not — it always invoked `build_idl_for_current_project()`, which
hard-errors for `default` projects. The two code paths disagreed.

## Fix

Gate the IDL step in `run_pipeline_once` on `framework.kind == "lez-framework"`, printing a
`Skipping IDL build for framework kind ...` line otherwise. Step numbering is unchanged.

## How it was found

Surfaced while dogfooding **scenario D7** (`run` pipeline + post-deploy hooks) against the
default template. After the fix, D7 passes end-to-end: numbered step headers, localnet reuse,
wallet topup, 5/5 deploy, and all post-deploy hooks firing with the documented env contract
(`SEQUENCER_URL`, `SCAFFOLD_IDL_DIR`, `SCAFFOLD_PROJECT_ROOT`, `NSSA_WALLET_HOME_DIR`).

## Verification

- `cargo test` — 387 + 168 tests pass, 0 failed.
- Manual: `lgs run`, `run --post-deploy <cmd>`, `run --no-post-deploy`, and the
  `--post-deploy x --no-post-deploy` clap-conflict path all behave correctly on a
  default-template project.