### PR TITLE
feat(api): expose scaffold commands as a public Rust API

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,25 @@
 - [FURPS+](FURPS.md) — Functional and non-functional requirements
 - [ADR](ADR.md) — Architecture Decision Records
 
+## Using scaffold as a Rust library
+
+Everything the CLI does is also exposed as a typed Rust API under
+`logos_scaffold::api`, so tests and dev tooling can drive scaffold-managed
+projects (setup, localnet lifecycle, wallet top-ups, deploys, diagnostics)
+without shelling out to `lgs` and parsing text:
+
+```rust
+use logos_scaffold::api::{LocalnetStartOptions, Project};
+
+let project = Project::open("/path/to/my-app")?;
+let node = project.localnet_start(&LocalnetStartOptions::default())?;
+println!("sequencer pid={} rpc={}", node.pid(), node.rpc_url());
+node.stop()?;
+```
+
+See the `api` module rustdoc for the full surface, typed result models, and
+categorized errors.
+
 ## Platform
 
 The CLI is currently Unix-only.

--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -1,0 +1,201 @@
+//! Public error type for the scaffold API.
+//!
+//! Every API entry point returns [`Error`], which buckets failures into the
+//! categories consumers need to branch on: configuration problems, missing
+//! tools, repository state, managed-process failures, timeouts, transport
+//! failures, and structured external-command failures. Anything that does not
+//! fit a category surfaces as [`Error::Other`] with the full error chain
+//! preserved.
+
+use std::path::PathBuf;
+
+pub use crate::error::CommandFailed;
+use crate::error::{LocalnetError, ResetError};
+
+/// Result alias used by every API entry point.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Categorized API error.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+    /// `scaffold.toml` is missing, unparseable, on an unsupported schema
+    /// version, or an option value is invalid.
+    #[error("configuration error: {message}")]
+    Config { message: String },
+
+    /// A required binary or artifact is missing (sequencer, wallet, spel,
+    /// circuits release, …). `path` is the location that was probed, when
+    /// known.
+    #[error("{message}")]
+    MissingTool {
+        message: String,
+        path: Option<PathBuf>,
+    },
+
+    /// A pinned repository checkout is dirty, missing, or not at the
+    /// configured pin.
+    #[error("repository state error: {message}")]
+    RepoState { message: String },
+
+    /// A managed long-lived process failed (sequencer exited before ready,
+    /// refused to stop, a foreign process holds its port, …).
+    #[error("{message}")]
+    Process {
+        message: String,
+        /// Tail of the process log when one was captured.
+        log_tail: Option<String>,
+    },
+
+    /// An operation did not complete within its deadline.
+    #[error("{message}")]
+    Timeout { message: String, timeout_sec: u64 },
+
+    /// An RPC/HTTP transport failure talking to the sequencer or a remote
+    /// endpoint. Distinct from business-level rejections.
+    #[error("transport error: {message}")]
+    Transport { message: String },
+
+    /// An external command exited non-zero. Carries the rendered command,
+    /// exit code, and captured diagnostic output.
+    #[error(transparent)]
+    Command(CommandFailed),
+
+    /// Uncategorized failure; the full `anyhow` chain is preserved.
+    #[error(transparent)]
+    Other(anyhow::Error),
+}
+
+/// Map an internal `anyhow::Error` onto the public categories by downcasting
+/// the typed errors the crate produces. Unknown errors pass through as
+/// [`Error::Other`] — no string sniffing.
+pub(crate) fn classify(err: anyhow::Error) -> Error {
+    let err = match err.downcast::<CommandFailed>() {
+        Ok(failure) => return Error::Command(failure),
+        Err(err) => err,
+    };
+
+    let err = match err.downcast::<LocalnetError>() {
+        Ok(localnet) => {
+            let message = localnet.to_string();
+            return match localnet {
+                LocalnetError::MissingSequencerBinary { path } => Error::MissingTool {
+                    message,
+                    path: Some(PathBuf::from(path)),
+                },
+                LocalnetError::ExitedBeforeReady { log_tail, .. } => Error::Process {
+                    message,
+                    log_tail: Some(log_tail),
+                },
+                LocalnetError::StartTimeout { timeout_sec, .. }
+                | LocalnetError::StopTimeout { timeout_sec, .. } => Error::Timeout {
+                    message,
+                    timeout_sec,
+                },
+                LocalnetError::StopKillFailed { .. } => Error::Process {
+                    message,
+                    log_tail: None,
+                },
+            };
+        }
+        Err(err) => err,
+    };
+
+    let err = match err.downcast::<ResetError>() {
+        Ok(reset) => {
+            let message = reset.to_string();
+            return match reset {
+                ResetError::ForeignListener { .. } => Error::Process {
+                    message,
+                    log_tail: None,
+                },
+                ResetError::BlocksNotProduced { timeout_sec } => Error::Timeout {
+                    message,
+                    timeout_sec,
+                },
+                ResetError::VerificationPollFailed(_) => Error::Transport { message },
+            };
+        }
+        Err(err) => err,
+    };
+
+    let err = match err.downcast::<crate::commands::wallet_support::RpcReachabilityError>() {
+        Ok(rpc) => {
+            return Error::Transport {
+                message: rpc.to_string(),
+            }
+        }
+        Err(err) => err,
+    };
+
+    Error::Other(err)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_maps_command_failed() {
+        let err: anyhow::Error = CommandFailed {
+            message: "build wallet failed with exit status: 1".to_string(),
+            command: "cargo build".to_string(),
+            label: "build wallet".to_string(),
+            exit_code: Some(1),
+            stdout: String::new(),
+            stderr: "boom".to_string(),
+            log_path: None,
+        }
+        .into();
+        match classify(err) {
+            Error::Command(failure) => {
+                assert_eq!(failure.exit_code, Some(1));
+                assert_eq!(failure.command, "cargo build");
+                assert_eq!(failure.stderr, "boom");
+            }
+            other => panic!("expected Command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_maps_missing_sequencer_to_missing_tool() {
+        let err: anyhow::Error = LocalnetError::MissingSequencerBinary {
+            path: "/tmp/lez/target/release/sequencer_service".to_string(),
+        }
+        .into();
+        match classify(err) {
+            Error::MissingTool { path, .. } => {
+                assert_eq!(
+                    path.as_deref(),
+                    Some(std::path::Path::new(
+                        "/tmp/lez/target/release/sequencer_service"
+                    ))
+                );
+            }
+            other => panic!("expected MissingTool, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_maps_start_timeout_to_timeout() {
+        let err: anyhow::Error = LocalnetError::StartTimeout {
+            timeout_sec: 20,
+            pid: 1234,
+            log_tail: "tail".to_string(),
+        }
+        .into();
+        match classify(err) {
+            Error::Timeout { timeout_sec, .. } => assert_eq!(timeout_sec, 20),
+            other => panic!("expected Timeout, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_passes_unknown_errors_through() {
+        let err = anyhow::anyhow!("something else");
+        match classify(err) {
+            Error::Other(inner) => assert_eq!(inner.to_string(), "something else"),
+            other => panic!("expected Other, got {other:?}"),
+        }
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,0 +1,814 @@
+//! Public Rust API for logos-scaffold.
+//!
+//! Everything the `lgs` / `logos-scaffold` CLI can do is available here as a
+//! typed library surface, so Rust tests and dev tooling can drive
+//! scaffold-managed projects without shelling out and parsing text.
+//!
+//! Design rules:
+//!
+//! - Every operation takes an **explicit project root** (via
+//!   [`Project::open`] / [`Project::discover`]); nothing depends on the
+//!   process working directory except where noted below.
+//! - Every operation returns **typed results** ([`LocalnetStatusReport`],
+//!   [`DoctorReport`], [`DeployResult`], …) — the same models that back the
+//!   CLI's `--json` output — and **categorized errors** ([`Error`]).
+//! - Operations that start long-lived processes return handles
+//!   ([`LocalnetHandle`]) exposing status and stop/cleanup.
+//! - Failures of external commands surface as [`CommandFailed`] with the
+//!   rendered command, exit code, and captured diagnostics.
+//!
+//! Long-running build-style operations ([`Project::setup`],
+//! [`Project::build`], [`Project::run`], [`Project::basecamp`]) stream their
+//! progress to stdout/stderr exactly like the CLI; their *results* are still
+//! typed. [`Project::build`] and [`Project::run`] temporarily change the
+//! process working directory (restored afterwards), so do not run them
+//! concurrently from multiple threads.
+//!
+//! # Examples
+//!
+//! Set up a project and manage its localnet:
+//!
+//! ```no_run
+//! use logos_scaffold::api::{LocalnetStartOptions, Project, SetupOptions};
+//!
+//! fn main() -> logos_scaffold::api::Result<()> {
+//!     let project = Project::open("/path/to/my-app")?;
+//!     project.setup(&SetupOptions::default())?;
+//!
+//!     let node = project.localnet_start(&LocalnetStartOptions::default())?;
+//!     println!("sequencer pid={} rpc={}", node.pid(), node.rpc_url());
+//!     assert!(node.status().ready);
+//!
+//!     node.stop()?;
+//!     Ok(())
+//! }
+//! ```
+//!
+//! Top up the default wallet and deploy:
+//!
+//! ```no_run
+//! use logos_scaffold::api::{DeployOptions, Project, TopupOptions, TopupOutcome};
+//!
+//! fn main() -> logos_scaffold::api::Result<()> {
+//!     let project = Project::open("/path/to/my-app")?;
+//!
+//!     match project.wallet_topup(&TopupOptions::default())? {
+//!         TopupOutcome::Success => {}
+//!         TopupOutcome::ConfirmationTimeout { message } => {
+//!             eprintln!("funding uncertain: {message}");
+//!         }
+//!     }
+//!
+//!     for result in project.deploy(&DeployOptions::default())? {
+//!         println!("{}: {:?} (tx={:?})", result.program, result.status, result.tx);
+//!     }
+//!     Ok(())
+//! }
+//! ```
+//!
+//! Run diagnostics and collect a report bundle:
+//!
+//! ```no_run
+//! use logos_scaffold::api::{Project, ReportOptions};
+//!
+//! fn main() -> logos_scaffold::api::Result<()> {
+//!     let project = Project::open("/path/to/my-app")?;
+//!
+//!     let doctor = project.doctor()?;
+//!     println!(
+//!         "doctor: {} ({} pass / {} warn / {} fail)",
+//!         doctor.status, doctor.summary.pass, doctor.summary.warn, doctor.summary.fail
+//!     );
+//!
+//!     let report = project.report(&ReportOptions::default())?;
+//!     println!("archive at {}", report.archive.display());
+//!     Ok(())
+//! }
+//! ```
+
+mod error;
+
+use std::path::{Path, PathBuf};
+
+pub use error::{CommandFailed, Error, Result};
+
+pub use crate::commands::deploy::{DeployResult, DeployStatus};
+pub use crate::commands::wallet::{TopupOutcome, WalletListReport};
+pub use crate::model::{
+    CheckRow, CheckStatus, CollectedItem, DoctorReport, DoctorSummary, LocalnetLogsReport,
+    LocalnetOwnership, LocalnetStatusReport, RedactionSummary, ReportManifest, SkippedItem,
+    ToolCommandResult,
+};
+
+use crate::commands::basecamp::{basecamp_for_project, BasecampAction};
+use crate::commands::build::cmd_build_shortcut;
+use crate::commands::client::generate_clients_from_current_idl;
+use crate::commands::deploy::deploy_for_project;
+use crate::commands::doctor::build_doctor_report;
+use crate::commands::idl::build_idl_for_current_project;
+use crate::commands::init::cmd_init_at;
+pub use crate::commands::localnet::LocalnetStopOutcome;
+
+use crate::commands::localnet::{
+    build_localnet_status_for_project, localnet_logs_for_project, localnet_reset_for_project,
+    localnet_start_for_project, localnet_stop_for_project,
+};
+use crate::commands::new::{create_project_in, NewCommand};
+use crate::commands::report::report_for_project;
+use crate::commands::run::{run_for_project, RunInvocation};
+use crate::commands::setup::setup_for_project;
+use crate::commands::spel::spel_passthrough_for_project;
+use crate::commands::wallet::{
+    cmd_wallet_proxy, cmd_wallet_topup_inner, wallet_default_set_for_project,
+    wallet_list_for_project,
+};
+use crate::constants::{
+    DEFAULT_RUN_LOCALNET_TIMEOUT_SEC, SEQUENCER_BIN_REL_PATH, SPEL_BIN_REL_PATH,
+    WALLET_BIN_REL_PATH,
+};
+use crate::project::{find_project_root, load_project_at, resolve_cache_root, resolve_repo_path};
+
+/// A scaffold-managed project, addressed by an explicit root directory.
+///
+/// This is the entry point of the API: open (or discover) a project once,
+/// then call operations on it. The handle is cheap to clone.
+#[derive(Clone, Debug)]
+pub struct Project {
+    inner: crate::model::Project,
+}
+
+impl Project {
+    /// Open the project whose root directory is `root` (the directory that
+    /// contains `scaffold.toml`). No upward discovery happens; pass the exact
+    /// root. Configuration problems surface as [`Error::Config`].
+    pub fn open(root: impl AsRef<Path>) -> Result<Self> {
+        let inner = load_project_at(root.as_ref()).map_err(|err| Error::Config {
+            message: format!("{err:#}"),
+        })?;
+        Ok(Self { inner })
+    }
+
+    /// Discover a project by walking upward from `start_dir` until a
+    /// directory containing `scaffold.toml` is found, then open it.
+    pub fn discover(start_dir: impl AsRef<Path>) -> Result<Self> {
+        let start = start_dir.as_ref().to_path_buf();
+        let root = find_project_root(start.clone()).ok_or_else(|| Error::Config {
+            message: format!(
+                "no scaffold.toml found in {} or any parent directory",
+                start.display()
+            ),
+        })?;
+        Self::open(root)
+    }
+
+    /// The project root directory.
+    pub fn root(&self) -> &Path {
+        &self.inner.root
+    }
+
+    /// The localnet RPC URL this project is configured for
+    /// (`http://127.0.0.1:<localnet.port>`).
+    pub fn localnet_rpc_url(&self) -> String {
+        format!("http://127.0.0.1:{}", self.inner.config.localnet.port)
+    }
+
+    /// Resolve every path scaffold derives for this project: cache root,
+    /// pinned repo checkouts, vendored binaries, wallet home, localnet state
+    /// and log files, and the circuits directory. Nothing is created or
+    /// downloaded; paths are reported whether or not they exist yet.
+    pub fn paths(&self) -> Result<ProjectPaths> {
+        let (cache_root, source) = resolve_cache_root(&self.inner).map_err(error::classify)?;
+        let lez_repo = resolve_repo_path(&self.inner, &self.inner.config.lez, "lez")
+            .map_err(error::classify)?;
+        let spel_repo = resolve_repo_path(&self.inner, &self.inner.config.spel, "spel")
+            .map_err(error::classify)?;
+        let circuits_dir =
+            crate::circuits::circuits_dir_for_cache_root(&cache_root).map_err(error::classify)?;
+        Ok(ProjectPaths {
+            root: self.inner.root.clone(),
+            scaffold_toml: self.inner.root.join("scaffold.toml"),
+            cache_root,
+            cache_root_source: source.label().to_string(),
+            sequencer_binary: lez_repo.join(SEQUENCER_BIN_REL_PATH),
+            wallet_binary: lez_repo.join(WALLET_BIN_REL_PATH),
+            spel_binary: spel_repo.join(SPEL_BIN_REL_PATH),
+            lez_repo,
+            spel_repo,
+            wallet_home: self.inner.root.join(&self.inner.config.wallet_home_dir),
+            localnet_state: self.inner.root.join(".scaffold/state/localnet.state"),
+            sequencer_log: self.inner.root.join(".scaffold/logs/sequencer.log"),
+            circuits_dir,
+        })
+    }
+
+    // ── setup / build / deploy / run ───────────────────────────────────────
+
+    /// Sync pinned repos and build the project-local binaries (sequencer,
+    /// wallet, spel). Streams build progress to stdout; external-command
+    /// failures surface as [`Error::Command`].
+    pub fn setup(&self, options: &SetupOptions) -> Result<()> {
+        setup_for_project(&self.inner, options.prebuilt).map_err(error::classify)
+    }
+
+    /// Build the project workspace and guest programs (chains `setup`
+    /// internally, mirroring `lgs build`). Temporarily changes the process
+    /// working directory to the project root.
+    pub fn build(&self, options: &BuildOptions) -> Result<()> {
+        cmd_build_shortcut(Some(self.inner.root.clone()), options.prebuilt).map_err(error::classify)
+    }
+
+    /// Build IDL files for the current project (framework projects only).
+    /// Temporarily changes the process working directory to the project root.
+    pub fn build_idl(&self) -> Result<()> {
+        crate::project::run_in_project_dir(Some(&self.inner.root), || {
+            build_idl_for_current_project()
+        })
+        .map_err(error::classify)
+    }
+
+    /// Generate client code from the current IDL files (framework projects
+    /// only). Temporarily changes the process working directory to the
+    /// project root.
+    pub fn build_client(&self) -> Result<()> {
+        crate::project::run_in_project_dir(Some(&self.inner.root), || {
+            generate_clients_from_current_idl()
+        })
+        .map_err(error::classify)
+    }
+
+    /// Deploy guest programs to the running localnet. Returns one
+    /// [`DeployResult`] per attempted program; inspect `status` to decide
+    /// whether failures are fatal — partial failure is **not** an `Err`.
+    pub fn deploy(&self, options: &DeployOptions) -> Result<Vec<DeployResult>> {
+        deploy_for_project(
+            &self.inner,
+            options.program.clone(),
+            options.program_path.clone(),
+            false,
+        )
+        .map_err(error::classify)
+    }
+
+    /// Execute the full run pipeline: build → IDL → localnet → wallet topup →
+    /// deploy → post-deploy hooks. Streams step progress to stdout and
+    /// temporarily changes the process working directory to the project root.
+    /// Watch mode is CLI-only.
+    pub fn run(&self, options: &RunOptions) -> Result<()> {
+        run_for_project(
+            &self.inner,
+            RunInvocation {
+                profile: options.profile.clone(),
+                reset: options.reset,
+                post_deploy_override: options.post_deploy_override.clone(),
+                localnet_timeout_sec: Some(
+                    options
+                        .localnet_timeout_sec
+                        .unwrap_or(DEFAULT_RUN_LOCALNET_TIMEOUT_SEC),
+                ),
+                watch: false,
+                watch_debounce_ms: None,
+            },
+        )
+        .map_err(error::classify)
+    }
+
+    // ── localnet lifecycle ─────────────────────────────────────────────────
+
+    /// Start (or reuse) the project's localnet sequencer and wait until it is
+    /// ready. Returns a [`LocalnetHandle`] exposing the pid, RPC URL, state
+    /// and log paths, plus status/stop operations. The sequencer keeps
+    /// running when the handle is dropped — stop it explicitly.
+    pub fn localnet_start(&self, options: &LocalnetStartOptions) -> Result<LocalnetHandle> {
+        let outcome = localnet_start_for_project(&self.inner, options.timeout_sec)
+            .map_err(error::classify)?;
+        Ok(LocalnetHandle {
+            project: self.inner.clone(),
+            pid: outcome.pid,
+            reused: outcome.reused,
+            rpc_url: outcome.rpc_url,
+            state_path: outcome.state_path,
+            log_path: outcome.log_path,
+        })
+    }
+
+    /// Stop the tracked localnet sequencer, if any. Never touches unmanaged
+    /// (foreign) listeners; see [`LocalnetStopOutcome`].
+    pub fn localnet_stop(&self) -> Result<LocalnetStopOutcome> {
+        localnet_stop_for_project(&self.inner).map_err(error::classify)
+    }
+
+    /// Current localnet status (tracked pid, listener, ownership, readiness,
+    /// remediation hints). Same model as `lgs localnet status --json`.
+    pub fn localnet_status(&self) -> LocalnetStatusReport {
+        build_localnet_status_for_project(&self.inner)
+    }
+
+    /// Tail of the sequencer log. Same model as `lgs localnet logs --json`.
+    pub fn localnet_logs(&self, tail: usize) -> Result<LocalnetLogsReport> {
+        localnet_logs_for_project(&self.inner, tail).map_err(error::classify)
+    }
+
+    /// Reset the localnet: stop the sequencer, wipe its chain database
+    /// (and optionally the wallet), restart, and verify block production.
+    /// **Destructive** — equivalent to `lgs localnet reset --yes`.
+    pub fn localnet_reset(&self, options: &LocalnetResetOptions) -> Result<()> {
+        localnet_reset_for_project(
+            &self.inner,
+            options.reset_wallet,
+            options.verify_timeout_sec,
+        )
+        .map_err(error::classify)
+    }
+
+    // ── wallet ─────────────────────────────────────────────────────────────
+
+    /// List wallet accounts via the vendored wallet binary, returning the
+    /// captured output. `long` mirrors `wallet list --long`.
+    pub fn wallet_list(&self, long: bool) -> Result<WalletListReport> {
+        wallet_list_for_project(&self.inner, long).map_err(error::classify)
+    }
+
+    /// Top up a wallet from the localnet faucet. With `address: None`, the
+    /// project's default wallet is used. A [`TopupOutcome::ConfirmationTimeout`]
+    /// means the submission reached the sequencer but confirmation timed out —
+    /// funding is uncertain, not failed.
+    pub fn wallet_topup(&self, options: &TopupOptions) -> Result<TopupOutcome> {
+        cmd_wallet_topup_inner(&self.inner, options.address.clone(), false, false)
+            .map_err(error::classify)
+    }
+
+    /// Set the project's default wallet address; returns the normalized form
+    /// (`Public/<base58>` or `Private/<base58>`).
+    pub fn wallet_set_default(&self, address: &str) -> Result<String> {
+        wallet_default_set_for_project(&self.inner, address).map_err(error::classify)
+    }
+
+    /// Forward raw arguments to the vendored wallet binary with the project's
+    /// wallet environment (`NSSA_WALLET_HOME_DIR`), streaming its output.
+    /// Non-zero exit surfaces as [`Error::Command`].
+    pub fn wallet_passthrough(&self, args: &[String]) -> Result<()> {
+        cmd_wallet_proxy(&self.inner, args).map_err(error::classify)
+    }
+
+    // ── passthrough / basecamp / diagnostics ──────────────────────────────
+
+    /// Forward arguments to the project-vendored `spel` binary, streaming its
+    /// output, and return its exit status (the API never exits the process).
+    pub fn spel(&self, args: &[String]) -> Result<std::process::ExitStatus> {
+        spel_passthrough_for_project(&self.inner, args).map_err(error::classify)
+    }
+
+    /// Execute a basecamp flow (setup, modules, install, launch, develop,
+    /// build-portable, doctor). Streams progress to stdout like the CLI.
+    pub fn basecamp(&self, command: BasecampCommand) -> Result<()> {
+        basecamp_for_project(self.inner.clone(), command.into_action()).map_err(error::classify)
+    }
+
+    /// Run all health checks and return the structured report. Same model as
+    /// `lgs doctor --json`; a report with failing checks is still `Ok` — read
+    /// `summary.fail`.
+    pub fn doctor(&self) -> Result<DoctorReport> {
+        // Suppress `$ <cmd>` echoes from the probe subprocesses; the report
+        // is the product here, not the console transcript.
+        let _echo = crate::process::EchoGuard::suppress();
+        build_doctor_report(&self.inner).map_err(error::classify)
+    }
+
+    /// Collect a sanitized diagnostics archive. Returns the archive path and
+    /// the manifest of collected/skipped items.
+    pub fn report(&self, options: &ReportOptions) -> Result<ReportOutcome> {
+        let outcome = report_for_project(&self.inner, options.out.clone(), options.tail)
+            .map_err(error::classify)?;
+        Ok(ReportOutcome {
+            archive: outcome.archive,
+            manifest: outcome.manifest,
+        })
+    }
+}
+
+/// Create a new scaffold project at `parent_dir/<options.name>` and return a
+/// handle to it. Equivalent to `lgs new` run from `parent_dir`.
+pub fn create_project(
+    parent_dir: impl AsRef<Path>,
+    options: CreateProjectOptions,
+) -> Result<Project> {
+    let root = create_project_in(
+        parent_dir.as_ref(),
+        NewCommand {
+            name: options.name,
+            template: options.template,
+            vendor_deps: options.vendor_deps,
+            lez_path: options.lez_path,
+            cache_root: options.cache_root,
+        },
+    )
+    .map_err(error::classify)?;
+    Project::open(root)
+}
+
+/// Initialize (or migrate) `scaffold.toml` in an existing directory and
+/// return a handle to the project. Equivalent to `lgs init`.
+pub fn init_project(dir: impl AsRef<Path>, options: InitProjectOptions) -> Result<Project> {
+    cmd_init_at(dir.as_ref(), "logos-scaffold", false, options.no_backup)
+        .map_err(error::classify)?;
+    Project::open(dir.as_ref())
+}
+
+/// Handle to a started localnet sequencer.
+///
+/// Dropping the handle does **not** stop the sequencer — localnet is a
+/// long-lived development service. Call [`LocalnetHandle::stop`] for
+/// deterministic teardown.
+#[derive(Clone, Debug)]
+pub struct LocalnetHandle {
+    project: crate::model::Project,
+    pid: u32,
+    reused: bool,
+    rpc_url: String,
+    state_path: PathBuf,
+    log_path: PathBuf,
+}
+
+impl LocalnetHandle {
+    /// Pid of the sequencer process.
+    pub fn pid(&self) -> u32 {
+        self.pid
+    }
+
+    /// `true` when an already-running tracked sequencer was reused instead of
+    /// spawning a new process.
+    pub fn reused(&self) -> bool {
+        self.reused
+    }
+
+    /// JSON-RPC endpoint of the sequencer (`http://127.0.0.1:<port>`).
+    pub fn rpc_url(&self) -> &str {
+        &self.rpc_url
+    }
+
+    /// Path of the localnet state file tracking the sequencer pid.
+    pub fn state_path(&self) -> &Path {
+        &self.state_path
+    }
+
+    /// Path of the sequencer log file.
+    pub fn log_path(&self) -> &Path {
+        &self.log_path
+    }
+
+    /// Current status (tracked pid, listener, ownership, readiness).
+    pub fn status(&self) -> LocalnetStatusReport {
+        build_localnet_status_for_project(&self.project)
+    }
+
+    /// Tail of the sequencer log.
+    pub fn logs(&self, tail: usize) -> Result<LocalnetLogsReport> {
+        localnet_logs_for_project(&self.project, tail).map_err(error::classify)
+    }
+
+    /// Stop the sequencer and clean up the state file.
+    pub fn stop(&self) -> Result<LocalnetStopOutcome> {
+        localnet_stop_for_project(&self.project).map_err(error::classify)
+    }
+}
+
+/// Every path scaffold derives for a project. Reported as configured/derived;
+/// existence is not guaranteed (run [`Project::setup`] to materialise
+/// binaries, repos, and circuits).
+#[derive(Clone, Debug)]
+pub struct ProjectPaths {
+    pub root: PathBuf,
+    pub scaffold_toml: PathBuf,
+    /// Resolved cache root (env override → scaffold.toml → platform default).
+    pub cache_root: PathBuf,
+    /// Which layer supplied `cache_root` (e.g. `LOGOS_SCAFFOLD_CACHE_ROOT`,
+    /// `scaffold.toml [scaffold].cache_root`, `$XDG_CACHE_HOME`).
+    pub cache_root_source: String,
+    /// Pinned LEZ checkout directory.
+    pub lez_repo: PathBuf,
+    /// Pinned spel checkout directory.
+    pub spel_repo: PathBuf,
+    /// Standalone sequencer binary built by `setup`.
+    pub sequencer_binary: PathBuf,
+    /// Wallet binary built by `setup`.
+    pub wallet_binary: PathBuf,
+    /// Vendored spel binary built by `setup`.
+    pub spel_binary: PathBuf,
+    /// Project wallet home directory.
+    pub wallet_home: PathBuf,
+    /// Localnet state file tracking the sequencer pid.
+    pub localnet_state: PathBuf,
+    /// Sequencer log file.
+    pub sequencer_log: PathBuf,
+    /// Circuits release directory (env override or cache location).
+    pub circuits_dir: PathBuf,
+}
+
+/// Options for [`Project::setup`].
+#[derive(Clone, Debug, Default)]
+pub struct SetupOptions {
+    /// Download prebuilt binaries instead of compiling from source, falling
+    /// back to a source build when no prebuilt exists for the pinned commit.
+    pub prebuilt: bool,
+}
+
+/// Options for [`Project::build`].
+#[derive(Clone, Debug, Default)]
+pub struct BuildOptions {
+    /// See [`SetupOptions::prebuilt`].
+    pub prebuilt: bool,
+}
+
+/// Options for [`Project::deploy`].
+#[derive(Clone, Debug, Default)]
+pub struct DeployOptions {
+    /// Deploy only this discovered program (default: all).
+    pub program: Option<String>,
+    /// Deploy a single ELF directly, skipping discovery.
+    pub program_path: Option<PathBuf>,
+}
+
+/// Options for [`Project::run`].
+#[derive(Clone, Debug, Default)]
+pub struct RunOptions {
+    /// Named `[run.profiles.<name>]` profile to use.
+    pub profile: Option<String>,
+    /// Override the profile's `reset` flag.
+    pub reset: Option<bool>,
+    /// Override the post-deploy hooks.
+    pub post_deploy_override: Option<Vec<String>>,
+    /// Seconds to wait for the sequencer when `run` starts localnet itself
+    /// (default: 120).
+    pub localnet_timeout_sec: Option<u64>,
+}
+
+/// Options for [`Project::localnet_start`].
+#[derive(Clone, Debug)]
+pub struct LocalnetStartOptions {
+    /// Seconds to wait for the sequencer to become ready (default: 20).
+    pub timeout_sec: u64,
+}
+
+impl Default for LocalnetStartOptions {
+    fn default() -> Self {
+        Self { timeout_sec: 20 }
+    }
+}
+
+/// Options for [`Project::localnet_reset`].
+#[derive(Clone, Debug)]
+pub struct LocalnetResetOptions {
+    /// Also delete the wallet home and wallet state (irrecoverable).
+    pub reset_wallet: bool,
+    /// Seconds to wait for post-reset block production (default: 30).
+    pub verify_timeout_sec: u64,
+}
+
+impl Default for LocalnetResetOptions {
+    fn default() -> Self {
+        Self {
+            reset_wallet: false,
+            verify_timeout_sec: 30,
+        }
+    }
+}
+
+/// Options for [`Project::wallet_topup`].
+#[derive(Clone, Debug, Default)]
+pub struct TopupOptions {
+    /// Destination address; `None` uses the project default wallet.
+    pub address: Option<String>,
+}
+
+/// Options for [`Project::report`].
+#[derive(Clone, Debug)]
+pub struct ReportOptions {
+    /// Output archive path (default: `.scaffold/reports/<timestamp>.tar.gz`).
+    pub out: Option<PathBuf>,
+    /// How many log lines to include per collected log (default: 500).
+    pub tail: usize,
+}
+
+impl Default for ReportOptions {
+    fn default() -> Self {
+        Self {
+            out: None,
+            tail: 500,
+        }
+    }
+}
+
+/// Result of [`Project::report`]: the written archive and its manifest.
+#[derive(Clone, Debug)]
+pub struct ReportOutcome {
+    pub archive: PathBuf,
+    pub manifest: ReportManifest,
+}
+
+/// Options for [`init_project`].
+#[derive(Clone, Debug, Default)]
+pub struct InitProjectOptions {
+    /// Skip writing `scaffold.toml.bak` when migrating an existing config.
+    pub no_backup: bool,
+}
+
+/// Options for [`create_project`].
+#[derive(Clone, Debug)]
+pub struct CreateProjectOptions {
+    /// Project (directory) name.
+    pub name: String,
+    /// Template name (`default` or `lez-framework`).
+    pub template: String,
+    /// Vendor pinned repos into the project instead of the shared cache.
+    pub vendor_deps: bool,
+    /// Use an existing local LEZ checkout instead of cloning.
+    pub lez_path: Option<PathBuf>,
+    /// Override the cache root recorded in `scaffold.toml`.
+    pub cache_root: Option<PathBuf>,
+}
+
+impl CreateProjectOptions {
+    /// Options for a `default`-template project named `name`.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            template: "default".to_string(),
+            vendor_deps: false,
+            lez_path: None,
+            cache_root: None,
+        }
+    }
+}
+
+/// Basecamp flows, mirroring `lgs basecamp <subcommand>`.
+#[derive(Clone, Debug)]
+pub enum BasecampCommand {
+    /// Build/install the pinned basecamp binary and seed profiles.
+    Setup,
+    /// Capture project modules (and dependencies) into `scaffold.toml`.
+    Modules {
+        paths: Vec<PathBuf>,
+        flakes: Vec<String>,
+        /// Only print the captured state; change nothing.
+        show: bool,
+    },
+    /// Build and install everything captured in state.
+    Install,
+    /// Launch a seeded profile.
+    Launch { profile: String },
+    /// Enter a module's Nix dev shell.
+    Develop {
+        module: String,
+        dev_shell: Option<String>,
+    },
+    /// Attr-swap replay producing portable module builds.
+    BuildPortable,
+    /// Basecamp-specific health checks.
+    Doctor,
+}
+
+impl BasecampCommand {
+    fn into_action(self) -> BasecampAction {
+        match self {
+            Self::Setup => BasecampAction::Setup,
+            Self::Modules {
+                paths,
+                flakes,
+                show,
+            } => BasecampAction::Modules {
+                paths,
+                flakes,
+                show,
+            },
+            Self::Install => BasecampAction::Install {
+                print_output: false,
+            },
+            Self::Launch { profile } => BasecampAction::Launch { profile },
+            Self::Develop { module, dev_shell } => BasecampAction::Develop { module, dev_shell },
+            Self::BuildPortable => BasecampAction::BuildPortable,
+            Self::Doctor => BasecampAction::Doctor { json: false },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    /// Minimal valid scaffold.toml for fixture projects, mirroring what
+    /// `lgs new` writes (schema 0.2.0).
+    fn write_fixture_config(root: &Path) {
+        fs::write(
+            root.join("scaffold.toml"),
+            r#"[scaffold]
+version = "0.2.0"
+
+[repos.lez]
+source = "https://github.com/logos-blockchain/logos-execution-zone.git"
+pin = "cf3639d8252040d13b3d4e933feb19b42c76e14a"
+build = "cargo"
+
+[repos.spel]
+source = "https://github.com/logos-co/spel.git"
+pin = "73fc462eb8f0a4d00f1a846437c627ec2e523f83"
+build = "cargo"
+
+[wallet]
+home_dir = ".scaffold/wallet"
+
+[framework]
+kind = "default"
+version = "0.1.0"
+
+[localnet]
+port = 3040
+"#,
+        )
+        .expect("write scaffold.toml");
+    }
+
+    #[test]
+    fn open_loads_project_from_explicit_root() {
+        let temp = tempdir().expect("tempdir");
+        write_fixture_config(temp.path());
+
+        let project = Project::open(temp.path()).expect("open project");
+        assert_eq!(project.root(), temp.path());
+        assert_eq!(project.localnet_rpc_url(), "http://127.0.0.1:3040");
+    }
+
+    #[test]
+    fn open_rejects_directory_without_scaffold_toml() {
+        let temp = tempdir().expect("tempdir");
+        let err = Project::open(temp.path()).expect_err("must fail");
+        match err {
+            Error::Config { message } => {
+                assert!(message.contains("scaffold.toml"), "{message}")
+            }
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn discover_walks_up_to_project_root() {
+        let temp = tempdir().expect("tempdir");
+        write_fixture_config(temp.path());
+        let nested = temp.path().join("src/deep/dir");
+        fs::create_dir_all(&nested).expect("mkdir nested");
+
+        let project = Project::discover(&nested).expect("discover project");
+        assert_eq!(project.root(), temp.path());
+    }
+
+    #[test]
+    fn paths_reports_project_owned_locations() {
+        let temp = tempdir().expect("tempdir");
+        write_fixture_config(temp.path());
+
+        let project = Project::open(temp.path()).expect("open project");
+        let paths = project.paths().expect("paths");
+
+        assert_eq!(paths.root, temp.path());
+        assert_eq!(paths.scaffold_toml, temp.path().join("scaffold.toml"));
+        assert_eq!(paths.wallet_home, temp.path().join(".scaffold/wallet"));
+        assert_eq!(
+            paths.localnet_state,
+            temp.path().join(".scaffold/state/localnet.state")
+        );
+        assert_eq!(
+            paths.sequencer_log,
+            temp.path().join(".scaffold/logs/sequencer.log")
+        );
+        assert!(paths
+            .sequencer_binary
+            .ends_with("target/release/sequencer_service"));
+        assert!(paths.wallet_binary.ends_with("target/release/wallet"));
+        assert!(paths.spel_binary.ends_with("target/release/spel"));
+    }
+
+    #[test]
+    fn localnet_status_on_fresh_project_is_stopped() {
+        let temp = tempdir().expect("tempdir");
+        write_fixture_config(temp.path());
+
+        let project = Project::open(temp.path()).expect("open project");
+        let status = project.localnet_status();
+        assert!(!status.ready);
+        assert!(status.tracked_pid.is_none());
+    }
+
+    #[test]
+    fn localnet_logs_reports_missing_log_file() {
+        let temp = tempdir().expect("tempdir");
+        write_fixture_config(temp.path());
+
+        let project = Project::open(temp.path()).expect("open project");
+        let logs = project.localnet_logs(50).expect("logs report");
+        assert!(!logs.exists);
+        assert!(logs.lines.is_empty());
+    }
+}

--- a/src/circuits.rs
+++ b/src/circuits.rs
@@ -79,6 +79,20 @@ pub(crate) fn ensure_circuits_for_subprocess(cache_root: &Path) -> DynResult<()>
     Ok(())
 }
 
+/// Resolve the directory the circuits release lives at (or would be
+/// materialised at) for `cache_root`, without downloading anything. The
+/// `LOGOS_BLOCKCHAIN_CIRCUITS` env override wins when it points at a
+/// populated checkout — mirroring `ensure_circuits_for_subprocess`.
+pub(crate) fn circuits_dir_for_cache_root(cache_root: &Path) -> DynResult<PathBuf> {
+    if let Some(path) = circuits_path_from_env() {
+        return Ok(path);
+    }
+    let triple = release_triple()?;
+    Ok(cache_root
+        .join("circuits")
+        .join(format!("v{DEFAULT_CIRCUITS_VERSION}-{triple}")))
+}
+
 fn circuits_path_from_env() -> Option<PathBuf> {
     let raw = std::env::var(LOGOS_BLOCKCHAIN_CIRCUITS_ENV).ok()?;
     let path = PathBuf::from(raw);

--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -77,6 +77,15 @@ pub(crate) fn cmd_basecamp(action: BasecampAction) -> DynResult<()> {
     }
 
     let project = load_project()?;
+    basecamp_for_project(project, action)
+}
+
+/// Dispatch a basecamp action against an explicit project. Used by the CLI
+/// (after cwd discovery) and the public API (with a caller-provided root).
+pub(crate) fn basecamp_for_project(project: Project, action: BasecampAction) -> DynResult<()> {
+    if matches!(action, BasecampAction::Docs) {
+        return cmd_basecamp_docs();
+    }
 
     match action {
         BasecampAction::Setup => cmd_basecamp_setup(project),

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -37,14 +37,41 @@ pub(crate) fn cmd_deploy(
     json: bool,
 ) -> DynResult<()> {
     let project = load_project()?;
-    let wallet = load_wallet_runtime(&project)?;
+    let results = deploy_for_project(&project, program_name, program_path, json)?;
+
+    let failed_count = results
+        .iter()
+        .filter(|result| matches!(result.status, DeployStatus::Failed))
+        .count();
+    if failed_count > 0 {
+        if results.len() == 1 {
+            bail!("deploy failed: {}", results[0].detail);
+        }
+        bail!("deploy completed with {failed_count} failed program(s)");
+    }
+
+    Ok(())
+}
+
+/// Deploy guest programs for `project`. Returns one `DeployResult` per
+/// attempted program; the caller decides whether failures are fatal. With
+/// `json = true` the CLI JSON object is printed and `$ <cmd>` echoes are
+/// suppressed; with `json = false` per-program progress lines stream to
+/// stdout (API callers should read the returned results, not the output).
+pub(crate) fn deploy_for_project(
+    project: &crate::model::Project,
+    program_name: Option<String>,
+    program_path: Option<PathBuf>,
+    json: bool,
+) -> DynResult<Vec<DeployResult>> {
+    let wallet = load_wallet_runtime(project)?;
     let spel_bin =
-        resolve_repo_path(&project, &project.config.spel, "spel")?.join(SPEL_BIN_REL_PATH);
+        resolve_repo_path(project, &project.config.spel, "spel")?.join(SPEL_BIN_REL_PATH);
 
     let sequencer_addr = wallet
         .sequencer_addr
         .clone()
-        .unwrap_or_else(|| default_sequencer_http_url_for_project(&project));
+        .unwrap_or_else(|| default_sequencer_http_url_for_project(project));
 
     // --program-path: deploy a single custom ELF directly, skip auto-discovery
     if let Some(custom_path) = program_path {
@@ -56,14 +83,15 @@ pub(crate) fn cmd_deploy(
             .and_then(|s| s.to_str())
             .unwrap_or("unknown")
             .to_string();
-        return deploy_single_program(
+        let result = deploy_single_program(
             &wallet,
             &program_name,
             &custom_path,
             &sequencer_addr,
             &spel_bin,
             json,
-        );
+        )?;
+        return Ok(vec![result]);
     }
 
     let available_programs = discover_deployable_programs(&project.root)?;
@@ -215,11 +243,7 @@ pub(crate) fn cmd_deploy(
         }
     }
 
-    if failed_count > 0 {
-        bail!("deploy completed with {failed_count} failed program(s)");
-    }
-
-    Ok(())
+    Ok(results)
 }
 
 pub(crate) fn render_deploy_result_json(result: &DeployResult) -> serde_json::Value {
@@ -338,7 +362,7 @@ fn deploy_single_program(
     sequencer_addr: &str,
     spel_bin: &Path,
     json: bool,
-) -> DynResult<()> {
+) -> DynResult<DeployResult> {
     preflight_sequencer_reachability(sequencer_addr)?;
 
     let mut command = std::process::Command::new(&wallet.wallet_binary);
@@ -372,7 +396,13 @@ fn deploy_single_program(
             println!("FAIL {program_name} deployment failed");
             println!("  Error: {summary}");
         }
-        bail!("deploy failed: {summary}");
+        return Ok(DeployResult {
+            program: program_name.to_string(),
+            status: DeployStatus::Failed,
+            detail: summary,
+            tx,
+            program_id: None,
+        });
     }
 
     let program_id = extract_program_id(spel_bin, binary_path);
@@ -415,7 +445,13 @@ fn deploy_single_program(
         );
     }
 
-    Ok(())
+    Ok(DeployResult {
+        program: program_name.to_string(),
+        status: DeployStatus::Submitted,
+        detail: "wallet submission command exited successfully".to_string(),
+        tx,
+        program_id,
+    })
 }
 
 /// Wall-clock cap for `spel inspect`. The CLI typically returns in
@@ -493,17 +529,22 @@ fn print_program_id_line(program_id: &Option<String>) {
     }
 }
 
-#[derive(Clone, Debug)]
-pub(crate) struct DeployResult {
-    pub(crate) program: String,
-    pub(crate) status: DeployStatus,
-    pub(crate) detail: String,
-    pub(crate) tx: Option<String>,
-    pub(crate) program_id: Option<String>,
+/// Outcome of one program deployment attempt.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct DeployResult {
+    pub program: String,
+    pub status: DeployStatus,
+    pub detail: String,
+    /// Transaction identifier extracted from the wallet output, when present.
+    pub tx: Option<String>,
+    /// Locally computed risc0 image ID (the on-chain program ID), when the
+    /// vendored `spel` binary was available to compute it.
+    pub program_id: Option<String>,
 }
 
-#[derive(Clone, Debug)]
-pub(crate) enum DeployStatus {
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DeployStatus {
     Submitted,
     Failed,
 }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -12,7 +12,7 @@ use crate::doctor_checks::{
     check_binary, check_container_runtime, check_logos_blockchain_circuits, check_path,
     check_port_warn, check_repo, check_standalone_support, one_line, print_rows,
 };
-use crate::model::{CheckRow, CheckStatus, DoctorReport, DoctorSummary};
+use crate::model::{CheckRow, CheckStatus, DoctorReport, DoctorSummary, Project};
 use crate::process::{pid_running, run_capture, run_with_stdin, set_command_echo};
 use crate::project::{load_project, resolve_cache_root, resolve_repo_path};
 use crate::state::read_localnet_state;
@@ -38,7 +38,8 @@ pub(crate) fn cmd_doctor(as_json: bool) -> DynResult<()> {
 }
 
 fn cmd_doctor_inner(as_json: bool) -> DynResult<()> {
-    let report = build_doctor_report()?;
+    let project = load_project()?;
+    let report = build_doctor_report(&project)?;
 
     if as_json {
         println!("{}", serde_json::to_string_pretty(&report)?);
@@ -69,9 +70,8 @@ fn cmd_doctor_inner(as_json: bool) -> DynResult<()> {
     Ok(())
 }
 
-pub(crate) fn build_doctor_report() -> DynResult<DoctorReport> {
-    let project = load_project()?;
-    let lez = resolve_repo_path(&project, &project.config.lez, "lez")?;
+pub(crate) fn build_doctor_report(project: &Project) -> DynResult<DoctorReport> {
+    let lez = resolve_repo_path(project, &project.config.lez, "lez")?;
     let spel = resolve_repo_path(&project, &project.config.spel, "spel")?;
     let wallet_home = project.root.join(&project.config.wallet_home_dir);
     let localnet_state_path = project.root.join(".scaffold/state/localnet.state");

--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -14,7 +14,10 @@ use crate::error::{LocalnetError, ResetError};
 use crate::model::{
     LocalnetLogsReport, LocalnetOwnership, LocalnetState, LocalnetStatusReport, Project,
 };
-use crate::process::{listener_pid, pid_alive, pid_command, pid_running, port_open, spawn_to_log};
+use crate::process::{
+    command_echo_enabled, listener_pid, pid_alive, pid_command, pid_running, port_open,
+    spawn_to_log,
+};
 use crate::project::{
     ensure_dir_exists, find_project_root, load_project, resolve_cache_root, resolve_repo_path,
 };
@@ -75,15 +78,125 @@ pub(crate) fn build_localnet_status_for_project(project: &Project) -> LocalnetSt
     )
 }
 
-fn cmd_localnet_in_project(project: &Project, action: LocalnetAction) -> DynResult<()> {
+/// Project-derived paths and addresses every localnet operation needs.
+pub(crate) struct LocalnetContext {
+    pub(crate) lez: PathBuf,
+    pub(crate) state_path: PathBuf,
+    pub(crate) log_path: PathBuf,
+    pub(crate) localnet_addr: String,
+    pub(crate) localnet_port: u16,
+    pub(crate) risc0_dev_mode: bool,
+}
+
+pub(crate) fn localnet_context(project: &Project) -> DynResult<LocalnetContext> {
     let localnet_port = project.config.localnet.port;
-    let risc0_dev_mode = project.config.localnet.risc0_dev_mode;
-    let localnet_addr = format!("127.0.0.1:{localnet_port}");
-    let lez = resolve_repo_path(project, &project.config.lez, "lez")?;
-    let state_path = project.root.join(".scaffold/state/localnet.state");
     let logs_dir = project.root.join(".scaffold/logs");
-    let log_path = logs_dir.join("sequencer.log");
     fs::create_dir_all(&logs_dir)?;
+    Ok(LocalnetContext {
+        lez: resolve_repo_path(project, &project.config.lez, "lez")?,
+        state_path: project.root.join(".scaffold/state/localnet.state"),
+        log_path: logs_dir.join("sequencer.log"),
+        localnet_addr: format!("127.0.0.1:{localnet_port}"),
+        localnet_port,
+        risc0_dev_mode: project.config.localnet.risc0_dev_mode,
+    })
+}
+
+/// Result of a localnet start, exposed through the public API.
+#[derive(Clone, Debug)]
+pub(crate) struct LocalnetStartOutcome {
+    pub(crate) pid: u32,
+    /// `true` when a tracked sequencer was already running and was reused
+    /// instead of spawning a new process.
+    pub(crate) reused: bool,
+    pub(crate) rpc_url: String,
+    pub(crate) state_path: PathBuf,
+    pub(crate) log_path: PathBuf,
+}
+
+/// Result of a localnet stop, exposed through the public API.
+#[derive(Clone, Debug)]
+pub enum LocalnetStopOutcome {
+    /// The tracked sequencer was sent TERM and exited.
+    Stopped { pid: u32 },
+    /// State tracked a pid that is no longer running; the stale state file
+    /// was removed.
+    ClearedStaleState { pid: u32 },
+    /// An unmanaged process is listening on the localnet port; it was left
+    /// alone.
+    ForeignListener { addr: String, pid: Option<u32> },
+    /// Nothing tracked and nothing listening.
+    NotRunning,
+}
+
+/// Start (or reuse) the project's localnet sequencer. Non-printing core used
+/// by both the CLI command and the public API.
+pub(crate) fn localnet_start_for_project(
+    project: &Project,
+    timeout_sec: u64,
+) -> DynResult<LocalnetStartOutcome> {
+    let ctx = localnet_context(project)?;
+    let (cache_root, _) = resolve_cache_root(project)?;
+    ensure_circuits_for_subprocess(&cache_root)?;
+    let (pid, reused) = start_localnet(
+        &ctx.lez,
+        &ctx.state_path,
+        &ctx.log_path,
+        timeout_sec,
+        ctx.localnet_port,
+        ctx.risc0_dev_mode,
+        &ctx.localnet_addr,
+    )?;
+    Ok(LocalnetStartOutcome {
+        pid,
+        reused,
+        rpc_url: format!("http://{}", ctx.localnet_addr),
+        state_path: ctx.state_path,
+        log_path: ctx.log_path,
+    })
+}
+
+/// Stop the project's localnet sequencer. Non-printing core used by both the
+/// CLI command and the public API.
+pub(crate) fn localnet_stop_for_project(project: &Project) -> DynResult<LocalnetStopOutcome> {
+    let ctx = localnet_context(project)?;
+    stop_localnet(&ctx.state_path, ctx.localnet_port)
+}
+
+/// Build the logs report for the public API / `--json` output.
+pub(crate) fn localnet_logs_for_project(
+    project: &Project,
+    tail: usize,
+) -> DynResult<LocalnetLogsReport> {
+    let log_path = project.root.join(".scaffold/logs/sequencer.log");
+    build_logs_report(&log_path, tail)
+}
+
+/// Reset the project's localnet (stop, wipe chain DB, restart, verify block
+/// production). Used by the public API; always operates non-interactively.
+pub(crate) fn localnet_reset_for_project(
+    project: &Project,
+    reset_wallet: bool,
+    verify_timeout_sec: u64,
+) -> DynResult<()> {
+    let ctx = localnet_context(project)?;
+    let (cache_root, _) = resolve_cache_root(project)?;
+    ensure_circuits_for_subprocess(&cache_root)?;
+    cmd_localnet_reset(
+        project,
+        &ctx.lez,
+        &ctx.state_path,
+        &ctx.log_path,
+        &ctx.localnet_addr,
+        false,
+        true,
+        reset_wallet,
+        verify_timeout_sec,
+    )
+}
+
+fn cmd_localnet_in_project(project: &Project, action: LocalnetAction) -> DynResult<()> {
+    let ctx = localnet_context(project)?;
 
     // The standalone `sequencer_service` binary calls into the
     // `logos-blockchain-zksign` runtime, which loads circuit witness
@@ -99,20 +212,32 @@ fn cmd_localnet_in_project(project: &Project, action: LocalnetAction) -> DynResu
     }
 
     match action {
-        LocalnetAction::Start { timeout_sec } => cmd_localnet_start(
-            &lez,
-            &state_path,
-            &log_path,
-            timeout_sec,
-            localnet_port,
-            risc0_dev_mode,
-            &localnet_addr,
-        ),
-        LocalnetAction::Stop => cmd_localnet_stop(&state_path, localnet_port),
-        LocalnetAction::Status { json } => {
-            cmd_localnet_status(&state_path, &log_path, json, &localnet_addr, localnet_port)
+        LocalnetAction::Start { timeout_sec } => {
+            let (pid, _) = start_localnet(
+                &ctx.lez,
+                &ctx.state_path,
+                &ctx.log_path,
+                timeout_sec,
+                ctx.localnet_port,
+                ctx.risc0_dev_mode,
+                &ctx.localnet_addr,
+            )?;
+            println!("localnet ready (sequencer pid={pid})");
+            Ok(())
         }
-        LocalnetAction::Logs { tail, json } => cmd_localnet_logs(&log_path, tail, json),
+        LocalnetAction::Stop => {
+            let outcome = stop_localnet(&ctx.state_path, ctx.localnet_port)?;
+            print_stop_outcome(&outcome, &ctx.localnet_addr);
+            Ok(())
+        }
+        LocalnetAction::Status { json } => cmd_localnet_status(
+            &ctx.state_path,
+            &ctx.log_path,
+            json,
+            &ctx.localnet_addr,
+            ctx.localnet_port,
+        ),
+        LocalnetAction::Logs { tail, json } => cmd_localnet_logs(&ctx.log_path, tail, json),
         LocalnetAction::Reset {
             dry_run,
             yes,
@@ -120,10 +245,10 @@ fn cmd_localnet_in_project(project: &Project, action: LocalnetAction) -> DynResu
             verify_timeout_sec,
         } => cmd_localnet_reset(
             project,
-            &lez,
-            &state_path,
-            &log_path,
-            &localnet_addr,
+            &ctx.lez,
+            &ctx.state_path,
+            &ctx.log_path,
+            &ctx.localnet_addr,
             dry_run,
             yes,
             reset_wallet,
@@ -165,7 +290,10 @@ fn cmd_localnet_stop_outside_project() -> DynResult<()> {
     Ok(())
 }
 
-fn cmd_localnet_start(
+/// Spawn (or reuse) the sequencer and wait for readiness. Returns
+/// `(pid, reused)`; does not print success lines so the public API stays
+/// quiet — callers print their own confirmation.
+fn start_localnet(
     lez: &Path,
     state_path: &Path,
     log_path: &Path,
@@ -173,7 +301,7 @@ fn cmd_localnet_start(
     localnet_port: u16,
     risc0_dev_mode: bool,
     localnet_addr: &str,
-) -> DynResult<()> {
+) -> DynResult<(u32, bool)> {
     ensure_dir_exists(lez, "lez")?;
     let sequencer_bin = lez.join(SEQUENCER_BIN_REL_PATH);
     if !sequencer_bin.exists() {
@@ -187,8 +315,7 @@ fn cmd_localnet_start(
     if let Some(pid) = state.sequencer_pid {
         if pid_running(pid) {
             wait_for_readiness(pid, timeout_sec, log_path, localnet_addr)?;
-            println!("localnet ready (sequencer pid={pid})");
-            return Ok(());
+            return Ok((pid, true));
         }
 
         if state_path.exists() {
@@ -268,8 +395,7 @@ fn cmd_localnet_start(
         return Err(err);
     }
 
-    println!("localnet ready (sequencer pid={sequencer_pid})");
-    Ok(())
+    Ok((sequencer_pid, false))
 }
 
 fn wait_for_readiness(
@@ -308,7 +434,10 @@ fn wait_for_readiness(
     }
 }
 
-fn cmd_localnet_stop(state_path: &Path, localnet_port: u16) -> DynResult<()> {
+/// Stop the tracked sequencer (if any). Non-printing core shared by the CLI
+/// command, the reset flow, and the public API. Informational text lives in
+/// `print_stop_outcome`; the `$ kill` echo follows the global echo setting.
+fn stop_localnet(state_path: &Path, localnet_port: u16) -> DynResult<LocalnetStopOutcome> {
     let localnet_addr = format!("127.0.0.1:{localnet_port}");
     let report = build_status_report(
         state_path,
@@ -317,8 +446,10 @@ fn cmd_localnet_stop(state_path: &Path, localnet_port: u16) -> DynResult<()> {
         localnet_port,
     );
     if let Some(pid) = report.tracked_pid {
-        if report.tracked_running {
-            println!("$ kill {pid} # sequencer");
+        let outcome = if report.tracked_running {
+            if command_echo_enabled() {
+                println!("$ kill {pid} # sequencer");
+            }
             let kill_output = Command::new("kill")
                 .arg(pid.to_string())
                 .output()
@@ -351,30 +482,44 @@ fn cmd_localnet_stop(state_path: &Path, localnet_port: u16) -> DynResult<()> {
             // foreign listener that survived our sequencer, and `localnet
             // start` will surface that with a more specific error.
             let _ = wait_for_port_free(&localnet_addr, Duration::from_secs(5));
+            LocalnetStopOutcome::Stopped { pid }
         } else {
-            println!("sequencer state is stale (pid={pid} not running)");
-        }
+            LocalnetStopOutcome::ClearedStaleState { pid }
+        };
 
         if state_path.exists() {
             fs::remove_file(state_path)?;
         }
-        println!("localnet stopped");
-        return Ok(());
+        return Ok(outcome);
     }
 
     if report.listener_present {
-        let pid_text = report
-            .listener_pid
-            .map(|pid| pid.to_string())
-            .unwrap_or_else(|| "unknown".to_string());
-        println!(
-            "foreign listener detected on {localnet_addr} (pid={pid_text}); not stopping unmanaged process"
-        );
-        return Ok(());
+        return Ok(LocalnetStopOutcome::ForeignListener {
+            addr: localnet_addr,
+            pid: report.listener_pid,
+        });
     }
 
-    println!("localnet not running");
-    Ok(())
+    Ok(LocalnetStopOutcome::NotRunning)
+}
+
+fn print_stop_outcome(outcome: &LocalnetStopOutcome, _localnet_addr: &str) {
+    match outcome {
+        LocalnetStopOutcome::Stopped { .. } => println!("localnet stopped"),
+        LocalnetStopOutcome::ClearedStaleState { pid } => {
+            println!("sequencer state is stale (pid={pid} not running)");
+            println!("localnet stopped");
+        }
+        LocalnetStopOutcome::ForeignListener { addr, pid } => {
+            let pid_text = pid
+                .map(|pid| pid.to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+            println!(
+                "foreign listener detected on {addr} (pid={pid_text}); not stopping unmanaged process"
+            );
+        }
+        LocalnetStopOutcome::NotRunning => println!("localnet not running"),
+    }
 }
 
 fn cmd_localnet_status(
@@ -434,60 +579,60 @@ fn ownership_label(ownership: LocalnetOwnership) -> &'static str {
 }
 
 fn cmd_localnet_logs(log_path: &Path, tail: usize, json: bool) -> DynResult<()> {
-    if !log_path.exists() {
-        if json {
-            print_logs_json(log_path, false, tail, Vec::new())?;
-        } else {
-            println!("log file does not exist yet: {}", log_path.display());
-        }
+    let report = build_logs_report(log_path, tail)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
         return Ok(());
     }
 
-    let content = fs::read_to_string(log_path)
-        .with_context(|| format!("failed to read log file {}", log_path.display()))?;
+    if !report.exists {
+        println!("log file does not exist yet: {}", log_path.display());
+        return Ok(());
+    }
 
-    // Treat a whitespace-only log as empty in BOTH modes. Without this, a log
-    // containing only newlines yields `content.lines() == [""]`, so JSON would
-    // report a non-empty `lines` array — contradicting the LocalnetLogsReport
-    // contract (empty when the log is empty) and the plain-text branch below.
-    if content.trim().is_empty() {
-        if json {
-            return print_logs_json(log_path, true, tail, Vec::new());
-        }
+    if report.lines.is_empty() {
         println!("log file is empty: {}", log_path.display());
         return Ok(());
     }
 
-    let all_lines: Vec<&str> = content.lines().collect();
-    let start = all_lines.len().saturating_sub(tail);
-    let tail_lines = &all_lines[start..];
-
-    if json {
-        let lines = tail_lines.iter().map(|l| l.to_string()).collect();
-        return print_logs_json(log_path, true, tail, lines);
-    }
-
-    for line in tail_lines {
+    for line in &report.lines {
         println!("{line}");
     }
 
     Ok(())
 }
 
-fn print_logs_json(
-    log_path: &Path,
-    exists: bool,
-    tail: usize,
-    lines: Vec<String>,
-) -> DynResult<()> {
-    let report = LocalnetLogsReport {
+/// Build the `LocalnetLogsReport` for a sequencer log file. A whitespace-only
+/// log reports as existing-but-empty (`lines` empty) so JSON consumers can
+/// tell an absent log apart from an empty one without parsing prose.
+fn build_logs_report(log_path: &Path, tail: usize) -> DynResult<LocalnetLogsReport> {
+    let mut report = LocalnetLogsReport {
         log_path: log_path.display().to_string(),
-        exists,
+        exists: false,
         tail,
-        lines,
+        lines: Vec::new(),
     };
-    println!("{}", serde_json::to_string_pretty(&report)?);
-    Ok(())
+
+    if !log_path.exists() {
+        return Ok(report);
+    }
+    report.exists = true;
+
+    let content = fs::read_to_string(log_path)
+        .with_context(|| format!("failed to read log file {}", log_path.display()))?;
+
+    // Treat a whitespace-only log as empty. Without this, a log containing
+    // only newlines yields `content.lines() == [""]`, so JSON would report a
+    // non-empty `lines` array — contradicting the LocalnetLogsReport contract.
+    if content.trim().is_empty() {
+        return Ok(report);
+    }
+
+    let all_lines: Vec<&str> = content.lines().collect();
+    let start = all_lines.len().saturating_sub(tail);
+    report.lines = all_lines[start..].iter().map(|l| l.to_string()).collect();
+    Ok(report)
 }
 
 fn build_status_report(
@@ -774,7 +919,8 @@ pub(crate) fn cmd_localnet_reset(
     }
 
     println!("stopping sequencer…");
-    cmd_localnet_stop(state_path, localnet_port)?;
+    let stop_outcome = stop_localnet(state_path, localnet_port)?;
+    print_stop_outcome(&stop_outcome, localnet_addr);
 
     // `cmd_localnet_stop` sends SIGTERM without waiting, so the port may still
     // be held by our own sequencer for a short window. Poll briefly for it to
@@ -790,7 +936,7 @@ pub(crate) fn cmd_localnet_reset(
     reset_cleanup(project, lez, state_path, reset_wallet)?;
 
     println!("starting sequencer…");
-    cmd_localnet_start(
+    let (pid, _) = start_localnet(
         lez,
         state_path,
         log_path,
@@ -799,6 +945,7 @@ pub(crate) fn cmd_localnet_reset(
         project.config.localnet.risc0_dev_mode,
         localnet_addr,
     )?;
+    println!("localnet ready (sequencer pid={pid})");
 
     println!("waiting for block production…");
     verify_block_production(localnet_addr, verify_timeout_sec)

--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -614,7 +614,12 @@ fn build_logs_report(log_path: &Path, tail: usize) -> DynResult<LocalnetLogsRepo
         lines: Vec::new(),
     };
 
-    if !log_path.exists() {
+    // `try_exists()` (not `exists()`): an unreadable log (permission/IO error)
+    // must surface as an error, not be reported as a missing log file.
+    if !log_path
+        .try_exists()
+        .with_context(|| format!("checking sequencer log at {}", log_path.display()))?
+    {
         return Ok(report);
     }
     report.exists = true;

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -32,6 +32,15 @@ pub(crate) struct NewCommand {
 }
 
 pub(crate) fn cmd_new(cmd: NewCommand) -> DynResult<()> {
+    let cwd = env::current_dir()?;
+    create_project_in(&cwd, cmd)?;
+    Ok(())
+}
+
+/// Create a new project at `base_dir/<cmd.name>` and return the project root.
+/// Used by the CLI (with the current directory) and the public API (with an
+/// explicit parent directory).
+pub(crate) fn create_project_in(base_dir: &Path, cmd: NewCommand) -> DynResult<PathBuf> {
     let template_variant = match cmd.template.as_str() {
         FRAMEWORK_KIND_DEFAULT | FRAMEWORK_KIND_LEZ_FRAMEWORK => cmd.template.clone(),
         other => {
@@ -39,8 +48,7 @@ pub(crate) fn cmd_new(cmd: NewCommand) -> DynResult<()> {
         }
     };
 
-    let cwd = env::current_dir()?;
-    let target = cwd.join(&cmd.name);
+    let target = base_dir.join(&cmd.name);
 
     if target.exists() {
         bail!("target exists: {}", target.display());
@@ -63,7 +71,7 @@ pub(crate) fn cmd_new(cmd: NewCommand) -> DynResult<()> {
             ),
         }
     }
-    result
+    result.map(|()| target)
 }
 
 fn cmd_new_inner(cmd: &NewCommand, target: &Path, template_variant: &str) -> DynResult<()> {

--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -24,9 +24,34 @@ use crate::DynResult;
 
 const REPORT_WARNING: &str = "WARNING: This diagnostics bundle is sanitized on a best-effort basis and may still contain sensitive data. Inspect every file before sharing it publicly.";
 
+/// Outcome of a diagnostics-report run: the archive that was written plus the
+/// manifest describing what was collected, skipped, and redacted.
+#[derive(Clone, Debug)]
+pub(crate) struct ReportOutcome {
+    pub(crate) archive: PathBuf,
+    pub(crate) manifest: ReportManifest,
+}
+
 pub(crate) fn cmd_report(out: Option<PathBuf>, tail: usize) -> DynResult<()> {
     let project = load_project()?;
+    let outcome = report_for_project(&project, out, tail)?;
 
+    println!("report complete");
+    println!("  archive: {}", outcome.archive.display());
+    println!("  included items: {}", outcome.manifest.include_count);
+    println!("  skipped items: {}", outcome.manifest.skip_count);
+    println!("{REPORT_WARNING}");
+
+    Ok(())
+}
+
+/// Collect and pack the sanitized diagnostics archive for `project`. Returns
+/// the archive path and manifest; prints only incidental warnings.
+pub(crate) fn report_for_project(
+    project: &crate::model::Project,
+    out: Option<PathBuf>,
+    tail: usize,
+) -> DynResult<ReportOutcome> {
     let now = unix_timestamp_now()?;
     let output_path = resolve_output_path(&project.root, out, now)?;
 
@@ -40,7 +65,7 @@ pub(crate) fn cmd_report(out: Option<PathBuf>, tail: usize) -> DynResult<()> {
     let staging_dir = reports_dir.join(format!(".tmp-report-{now}-{}", std::process::id()));
     fs::create_dir_all(&staging_dir)?;
 
-    let collection = collect_report_artifacts(&project, tail, now, &staging_dir, &output_path);
+    let collection = collect_report_artifacts(project, tail, now, &staging_dir, &output_path);
 
     let manifest = match collection {
         Ok(manifest) => manifest,
@@ -67,13 +92,10 @@ pub(crate) fn cmd_report(out: Option<PathBuf>, tail: usize) -> DynResult<()> {
         );
     }
 
-    println!("report complete");
-    println!("  archive: {}", output_path.display());
-    println!("  included items: {}", manifest.include_count);
-    println!("  skipped items: {}", manifest.skip_count);
-    println!("{REPORT_WARNING}");
-
-    Ok(())
+    Ok(ReportOutcome {
+        archive: output_path,
+        manifest,
+    })
 }
 
 fn resolve_home_dir_for_scrubbing() -> Option<PathBuf> {
@@ -169,7 +191,7 @@ fn collect_report_artifacts(
     });
 
     set_command_echo(false);
-    let doctor_result = build_doctor_report();
+    let doctor_result = build_doctor_report(project);
     set_command_echo(true);
     match doctor_result {
         Ok(report) => {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -50,6 +50,14 @@ pub(crate) struct RunInvocation {
 
 pub(crate) fn cmd_run(inv: RunInvocation) -> DynResult<()> {
     let project = load_project()?;
+    run_for_project(&project, inv)
+}
+
+/// Execute the `lgs run` pipeline (build → IDL → localnet → topup → deploy →
+/// hooks) for `project`. Streams step progress to stdout. With `inv.watch`
+/// set, blocks in the watch loop until interrupted — API callers normally
+/// leave `watch` off.
+pub(crate) fn run_for_project(project: &Project, inv: RunInvocation) -> DynResult<()> {
     let resolved = project.config.run.resolve_profile(inv.profile.as_deref())?;
     if let Some(name) = inv.profile.as_deref() {
         println!("Using [run.profiles.{name}]");

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -41,16 +41,23 @@ pub(crate) fn cmd_setup(prebuilt: bool) -> DynResult<()> {
     // gripes (circuits artifact, etc.). Tests assert the migration hint
     // wins on pre-v0.2.0 configs.
     let project = load_project()?;
+    setup_for_project(&project, prebuilt)
+}
+
+/// Sync pinned repos and build project-local binaries (sequencer, wallet,
+/// spel) for `project`. Streams build progress to stdout; failures surface as
+/// typed `CommandFailed` errors where an external command is at fault.
+pub(crate) fn setup_for_project(project: &crate::model::Project, prebuilt: bool) -> DynResult<()> {
     ensure_logos_blockchain_circuits_present()?;
-    let lez = resolve_repo_path(&project, &project.config.lez, "lez")?;
-    let spel = resolve_repo_path(&project, &project.config.spel, "spel")?;
+    let lez = resolve_repo_path(project, &project.config.lez, "lez")?;
+    let spel = resolve_repo_path(project, &project.config.spel, "spel")?;
 
     // Both the LEZ standalone-sequencer build below and (downstream) the
     // user-project workspace build pull in `logos-blockchain-{pol,poc,poq,zksign}`
     // build scripts, which panic when their circuits release isn't visible.
     // Materialise it once before any cargo invocation; the export propagates
     // to every subprocess for the rest of the process.
-    let (cache_root, _) = resolve_cache_root(&project)?;
+    let (cache_root, _) = resolve_cache_root(project)?;
     ensure_circuits_for_subprocess(&cache_root)?;
 
     sync_pinned_repo(&project.config.lez, &lez, "lez")?;

--- a/src/commands/spel.rs
+++ b/src/commands/spel.rs
@@ -13,17 +13,27 @@ use crate::DynResult;
 /// user at `setup` rather than failing with a raw exec error.
 pub(crate) fn cmd_spel(args: Vec<String>) -> DynResult<()> {
     let project = load_project()?;
+    let status = spel_passthrough_for_project(&project, &args)?;
+    if !status.success() {
+        std::process::exit(status.code().unwrap_or(1));
+    }
+    Ok(())
+}
+
+/// Run the project-vendored `spel` binary with `args`, forwarding its output,
+/// and return the exit status. The API path uses the returned status instead
+/// of exiting the process.
+pub(crate) fn spel_passthrough_for_project(
+    project: &crate::model::Project,
+    args: &[String],
+) -> DynResult<std::process::ExitStatus> {
     let spel_bin =
-        resolve_repo_path(&project, &project.config.spel, "spel")?.join(SPEL_BIN_REL_PATH);
+        resolve_repo_path(project, &project.config.spel, "spel")?.join(SPEL_BIN_REL_PATH);
     if !spel_bin.exists() {
         bail!(
             "vendored spel binary not found at `{}`\nNext step: run `logos-scaffold setup` to build it.",
             spel_bin.display()
         );
     }
-    let status = Command::new(&spel_bin).args(&args).status()?;
-    if !status.success() {
-        std::process::exit(status.code().unwrap_or(1));
-    }
-    Ok(())
+    Ok(Command::new(&spel_bin).args(args).status()?)
 }

--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -20,9 +20,87 @@ use super::wallet_support::{
 /// rather than continue with uncertain funding. Standalone `wallet topup`
 /// treats both as success (matching prior behavior).
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum TopupOutcome {
+pub enum TopupOutcome {
     Success,
-    ConfirmationTimeout { message: String },
+    /// The topup was submitted but confirmation timed out — funding is
+    /// uncertain. `message` carries the full diagnostic (address, network,
+    /// tx identifier when known).
+    ConfirmationTimeout {
+        message: String,
+    },
+}
+
+/// Captured output of `wallet account list`, shared by `--json` mode and the
+/// public API.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct WalletListReport {
+    /// Rendered wallet command that produced this output.
+    pub command: String,
+    /// Exit code (`128 + signal` when killed by a signal, `-1` if unknown).
+    pub exit_code: i32,
+    /// Best-effort line split of stdout (trimmed, blanks removed).
+    pub accounts: Vec<String>,
+    /// Raw stdout from the wallet binary.
+    pub stdout: String,
+    /// Raw stderr from the wallet binary.
+    pub stderr: String,
+}
+
+/// Run `wallet account list` for `project` and capture the output. Used by
+/// `wallet list --json` and the public API.
+pub(crate) fn wallet_list_for_project(
+    project: &crate::model::Project,
+    long: bool,
+) -> DynResult<WalletListReport> {
+    let wallet = load_wallet_runtime(project)?;
+
+    let mut command = Command::new(&wallet.wallet_binary);
+    command
+        .env(
+            "NSSA_WALLET_HOME_DIR",
+            wallet.wallet_home.as_os_str().to_string_lossy().to_string(),
+        )
+        .arg("account")
+        .arg("list");
+    if long {
+        command.arg("--long");
+    }
+
+    let rendered_command = render_command(&command);
+    let output = command
+        .output()
+        .context("failed to execute wallet list command")?;
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    // Always emit a number: a wallet killed by a signal has no exit code,
+    // so map that to the shell convention `128 + signal` (else -1) rather
+    // than letting `exit_code` serialize as `null`.
+    let exit_code = output.status.code().unwrap_or_else(|| {
+        use std::os::unix::process::ExitStatusExt;
+        output.status.signal().map(|s| 128 + s).unwrap_or(-1)
+    });
+    let accounts: Vec<String> = stdout
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToString::to_string)
+        .collect();
+
+    Ok(WalletListReport {
+        command: rendered_command,
+        exit_code,
+        accounts,
+        stdout,
+        stderr,
+    })
+}
+
+/// Set the project default wallet address; returns the normalized form.
+pub(crate) fn wallet_default_set_for_project(
+    project: &crate::model::Project,
+    address: &str,
+) -> DynResult<String> {
+    write_default_wallet_address(&project.root, address)
 }
 
 #[derive(Debug, Clone)]
@@ -60,6 +138,21 @@ pub(crate) fn cmd_wallet(action: WalletAction) -> DynResult<()> {
 }
 
 fn cmd_wallet_list(project: &crate::model::Project, long: bool, json: bool) -> DynResult<()> {
+    if json {
+        // Capture the inner wallet output and re-emit a structured envelope so
+        // consumers can read `exit_code` instead of guessing success from text.
+        // `accounts` is the best-effort line split; `stdout`/`stderr` keep the
+        // raw output for callers that need the wallet's own formatting.
+        // `command` is the actual rendered invocation (binary + args, so it
+        // reflects `--long`) rather than a hard-coded label.
+        let report = wallet_list_for_project(project, long)?;
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        if report.exit_code != 0 {
+            bail!("wallet account list failed");
+        }
+        return Ok(());
+    }
+
     let wallet = load_wallet_runtime(project)?;
 
     let mut command = Command::new(&wallet.wallet_binary);
@@ -75,52 +168,13 @@ fn cmd_wallet_list(project: &crate::model::Project, long: bool, json: bool) -> D
         command.arg("--long");
     }
 
-    if json {
-        // Capture the inner wallet output and re-emit a structured envelope so
-        // consumers can read `exit_code` instead of guessing success from text.
-        // `accounts` is the best-effort line split; `stdout`/`stderr` keep the
-        // raw output for callers that need the wallet's own formatting.
-        // `command` is the actual rendered invocation (binary + args, so it
-        // reflects `--long`) rather than a hard-coded label.
-        let rendered_command = render_command(&command);
-        let output = command
-            .output()
-            .context("failed to execute wallet list command")?;
-        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        // Always emit a number: a wallet killed by a signal has no exit code,
-        // so map that to the shell convention `128 + signal` (else -1) rather
-        // than letting `exit_code` serialize as `null`.
-        let exit_code = output.status.code().unwrap_or_else(|| {
-            use std::os::unix::process::ExitStatusExt;
-            output.status.signal().map(|s| 128 + s).unwrap_or(-1)
-        });
-        let accounts: Vec<&str> = stdout
-            .lines()
-            .map(str::trim)
-            .filter(|line| !line.is_empty())
-            .collect();
-        let report = json!({
-            "command": rendered_command,
-            "exit_code": exit_code,
-            "accounts": accounts,
-            "stdout": stdout,
-            "stderr": stderr,
-        });
-        println!("{}", serde_json::to_string_pretty(&report)?);
-        if !output.status.success() {
-            bail!("wallet account list failed");
-        }
-        return Ok(());
-    }
-
     run_forwarded(&mut command, "wallet account list")
         .context("failed to execute wallet list command")?;
 
     Ok(())
 }
 
-fn cmd_wallet_proxy(project: &crate::model::Project, args: &[String]) -> DynResult<()> {
+pub(crate) fn cmd_wallet_proxy(project: &crate::model::Project, args: &[String]) -> DynResult<()> {
     if args.is_empty() {
         bail!("wallet passthrough requires at least one argument after `--`. Example: `logos-scaffold wallet -- account list`");
     }
@@ -428,7 +482,7 @@ fn confirmation_timeout_message(
 }
 
 fn cmd_wallet_default_set(project: &crate::model::Project, address: &str) -> DynResult<()> {
-    let normalized_address = write_default_wallet_address(&project.root, address)?;
+    let normalized_address = wallet_default_set_for_project(project, address)?;
     let state_path = wallet_state_path(&project.root);
 
     println!("default wallet updated");

--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -55,11 +55,10 @@ pub(crate) fn wallet_list_for_project(
     let wallet = load_wallet_runtime(project)?;
 
     let mut command = Command::new(&wallet.wallet_binary);
+    // Pass the path as an `OsStr` (not via `to_string_lossy`) so a non-UTF8
+    // wallet-home path reaches the child verbatim instead of being corrupted.
     command
-        .env(
-            "NSSA_WALLET_HOME_DIR",
-            wallet.wallet_home.as_os_str().to_string_lossy().to_string(),
-        )
+        .env("NSSA_WALLET_HOME_DIR", &wallet.wallet_home)
         .arg("account")
         .arg("list");
     if long {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,33 @@
+use std::path::PathBuf;
+
 use thiserror::Error;
+
+/// Structured failure of an external command (cargo, git, wallet, nix, …).
+///
+/// Carries the rendered command line, the step label scaffold attached to the
+/// invocation, the exit code (when the process exited normally), any captured
+/// stdout/stderr, and the log file when output was redirected to one. The
+/// `Display` output is preserved per call site so existing CLI error text is
+/// unchanged; API consumers should read the structured fields instead of
+/// parsing the message.
+#[derive(Debug, Error)]
+#[error("{message}")]
+pub struct CommandFailed {
+    /// Rendered command line (`program arg1 arg2 …`).
+    pub command: String,
+    /// Human-readable step label (e.g. `build wallet`).
+    pub label: String,
+    /// Exit code if the process exited normally; `None` when killed by a
+    /// signal or the status could not be determined.
+    pub exit_code: Option<i32>,
+    /// Captured stdout (empty when output was streamed or logged to a file).
+    pub stdout: String,
+    /// Captured stderr (empty when output was streamed or logged to a file).
+    pub stderr: String,
+    /// Log file holding the full output, when the step captured to one.
+    pub log_path: Option<PathBuf>,
+    pub(crate) message: String,
+}
 
 #[derive(Debug, Error)]
 pub(crate) enum LocalnetError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 pub(crate) type DynResult<T> = anyhow::Result<T>;
 
+pub mod api;
+
 pub(crate) mod circuits;
 pub(crate) mod cli;
 pub(crate) mod cli_help;

--- a/src/model.rs
+++ b/src/model.rs
@@ -163,18 +163,18 @@ pub(crate) struct BasecampState {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
-pub(crate) enum CheckStatus {
+pub enum CheckStatus {
     Pass,
     Warn,
     Fail,
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct CheckRow {
-    pub(crate) status: CheckStatus,
-    pub(crate) name: String,
-    pub(crate) detail: String,
-    pub(crate) remediation: Option<String>,
+pub struct CheckRow {
+    pub status: CheckStatus,
+    pub name: String,
+    pub detail: String,
+    pub remediation: Option<String>,
 }
 
 pub(crate) struct Captured {
@@ -185,7 +185,7 @@ pub(crate) struct Captured {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum LocalnetOwnership {
+pub enum LocalnetOwnership {
     Managed,
     Foreign,
     StaleState,
@@ -194,15 +194,15 @@ pub(crate) enum LocalnetOwnership {
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct LocalnetStatusReport {
-    pub(crate) tracked_pid: Option<u32>,
-    pub(crate) tracked_running: bool,
-    pub(crate) listener_present: bool,
-    pub(crate) listener_pid: Option<u32>,
-    pub(crate) ownership: LocalnetOwnership,
-    pub(crate) ready: bool,
-    pub(crate) log_path: String,
-    pub(crate) remediation: Vec<String>,
+pub struct LocalnetStatusReport {
+    pub tracked_pid: Option<u32>,
+    pub tracked_running: bool,
+    pub listener_present: bool,
+    pub listener_pid: Option<u32>,
+    pub ownership: LocalnetOwnership,
+    pub ready: bool,
+    pub log_path: String,
+    pub remediation: Vec<String>,
 }
 
 /// Machine-readable shape for `localnet logs --json`. Mirrors the human
@@ -210,68 +210,68 @@ pub(crate) struct LocalnetStatusReport {
 /// when the log is missing or empty), and `exists` lets consumers tell an
 /// absent log file apart from an empty one without parsing prose.
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct LocalnetLogsReport {
-    pub(crate) log_path: String,
-    pub(crate) exists: bool,
-    pub(crate) tail: usize,
-    pub(crate) lines: Vec<String>,
+pub struct LocalnetLogsReport {
+    pub log_path: String,
+    pub exists: bool,
+    pub tail: usize,
+    pub lines: Vec<String>,
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct DoctorSummary {
-    pub(crate) pass: usize,
-    pub(crate) warn: usize,
-    pub(crate) fail: usize,
+pub struct DoctorSummary {
+    pub pass: usize,
+    pub warn: usize,
+    pub fail: usize,
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct DoctorReport {
-    pub(crate) status: String,
-    pub(crate) summary: DoctorSummary,
-    pub(crate) checks: Vec<CheckRow>,
-    pub(crate) next_steps: Vec<String>,
+pub struct DoctorReport {
+    pub status: String,
+    pub summary: DoctorSummary,
+    pub checks: Vec<CheckRow>,
+    pub next_steps: Vec<String>,
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct CollectedItem {
-    pub(crate) path: String,
-    pub(crate) source: String,
-    pub(crate) notes: Option<String>,
+pub struct CollectedItem {
+    pub path: String,
+    pub source: String,
+    pub notes: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct SkippedItem {
-    pub(crate) path: String,
-    pub(crate) reason: String,
+pub struct SkippedItem {
+    pub path: String,
+    pub reason: String,
 }
 
 #[derive(Clone, Debug, Default, Serialize)]
-pub(crate) struct RedactionSummary {
-    pub(crate) files_redacted: usize,
-    pub(crate) replacements: usize,
+pub struct RedactionSummary {
+    pub files_redacted: usize,
+    pub replacements: usize,
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct ToolCommandResult {
-    pub(crate) name: String,
-    pub(crate) command: String,
-    pub(crate) status: Option<i32>,
-    pub(crate) stdout: String,
-    pub(crate) stderr: String,
-    pub(crate) error: Option<String>,
+pub struct ToolCommandResult {
+    pub name: String,
+    pub command: String,
+    pub status: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+    pub error: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct ReportManifest {
-    pub(crate) generated_at_unix: u64,
-    pub(crate) project_root: String,
-    pub(crate) output_archive: String,
-    pub(crate) include_count: usize,
-    pub(crate) skip_count: usize,
-    pub(crate) redaction: RedactionSummary,
-    pub(crate) collected: Vec<CollectedItem>,
-    pub(crate) skipped: Vec<SkippedItem>,
-    pub(crate) warnings: Vec<String>,
+pub struct ReportManifest {
+    pub generated_at_unix: u64,
+    pub project_root: String,
+    pub output_archive: String,
+    pub include_count: usize,
+    pub skip_count: usize,
+    pub redaction: RedactionSummary,
+    pub collected: Vec<CollectedItem>,
+    pub skipped: Vec<SkippedItem>,
+    pub warnings: Vec<String>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/process.rs
+++ b/src/process.rs
@@ -6,8 +6,7 @@ use std::process::{Command, Output, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
-use anyhow::bail;
-
+use crate::error::CommandFailed;
 use crate::model::Captured;
 use crate::DynResult;
 
@@ -45,6 +44,12 @@ fn should_echo() -> bool {
     ECHO_COMMANDS.load(Ordering::Relaxed)
 }
 
+/// Whether `$ <cmd>` echo lines are currently enabled. For call sites that
+/// hand-print an echo line instead of going through `run_*`.
+pub(crate) fn command_echo_enabled() -> bool {
+    should_echo()
+}
+
 pub(crate) fn render_command(cmd: &Command) -> String {
     let mut out = cmd.get_program().to_string_lossy().to_string();
     for arg in cmd.get_args() {
@@ -62,9 +67,19 @@ pub(crate) fn run_forwarded(cmd: &mut Command, label: &str) -> DynResult<()> {
     if should_echo() {
         println!("$ {}", render_command(cmd));
     }
+    let command = render_command(cmd);
     let status = cmd.status()?;
     if !status.success() {
-        bail!("{label} failed with {status}");
+        return Err(CommandFailed {
+            message: format!("{label} failed with {status}"),
+            command,
+            label: label.to_string(),
+            exit_code: status.code(),
+            stdout: String::new(),
+            stderr: String::new(),
+            log_path: None,
+        }
+        .into());
     }
     Ok(())
 }
@@ -177,7 +192,16 @@ pub(crate) fn run_logged(cmd: &mut Command, step: &str, log_path: &Path) -> DynR
                 render_command(cmd)
             ));
         }
-        bail!("{detail}");
+        Err(CommandFailed {
+            message: detail,
+            command: render_command(cmd),
+            label: step.to_string(),
+            exit_code: status.code(),
+            stdout: String::new(),
+            stderr: String::new(),
+            log_path: Some(log_path.to_path_buf()),
+        }
+        .into())
     }
 }
 
@@ -194,7 +218,16 @@ fn run_forwarded_with_status(cmd: &mut Command, step: &str) -> DynResult<()> {
         Ok(())
     } else {
         println!("  ✗ {step} ({duration})");
-        bail!("{step} failed with {status}");
+        Err(CommandFailed {
+            message: format!("{step} failed with {status}"),
+            command: render_command(cmd),
+            label: step.to_string(),
+            exit_code: status.code(),
+            stdout: String::new(),
+            stderr: String::new(),
+            log_path: None,
+        }
+        .into())
     }
 }
 
@@ -491,6 +524,7 @@ pub(crate) fn run_capture(cmd: &mut Command, label: &str) -> DynResult<Captured>
     if should_echo() {
         println!("$ {}", render_command(cmd));
     }
+    let command = render_command(cmd);
     let Output {
         status,
         stdout,
@@ -504,7 +538,16 @@ pub(crate) fn run_capture(cmd: &mut Command, label: &str) -> DynResult<Captured>
     };
 
     if !captured.status.success() {
-        bail!("{label} failed: {}", captured.stderr);
+        return Err(CommandFailed {
+            message: format!("{label} failed: {}", captured.stderr),
+            command,
+            label: label.to_string(),
+            exit_code: captured.status.code(),
+            stdout: captured.stdout,
+            stderr: captured.stderr,
+            log_path: None,
+        }
+        .into());
     }
 
     Ok(captured)

--- a/src/process.rs
+++ b/src/process.rs
@@ -64,10 +64,11 @@ pub(crate) fn run_checked(cmd: &mut Command, label: &str) -> DynResult<()> {
 }
 
 pub(crate) fn run_forwarded(cmd: &mut Command, label: &str) -> DynResult<()> {
-    if should_echo() {
-        println!("$ {}", render_command(cmd));
-    }
+    // Render once and reuse for both the echo line and any `CommandFailed`.
     let command = render_command(cmd);
+    if should_echo() {
+        println!("$ {command}");
+    }
     let status = cmd.status()?;
     if !status.success() {
         return Err(CommandFailed {
@@ -521,10 +522,11 @@ mod logged_tests {
 }
 
 pub(crate) fn run_capture(cmd: &mut Command, label: &str) -> DynResult<Captured> {
-    if should_echo() {
-        println!("$ {}", render_command(cmd));
-    }
+    // Render once and reuse for both the echo line and any `CommandFailed`.
     let command = render_command(cmd);
+    if should_echo() {
+        println!("$ {command}");
+    }
     let Output {
         status,
         stdout,

--- a/src/project.rs
+++ b/src/project.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, bail};
+use anyhow::{anyhow, bail, Context};
 
 use crate::config::{parse_config, serialize_config};
 use crate::model::{Project, RepoRef};
@@ -43,7 +43,12 @@ pub(crate) fn load_project() -> DynResult<Project> {
 /// depending on the process working directory.
 pub(crate) fn load_project_at(root: &Path) -> DynResult<Project> {
     let config_path = root.join("scaffold.toml");
-    if !config_path.exists() {
+    // `try_exists()` (not `exists()`): a permission/IO error on the path must
+    // surface as a real error, not be silently reported as a missing config.
+    if !config_path
+        .try_exists()
+        .with_context(|| format!("checking for {}", config_path.display()))?
+    {
         bail!(
             "no scaffold.toml found at {}. Pass the root directory of a logos-scaffold project.",
             root.display()

--- a/src/project.rs
+++ b/src/project.rs
@@ -35,10 +35,26 @@ pub(crate) fn load_project() -> DynResult<Project> {
         )
     })?;
 
+    load_project_at(&root)
+}
+
+/// Load a project from an explicit root directory (no upward discovery).
+/// The API layer uses this so consumers can target a project without
+/// depending on the process working directory.
+pub(crate) fn load_project_at(root: &Path) -> DynResult<Project> {
     let config_path = root.join("scaffold.toml");
+    if !config_path.exists() {
+        bail!(
+            "no scaffold.toml found at {}. Pass the root directory of a logos-scaffold project.",
+            root.display()
+        );
+    }
     let cfg_text = fs::read_to_string(&config_path)?;
     let cfg = parse_config(&cfg_text)?;
-    Ok(Project { root, config: cfg })
+    Ok(Project {
+        root: root.to_path_buf(),
+        config: cfg,
+    })
 }
 
 pub(crate) fn run_in_project_dir(


### PR DESCRIPTION
## Summary

Implements #202: everything the `lgs` CLI does is now available as a typed library surface under `logos_scaffold::api`, so Rust tests and dev tooling can drive scaffold-managed projects without shelling out and parsing text.

### Public surface

- **`api::Project::open(root)` / `discover(start_dir)`** — every operation targets an explicit project root; no cwd discovery in the API path.
- **Operations:** `setup`, `build`, `build_idl`, `build_client`, `deploy`, `run`, `localnet_start/stop/status/logs/reset`, `wallet_list/topup/set_default/passthrough`, `spel` passthrough, `basecamp(BasecampCommand)`, `doctor`, `report`, plus free functions `create_project` / `init_project`.
- **Typed results** shared with the CLI's `--json` output: `LocalnetStatusReport`, `LocalnetLogsReport`, `DoctorReport`, `DeployResult`, `WalletListReport`, `TopupOutcome`, `ReportManifest`, and a new `ProjectPaths` report (cache root + which layer supplied it, repo checkouts, vendored binaries, wallet home, localnet state/log, circuits dir).
- **`LocalnetHandle`** returned by `localnet_start`: pid, `rpc_url()`, state/log paths, `status()`, `logs()`, `stop()`. Dropping it does not kill the sequencer (localnet is a long-lived dev service); stop is explicit.
- **Categorized `api::Error`**: `Config`, `MissingTool`, `RepoState`, `Process`, `Timeout`, `Transport`, `Command(CommandFailed)`, `Other` — mapped from the crate's typed errors by downcast (no string sniffing).
- **`CommandFailed`**: external command failures now carry the rendered command, step label, exit code, captured stdout/stderr, and log path end to end, with CLI-identical `Display` text.

### Internal refactors (no CLI behavior changes)

- `localnet` start/stop/logs extracted into non-printing cores returning typed outcomes; CLI wrappers keep the exact output.
- `deploy`/`setup`/`run`/`report`/`wallet`/`spel`/`basecamp` entry points split into `*_for_project(&Project, …)` cores plus thin CLI wrappers.
- `load_project_at(root)` for explicit-root loading.
- `deploy` core now returns `Vec<DeployResult>`; the CLI wrapper preserves the exit-code contract (non-zero when any program fails).

### Notes / scope

- Long-running build-style operations (`setup`, `build`, `run`, `basecamp`) still stream progress to stdout like the CLI; their *results* are typed. `build`/`run` temporarily chdir to the project root (restored afterwards) — documented in the module docs.
- This API is the library boundary the test-node issues (#203–#208) build on.

## Verification

- `cargo fmt --check`, `cargo check` clean
- `cargo test`: 397 lib tests (10 new API tests, 4 new error-classification tests) + 168 CLI integration tests + 3 doc examples, all green

Closes #202