### PR TITLE
feat(test-node): isolated local sequencer test nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ logos-scaffold localnet stop
 logos-scaffold localnet status [--json]
 logos-scaffold localnet logs [--tail N]
 logos-scaffold localnet reset (--yes | --dry-run) [--reset-wallet] [--verify-timeout-sec N]
+logos-scaffold test-node prepare [--project DIR] [--json]
+logos-scaffold test-node start [--project DIR] [--state DIR] [--port N] [--work-dir DIR] [--preserve-work-dir] [--json]
+logos-scaffold test-node status --node <id|dir> [--json]
+logos-scaffold test-node stop --node <id|dir> [--preserve-work-dir]
+logos-scaffold test-node run [--project DIR] [--state DIR] [--serial | --parallel N] -- <command...>
 logos-scaffold build idl [project-path]
 logos-scaffold build client [project-path]
 logos-scaffold wallet list [--long]
@@ -127,6 +132,7 @@ Each subcommand documents copy-paste examples under `--help`. Global `-q` / `--q
 - `localnet start` waits until localnet is actually ready (`pid alive` + `127.0.0.1:3040` reachable), otherwise fails with diagnostics.
 - `localnet status` distinguishes managed process, stale state, and foreign listeners.
 - `localnet reset` stops the sequencer, clears sequencer chain state, restarts, and verifies blocks. Destructive: `--yes` is required unless `--dry-run` is passed (`--dry-run` prints the plan without changing anything). `--reset-wallet` also deletes the project wallet home and default-address state (irrecoverable).
+- `test-node` manages isolated, short-lived sequencer instances for integration tests — unlike `localnet` (one long-lived developer sequencer per project on a fixed port), each test node gets its own RPC port, config, database, log, and runtime directory under `.scaffold/test-nodes/<id>`. `prepare` verifies the standalone sequencer binary and circuits release are available. `start` spawns a node (`--port 0`/default picks a free port; `--state DIR` seeds the database from a caller-provided state directory) and prints connection details — machine-readable with `--json` (`rpc_url`, `pid`, `state_dir`, `config_path`, `log_path`, `genesis_block_id`, `block_height`). `status --node <id>` reports health and the served RPC URL. `stop --node <id>` terminates only that node and removes its runtime state unless `--preserve-work-dir` is passed. `run -- <cmd>` starts a node, waits for health, runs the command with `LGS_TEST_NODE_RPC_URL` / `LGS_TEST_NODE_PORT` / `LGS_TEST_NODE_STATE_DIR` (and friends) exported, forwards the command's exit status, and stops the node; `--serial` caps machine-wide node concurrency at one for low-resource CI, `--parallel N` at N. The same surface is available in Rust via `logos_scaffold::api::testnode::TestNode`.
 - `wallet list` shows known wallet accounts (`wallet account list`).
 - `wallet topup` checks account state first (`wallet account get --account-id ...`), runs `wallet auth-transfer init --account-id ...` only when the destination is uninitialized, then performs Piñata faucet claim (`wallet pinata claim --to ...`). If address is omitted, scaffold uses project default wallet from `.scaffold/state/wallet.state`.
 - `wallet default set` stores a project-scoped default wallet address in `.scaffold/state/wallet.state`.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,25 @@
 - [FURPS+](FURPS.md) — Functional and non-functional requirements
 - [ADR](ADR.md) — Architecture Decision Records
 
+## Using scaffold as a Rust library
+
+Everything the CLI does is also exposed as a typed Rust API under
+`logos_scaffold::api`, so tests and dev tooling can drive scaffold-managed
+projects (setup, localnet lifecycle, wallet top-ups, deploys, diagnostics)
+without shelling out to `lgs` and parsing text:
+
+```rust
+use logos_scaffold::api::{LocalnetStartOptions, Project};
+
+let project = Project::open("/path/to/my-app")?;
+let node = project.localnet_start(&LocalnetStartOptions::default())?;
+println!("sequencer pid={} rpc={}", node.pid(), node.rpc_url());
+node.stop()?;
+```
+
+See the `api` module rustdoc for the full surface, typed result models, and
+categorized errors.
+
 ## Platform
 
 The CLI is currently Unix-only.

--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -1,0 +1,201 @@
+//! Public error type for the scaffold API.
+//!
+//! Every API entry point returns [`Error`], which buckets failures into the
+//! categories consumers need to branch on: configuration problems, missing
+//! tools, repository state, managed-process failures, timeouts, transport
+//! failures, and structured external-command failures. Anything that does not
+//! fit a category surfaces as [`Error::Other`] with the full error chain
+//! preserved.
+
+use std::path::PathBuf;
+
+pub use crate::error::CommandFailed;
+use crate::error::{LocalnetError, ResetError};
+
+/// Result alias used by every API entry point.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Categorized API error.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+    /// `scaffold.toml` is missing, unparseable, on an unsupported schema
+    /// version, or an option value is invalid.
+    #[error("configuration error: {message}")]
+    Config { message: String },
+
+    /// A required binary or artifact is missing (sequencer, wallet, spel,
+    /// circuits release, …). `path` is the location that was probed, when
+    /// known.
+    #[error("{message}")]
+    MissingTool {
+        message: String,
+        path: Option<PathBuf>,
+    },
+
+    /// A pinned repository checkout is dirty, missing, or not at the
+    /// configured pin.
+    #[error("repository state error: {message}")]
+    RepoState { message: String },
+
+    /// A managed long-lived process failed (sequencer exited before ready,
+    /// refused to stop, a foreign process holds its port, …).
+    #[error("{message}")]
+    Process {
+        message: String,
+        /// Tail of the process log when one was captured.
+        log_tail: Option<String>,
+    },
+
+    /// An operation did not complete within its deadline.
+    #[error("{message}")]
+    Timeout { message: String, timeout_sec: u64 },
+
+    /// An RPC/HTTP transport failure talking to the sequencer or a remote
+    /// endpoint. Distinct from business-level rejections.
+    #[error("transport error: {message}")]
+    Transport { message: String },
+
+    /// An external command exited non-zero. Carries the rendered command,
+    /// exit code, and captured diagnostic output.
+    #[error(transparent)]
+    Command(CommandFailed),
+
+    /// Uncategorized failure; the full `anyhow` chain is preserved.
+    #[error(transparent)]
+    Other(anyhow::Error),
+}
+
+/// Map an internal `anyhow::Error` onto the public categories by downcasting
+/// the typed errors the crate produces. Unknown errors pass through as
+/// [`Error::Other`] — no string sniffing.
+pub(crate) fn classify(err: anyhow::Error) -> Error {
+    let err = match err.downcast::<CommandFailed>() {
+        Ok(failure) => return Error::Command(failure),
+        Err(err) => err,
+    };
+
+    let err = match err.downcast::<LocalnetError>() {
+        Ok(localnet) => {
+            let message = localnet.to_string();
+            return match localnet {
+                LocalnetError::MissingSequencerBinary { path } => Error::MissingTool {
+                    message,
+                    path: Some(PathBuf::from(path)),
+                },
+                LocalnetError::ExitedBeforeReady { log_tail, .. } => Error::Process {
+                    message,
+                    log_tail: Some(log_tail),
+                },
+                LocalnetError::StartTimeout { timeout_sec, .. }
+                | LocalnetError::StopTimeout { timeout_sec, .. } => Error::Timeout {
+                    message,
+                    timeout_sec,
+                },
+                LocalnetError::StopKillFailed { .. } => Error::Process {
+                    message,
+                    log_tail: None,
+                },
+            };
+        }
+        Err(err) => err,
+    };
+
+    let err = match err.downcast::<ResetError>() {
+        Ok(reset) => {
+            let message = reset.to_string();
+            return match reset {
+                ResetError::ForeignListener { .. } => Error::Process {
+                    message,
+                    log_tail: None,
+                },
+                ResetError::BlocksNotProduced { timeout_sec } => Error::Timeout {
+                    message,
+                    timeout_sec,
+                },
+                ResetError::VerificationPollFailed(_) => Error::Transport { message },
+            };
+        }
+        Err(err) => err,
+    };
+
+    let err = match err.downcast::<crate::commands::wallet_support::RpcReachabilityError>() {
+        Ok(rpc) => {
+            return Error::Transport {
+                message: rpc.to_string(),
+            }
+        }
+        Err(err) => err,
+    };
+
+    Error::Other(err)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_maps_command_failed() {
+        let err: anyhow::Error = CommandFailed {
+            message: "build wallet failed with exit status: 1".to_string(),
+            command: "cargo build".to_string(),
+            label: "build wallet".to_string(),
+            exit_code: Some(1),
+            stdout: String::new(),
+            stderr: "boom".to_string(),
+            log_path: None,
+        }
+        .into();
+        match classify(err) {
+            Error::Command(failure) => {
+                assert_eq!(failure.exit_code, Some(1));
+                assert_eq!(failure.command, "cargo build");
+                assert_eq!(failure.stderr, "boom");
+            }
+            other => panic!("expected Command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_maps_missing_sequencer_to_missing_tool() {
+        let err: anyhow::Error = LocalnetError::MissingSequencerBinary {
+            path: "/tmp/lez/target/release/sequencer_service".to_string(),
+        }
+        .into();
+        match classify(err) {
+            Error::MissingTool { path, .. } => {
+                assert_eq!(
+                    path.as_deref(),
+                    Some(std::path::Path::new(
+                        "/tmp/lez/target/release/sequencer_service"
+                    ))
+                );
+            }
+            other => panic!("expected MissingTool, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_maps_start_timeout_to_timeout() {
+        let err: anyhow::Error = LocalnetError::StartTimeout {
+            timeout_sec: 20,
+            pid: 1234,
+            log_tail: "tail".to_string(),
+        }
+        .into();
+        match classify(err) {
+            Error::Timeout { timeout_sec, .. } => assert_eq!(timeout_sec, 20),
+            other => panic!("expected Timeout, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_passes_unknown_errors_through() {
+        let err = anyhow::anyhow!("something else");
+        match classify(err) {
+            Error::Other(inner) => assert_eq!(inner.to_string(), "something else"),
+            other => panic!("expected Other, got {other:?}"),
+        }
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -87,6 +87,7 @@
 //! ```
 
 mod error;
+pub mod testnode;
 
 use std::path::{Path, PathBuf};
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,0 +1,814 @@
+//! Public Rust API for logos-scaffold.
+//!
+//! Everything the `lgs` / `logos-scaffold` CLI can do is available here as a
+//! typed library surface, so Rust tests and dev tooling can drive
+//! scaffold-managed projects without shelling out and parsing text.
+//!
+//! Design rules:
+//!
+//! - Every operation takes an **explicit project root** (via
+//!   [`Project::open`] / [`Project::discover`]); nothing depends on the
+//!   process working directory except where noted below.
+//! - Every operation returns **typed results** ([`LocalnetStatusReport`],
+//!   [`DoctorReport`], [`DeployResult`], …) — the same models that back the
+//!   CLI's `--json` output — and **categorized errors** ([`Error`]).
+//! - Operations that start long-lived processes return handles
+//!   ([`LocalnetHandle`]) exposing status and stop/cleanup.
+//! - Failures of external commands surface as [`CommandFailed`] with the
+//!   rendered command, exit code, and captured diagnostics.
+//!
+//! Long-running build-style operations ([`Project::setup`],
+//! [`Project::build`], [`Project::run`], [`Project::basecamp`]) stream their
+//! progress to stdout/stderr exactly like the CLI; their *results* are still
+//! typed. [`Project::build`] and [`Project::run`] temporarily change the
+//! process working directory (restored afterwards), so do not run them
+//! concurrently from multiple threads.
+//!
+//! # Examples
+//!
+//! Set up a project and manage its localnet:
+//!
+//! ```no_run
+//! use logos_scaffold::api::{LocalnetStartOptions, Project, SetupOptions};
+//!
+//! fn main() -> logos_scaffold::api::Result<()> {
+//!     let project = Project::open("/path/to/my-app")?;
+//!     project.setup(&SetupOptions::default())?;
+//!
+//!     let node = project.localnet_start(&LocalnetStartOptions::default())?;
+//!     println!("sequencer pid={} rpc={}", node.pid(), node.rpc_url());
+//!     assert!(node.status().ready);
+//!
+//!     node.stop()?;
+//!     Ok(())
+//! }
+//! ```
+//!
+//! Top up the default wallet and deploy:
+//!
+//! ```no_run
+//! use logos_scaffold::api::{DeployOptions, Project, TopupOptions, TopupOutcome};
+//!
+//! fn main() -> logos_scaffold::api::Result<()> {
+//!     let project = Project::open("/path/to/my-app")?;
+//!
+//!     match project.wallet_topup(&TopupOptions::default())? {
+//!         TopupOutcome::Success => {}
+//!         TopupOutcome::ConfirmationTimeout { message } => {
+//!             eprintln!("funding uncertain: {message}");
+//!         }
+//!     }
+//!
+//!     for result in project.deploy(&DeployOptions::default())? {
+//!         println!("{}: {:?} (tx={:?})", result.program, result.status, result.tx);
+//!     }
+//!     Ok(())
+//! }
+//! ```
+//!
+//! Run diagnostics and collect a report bundle:
+//!
+//! ```no_run
+//! use logos_scaffold::api::{Project, ReportOptions};
+//!
+//! fn main() -> logos_scaffold::api::Result<()> {
+//!     let project = Project::open("/path/to/my-app")?;
+//!
+//!     let doctor = project.doctor()?;
+//!     println!(
+//!         "doctor: {} ({} pass / {} warn / {} fail)",
+//!         doctor.status, doctor.summary.pass, doctor.summary.warn, doctor.summary.fail
+//!     );
+//!
+//!     let report = project.report(&ReportOptions::default())?;
+//!     println!("archive at {}", report.archive.display());
+//!     Ok(())
+//! }
+//! ```
+
+mod error;
+
+use std::path::{Path, PathBuf};
+
+pub use error::{CommandFailed, Error, Result};
+
+pub use crate::commands::deploy::{DeployResult, DeployStatus};
+pub use crate::commands::wallet::{TopupOutcome, WalletListReport};
+pub use crate::model::{
+    CheckRow, CheckStatus, CollectedItem, DoctorReport, DoctorSummary, LocalnetLogsReport,
+    LocalnetOwnership, LocalnetStatusReport, RedactionSummary, ReportManifest, SkippedItem,
+    ToolCommandResult,
+};
+
+use crate::commands::basecamp::{basecamp_for_project, BasecampAction};
+use crate::commands::build::cmd_build_shortcut;
+use crate::commands::client::generate_clients_from_current_idl;
+use crate::commands::deploy::deploy_for_project;
+use crate::commands::doctor::build_doctor_report;
+use crate::commands::idl::build_idl_for_current_project;
+use crate::commands::init::cmd_init_at;
+pub use crate::commands::localnet::LocalnetStopOutcome;
+
+use crate::commands::localnet::{
+    build_localnet_status_for_project, localnet_logs_for_project, localnet_reset_for_project,
+    localnet_start_for_project, localnet_stop_for_project,
+};
+use crate::commands::new::{create_project_in, NewCommand};
+use crate::commands::report::report_for_project;
+use crate::commands::run::{run_for_project, RunInvocation};
+use crate::commands::setup::setup_for_project;
+use crate::commands::spel::spel_passthrough_for_project;
+use crate::commands::wallet::{
+    cmd_wallet_proxy, cmd_wallet_topup_inner, wallet_default_set_for_project,
+    wallet_list_for_project,
+};
+use crate::constants::{
+    DEFAULT_RUN_LOCALNET_TIMEOUT_SEC, SEQUENCER_BIN_REL_PATH, SPEL_BIN_REL_PATH,
+    WALLET_BIN_REL_PATH,
+};
+use crate::project::{find_project_root, load_project_at, resolve_cache_root, resolve_repo_path};
+
+/// A scaffold-managed project, addressed by an explicit root directory.
+///
+/// This is the entry point of the API: open (or discover) a project once,
+/// then call operations on it. The handle is cheap to clone.
+#[derive(Clone, Debug)]
+pub struct Project {
+    inner: crate::model::Project,
+}
+
+impl Project {
+    /// Open the project whose root directory is `root` (the directory that
+    /// contains `scaffold.toml`). No upward discovery happens; pass the exact
+    /// root. Configuration problems surface as [`Error::Config`].
+    pub fn open(root: impl AsRef<Path>) -> Result<Self> {
+        let inner = load_project_at(root.as_ref()).map_err(|err| Error::Config {
+            message: format!("{err:#}"),
+        })?;
+        Ok(Self { inner })
+    }
+
+    /// Discover a project by walking upward from `start_dir` until a
+    /// directory containing `scaffold.toml` is found, then open it.
+    pub fn discover(start_dir: impl AsRef<Path>) -> Result<Self> {
+        let start = start_dir.as_ref().to_path_buf();
+        let root = find_project_root(start.clone()).ok_or_else(|| Error::Config {
+            message: format!(
+                "no scaffold.toml found in {} or any parent directory",
+                start.display()
+            ),
+        })?;
+        Self::open(root)
+    }
+
+    /// The project root directory.
+    pub fn root(&self) -> &Path {
+        &self.inner.root
+    }
+
+    /// The localnet RPC URL this project is configured for
+    /// (`http://127.0.0.1:<localnet.port>`).
+    pub fn localnet_rpc_url(&self) -> String {
+        format!("http://127.0.0.1:{}", self.inner.config.localnet.port)
+    }
+
+    /// Resolve every path scaffold derives for this project: cache root,
+    /// pinned repo checkouts, vendored binaries, wallet home, localnet state
+    /// and log files, and the circuits directory. Nothing is created or
+    /// downloaded; paths are reported whether or not they exist yet.
+    pub fn paths(&self) -> Result<ProjectPaths> {
+        let (cache_root, source) = resolve_cache_root(&self.inner).map_err(error::classify)?;
+        let lez_repo = resolve_repo_path(&self.inner, &self.inner.config.lez, "lez")
+            .map_err(error::classify)?;
+        let spel_repo = resolve_repo_path(&self.inner, &self.inner.config.spel, "spel")
+            .map_err(error::classify)?;
+        let circuits_dir =
+            crate::circuits::circuits_dir_for_cache_root(&cache_root).map_err(error::classify)?;
+        Ok(ProjectPaths {
+            root: self.inner.root.clone(),
+            scaffold_toml: self.inner.root.join("scaffold.toml"),
+            cache_root,
+            cache_root_source: source.label().to_string(),
+            sequencer_binary: lez_repo.join(SEQUENCER_BIN_REL_PATH),
+            wallet_binary: lez_repo.join(WALLET_BIN_REL_PATH),
+            spel_binary: spel_repo.join(SPEL_BIN_REL_PATH),
+            lez_repo,
+            spel_repo,
+            wallet_home: self.inner.root.join(&self.inner.config.wallet_home_dir),
+            localnet_state: self.inner.root.join(".scaffold/state/localnet.state"),
+            sequencer_log: self.inner.root.join(".scaffold/logs/sequencer.log"),
+            circuits_dir,
+        })
+    }
+
+    // ── setup / build / deploy / run ───────────────────────────────────────
+
+    /// Sync pinned repos and build the project-local binaries (sequencer,
+    /// wallet, spel). Streams build progress to stdout; external-command
+    /// failures surface as [`Error::Command`].
+    pub fn setup(&self, options: &SetupOptions) -> Result<()> {
+        setup_for_project(&self.inner, options.prebuilt).map_err(error::classify)
+    }
+
+    /// Build the project workspace and guest programs (chains `setup`
+    /// internally, mirroring `lgs build`). Temporarily changes the process
+    /// working directory to the project root.
+    pub fn build(&self, options: &BuildOptions) -> Result<()> {
+        cmd_build_shortcut(Some(self.inner.root.clone()), options.prebuilt).map_err(error::classify)
+    }
+
+    /// Build IDL files for the current project (framework projects only).
+    /// Temporarily changes the process working directory to the project root.
+    pub fn build_idl(&self) -> Result<()> {
+        crate::project::run_in_project_dir(Some(&self.inner.root), || {
+            build_idl_for_current_project()
+        })
+        .map_err(error::classify)
+    }
+
+    /// Generate client code from the current IDL files (framework projects
+    /// only). Temporarily changes the process working directory to the
+    /// project root.
+    pub fn build_client(&self) -> Result<()> {
+        crate::project::run_in_project_dir(Some(&self.inner.root), || {
+            generate_clients_from_current_idl()
+        })
+        .map_err(error::classify)
+    }
+
+    /// Deploy guest programs to the running localnet. Returns one
+    /// [`DeployResult`] per attempted program; inspect `status` to decide
+    /// whether failures are fatal — partial failure is **not** an `Err`.
+    pub fn deploy(&self, options: &DeployOptions) -> Result<Vec<DeployResult>> {
+        deploy_for_project(
+            &self.inner,
+            options.program.clone(),
+            options.program_path.clone(),
+            false,
+        )
+        .map_err(error::classify)
+    }
+
+    /// Execute the full run pipeline: build → IDL → localnet → wallet topup →
+    /// deploy → post-deploy hooks. Streams step progress to stdout and
+    /// temporarily changes the process working directory to the project root.
+    /// Watch mode is CLI-only.
+    pub fn run(&self, options: &RunOptions) -> Result<()> {
+        run_for_project(
+            &self.inner,
+            RunInvocation {
+                profile: options.profile.clone(),
+                reset: options.reset,
+                post_deploy_override: options.post_deploy_override.clone(),
+                localnet_timeout_sec: Some(
+                    options
+                        .localnet_timeout_sec
+                        .unwrap_or(DEFAULT_RUN_LOCALNET_TIMEOUT_SEC),
+                ),
+                watch: false,
+                watch_debounce_ms: None,
+            },
+        )
+        .map_err(error::classify)
+    }
+
+    // ── localnet lifecycle ─────────────────────────────────────────────────
+
+    /// Start (or reuse) the project's localnet sequencer and wait until it is
+    /// ready. Returns a [`LocalnetHandle`] exposing the pid, RPC URL, state
+    /// and log paths, plus status/stop operations. The sequencer keeps
+    /// running when the handle is dropped — stop it explicitly.
+    pub fn localnet_start(&self, options: &LocalnetStartOptions) -> Result<LocalnetHandle> {
+        let outcome = localnet_start_for_project(&self.inner, options.timeout_sec)
+            .map_err(error::classify)?;
+        Ok(LocalnetHandle {
+            project: self.inner.clone(),
+            pid: outcome.pid,
+            reused: outcome.reused,
+            rpc_url: outcome.rpc_url,
+            state_path: outcome.state_path,
+            log_path: outcome.log_path,
+        })
+    }
+
+    /// Stop the tracked localnet sequencer, if any. Never touches unmanaged
+    /// (foreign) listeners; see [`LocalnetStopOutcome`].
+    pub fn localnet_stop(&self) -> Result<LocalnetStopOutcome> {
+        localnet_stop_for_project(&self.inner).map_err(error::classify)
+    }
+
+    /// Current localnet status (tracked pid, listener, ownership, readiness,
+    /// remediation hints). Same model as `lgs localnet status --json`.
+    pub fn localnet_status(&self) -> LocalnetStatusReport {
+        build_localnet_status_for_project(&self.inner)
+    }
+
+    /// Tail of the sequencer log. Same model as `lgs localnet logs --json`.
+    pub fn localnet_logs(&self, tail: usize) -> Result<LocalnetLogsReport> {
+        localnet_logs_for_project(&self.inner, tail).map_err(error::classify)
+    }
+
+    /// Reset the localnet: stop the sequencer, wipe its chain database
+    /// (and optionally the wallet), restart, and verify block production.
+    /// **Destructive** — equivalent to `lgs localnet reset --yes`.
+    pub fn localnet_reset(&self, options: &LocalnetResetOptions) -> Result<()> {
+        localnet_reset_for_project(
+            &self.inner,
+            options.reset_wallet,
+            options.verify_timeout_sec,
+        )
+        .map_err(error::classify)
+    }
+
+    // ── wallet ─────────────────────────────────────────────────────────────
+
+    /// List wallet accounts via the vendored wallet binary, returning the
+    /// captured output. `long` mirrors `wallet list --long`.
+    pub fn wallet_list(&self, long: bool) -> Result<WalletListReport> {
+        wallet_list_for_project(&self.inner, long).map_err(error::classify)
+    }
+
+    /// Top up a wallet from the localnet faucet. With `address: None`, the
+    /// project's default wallet is used. A [`TopupOutcome::ConfirmationTimeout`]
+    /// means the submission reached the sequencer but confirmation timed out —
+    /// funding is uncertain, not failed.
+    pub fn wallet_topup(&self, options: &TopupOptions) -> Result<TopupOutcome> {
+        cmd_wallet_topup_inner(&self.inner, options.address.clone(), false, false)
+            .map_err(error::classify)
+    }
+
+    /// Set the project's default wallet address; returns the normalized form
+    /// (`Public/<base58>` or `Private/<base58>`).
+    pub fn wallet_set_default(&self, address: &str) -> Result<String> {
+        wallet_default_set_for_project(&self.inner, address).map_err(error::classify)
+    }
+
+    /// Forward raw arguments to the vendored wallet binary with the project's
+    /// wallet environment (`NSSA_WALLET_HOME_DIR`), streaming its output.
+    /// Non-zero exit surfaces as [`Error::Command`].
+    pub fn wallet_passthrough(&self, args: &[String]) -> Result<()> {
+        cmd_wallet_proxy(&self.inner, args).map_err(error::classify)
+    }
+
+    // ── passthrough / basecamp / diagnostics ──────────────────────────────
+
+    /// Forward arguments to the project-vendored `spel` binary, streaming its
+    /// output, and return its exit status (the API never exits the process).
+    pub fn spel(&self, args: &[String]) -> Result<std::process::ExitStatus> {
+        spel_passthrough_for_project(&self.inner, args).map_err(error::classify)
+    }
+
+    /// Execute a basecamp flow (setup, modules, install, launch, develop,
+    /// build-portable, doctor). Streams progress to stdout like the CLI.
+    pub fn basecamp(&self, command: BasecampCommand) -> Result<()> {
+        basecamp_for_project(self.inner.clone(), command.into_action()).map_err(error::classify)
+    }
+
+    /// Run all health checks and return the structured report. Same model as
+    /// `lgs doctor --json`; a report with failing checks is still `Ok` — read
+    /// `summary.fail`.
+    pub fn doctor(&self) -> Result<DoctorReport> {
+        // Suppress `$ <cmd>` echoes from the probe subprocesses; the report
+        // is the product here, not the console transcript.
+        let _echo = crate::process::EchoGuard::suppress();
+        build_doctor_report(&self.inner).map_err(error::classify)
+    }
+
+    /// Collect a sanitized diagnostics archive. Returns the archive path and
+    /// the manifest of collected/skipped items.
+    pub fn report(&self, options: &ReportOptions) -> Result<ReportOutcome> {
+        let outcome = report_for_project(&self.inner, options.out.clone(), options.tail)
+            .map_err(error::classify)?;
+        Ok(ReportOutcome {
+            archive: outcome.archive,
+            manifest: outcome.manifest,
+        })
+    }
+}
+
+/// Create a new scaffold project at `parent_dir/<options.name>` and return a
+/// handle to it. Equivalent to `lgs new` run from `parent_dir`.
+pub fn create_project(
+    parent_dir: impl AsRef<Path>,
+    options: CreateProjectOptions,
+) -> Result<Project> {
+    let root = create_project_in(
+        parent_dir.as_ref(),
+        NewCommand {
+            name: options.name,
+            template: options.template,
+            vendor_deps: options.vendor_deps,
+            lez_path: options.lez_path,
+            cache_root: options.cache_root,
+        },
+    )
+    .map_err(error::classify)?;
+    Project::open(root)
+}
+
+/// Initialize (or migrate) `scaffold.toml` in an existing directory and
+/// return a handle to the project. Equivalent to `lgs init`.
+pub fn init_project(dir: impl AsRef<Path>, options: InitProjectOptions) -> Result<Project> {
+    cmd_init_at(dir.as_ref(), "logos-scaffold", false, options.no_backup)
+        .map_err(error::classify)?;
+    Project::open(dir.as_ref())
+}
+
+/// Handle to a started localnet sequencer.
+///
+/// Dropping the handle does **not** stop the sequencer — localnet is a
+/// long-lived development service. Call [`LocalnetHandle::stop`] for
+/// deterministic teardown.
+#[derive(Clone, Debug)]
+pub struct LocalnetHandle {
+    project: crate::model::Project,
+    pid: u32,
+    reused: bool,
+    rpc_url: String,
+    state_path: PathBuf,
+    log_path: PathBuf,
+}
+
+impl LocalnetHandle {
+    /// Pid of the sequencer process.
+    pub fn pid(&self) -> u32 {
+        self.pid
+    }
+
+    /// `true` when an already-running tracked sequencer was reused instead of
+    /// spawning a new process.
+    pub fn reused(&self) -> bool {
+        self.reused
+    }
+
+    /// JSON-RPC endpoint of the sequencer (`http://127.0.0.1:<port>`).
+    pub fn rpc_url(&self) -> &str {
+        &self.rpc_url
+    }
+
+    /// Path of the localnet state file tracking the sequencer pid.
+    pub fn state_path(&self) -> &Path {
+        &self.state_path
+    }
+
+    /// Path of the sequencer log file.
+    pub fn log_path(&self) -> &Path {
+        &self.log_path
+    }
+
+    /// Current status (tracked pid, listener, ownership, readiness).
+    pub fn status(&self) -> LocalnetStatusReport {
+        build_localnet_status_for_project(&self.project)
+    }
+
+    /// Tail of the sequencer log.
+    pub fn logs(&self, tail: usize) -> Result<LocalnetLogsReport> {
+        localnet_logs_for_project(&self.project, tail).map_err(error::classify)
+    }
+
+    /// Stop the sequencer and clean up the state file.
+    pub fn stop(&self) -> Result<LocalnetStopOutcome> {
+        localnet_stop_for_project(&self.project).map_err(error::classify)
+    }
+}
+
+/// Every path scaffold derives for a project. Reported as configured/derived;
+/// existence is not guaranteed (run [`Project::setup`] to materialise
+/// binaries, repos, and circuits).
+#[derive(Clone, Debug)]
+pub struct ProjectPaths {
+    pub root: PathBuf,
+    pub scaffold_toml: PathBuf,
+    /// Resolved cache root (env override → scaffold.toml → platform default).
+    pub cache_root: PathBuf,
+    /// Which layer supplied `cache_root` (e.g. `LOGOS_SCAFFOLD_CACHE_ROOT`,
+    /// `scaffold.toml [scaffold].cache_root`, `$XDG_CACHE_HOME`).
+    pub cache_root_source: String,
+    /// Pinned LEZ checkout directory.
+    pub lez_repo: PathBuf,
+    /// Pinned spel checkout directory.
+    pub spel_repo: PathBuf,
+    /// Standalone sequencer binary built by `setup`.
+    pub sequencer_binary: PathBuf,
+    /// Wallet binary built by `setup`.
+    pub wallet_binary: PathBuf,
+    /// Vendored spel binary built by `setup`.
+    pub spel_binary: PathBuf,
+    /// Project wallet home directory.
+    pub wallet_home: PathBuf,
+    /// Localnet state file tracking the sequencer pid.
+    pub localnet_state: PathBuf,
+    /// Sequencer log file.
+    pub sequencer_log: PathBuf,
+    /// Circuits release directory (env override or cache location).
+    pub circuits_dir: PathBuf,
+}
+
+/// Options for [`Project::setup`].
+#[derive(Clone, Debug, Default)]
+pub struct SetupOptions {
+    /// Download prebuilt binaries instead of compiling from source, falling
+    /// back to a source build when no prebuilt exists for the pinned commit.
+    pub prebuilt: bool,
+}
+
+/// Options for [`Project::build`].
+#[derive(Clone, Debug, Default)]
+pub struct BuildOptions {
+    /// See [`SetupOptions::prebuilt`].
+    pub prebuilt: bool,
+}
+
+/// Options for [`Project::deploy`].
+#[derive(Clone, Debug, Default)]
+pub struct DeployOptions {
+    /// Deploy only this discovered program (default: all).
+    pub program: Option<String>,
+    /// Deploy a single ELF directly, skipping discovery.
+    pub program_path: Option<PathBuf>,
+}
+
+/// Options for [`Project::run`].
+#[derive(Clone, Debug, Default)]
+pub struct RunOptions {
+    /// Named `[run.profiles.<name>]` profile to use.
+    pub profile: Option<String>,
+    /// Override the profile's `reset` flag.
+    pub reset: Option<bool>,
+    /// Override the post-deploy hooks.
+    pub post_deploy_override: Option<Vec<String>>,
+    /// Seconds to wait for the sequencer when `run` starts localnet itself
+    /// (default: 120).
+    pub localnet_timeout_sec: Option<u64>,
+}
+
+/// Options for [`Project::localnet_start`].
+#[derive(Clone, Debug)]
+pub struct LocalnetStartOptions {
+    /// Seconds to wait for the sequencer to become ready (default: 20).
+    pub timeout_sec: u64,
+}
+
+impl Default for LocalnetStartOptions {
+    fn default() -> Self {
+        Self { timeout_sec: 20 }
+    }
+}
+
+/// Options for [`Project::localnet_reset`].
+#[derive(Clone, Debug)]
+pub struct LocalnetResetOptions {
+    /// Also delete the wallet home and wallet state (irrecoverable).
+    pub reset_wallet: bool,
+    /// Seconds to wait for post-reset block production (default: 30).
+    pub verify_timeout_sec: u64,
+}
+
+impl Default for LocalnetResetOptions {
+    fn default() -> Self {
+        Self {
+            reset_wallet: false,
+            verify_timeout_sec: 30,
+        }
+    }
+}
+
+/// Options for [`Project::wallet_topup`].
+#[derive(Clone, Debug, Default)]
+pub struct TopupOptions {
+    /// Destination address; `None` uses the project default wallet.
+    pub address: Option<String>,
+}
+
+/// Options for [`Project::report`].
+#[derive(Clone, Debug)]
+pub struct ReportOptions {
+    /// Output archive path (default: `.scaffold/reports/<timestamp>.tar.gz`).
+    pub out: Option<PathBuf>,
+    /// How many log lines to include per collected log (default: 500).
+    pub tail: usize,
+}
+
+impl Default for ReportOptions {
+    fn default() -> Self {
+        Self {
+            out: None,
+            tail: 500,
+        }
+    }
+}
+
+/// Result of [`Project::report`]: the written archive and its manifest.
+#[derive(Clone, Debug)]
+pub struct ReportOutcome {
+    pub archive: PathBuf,
+    pub manifest: ReportManifest,
+}
+
+/// Options for [`init_project`].
+#[derive(Clone, Debug, Default)]
+pub struct InitProjectOptions {
+    /// Skip writing `scaffold.toml.bak` when migrating an existing config.
+    pub no_backup: bool,
+}
+
+/// Options for [`create_project`].
+#[derive(Clone, Debug)]
+pub struct CreateProjectOptions {
+    /// Project (directory) name.
+    pub name: String,
+    /// Template name (`default` or `lez-framework`).
+    pub template: String,
+    /// Vendor pinned repos into the project instead of the shared cache.
+    pub vendor_deps: bool,
+    /// Use an existing local LEZ checkout instead of cloning.
+    pub lez_path: Option<PathBuf>,
+    /// Override the cache root recorded in `scaffold.toml`.
+    pub cache_root: Option<PathBuf>,
+}
+
+impl CreateProjectOptions {
+    /// Options for a `default`-template project named `name`.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            template: "default".to_string(),
+            vendor_deps: false,
+            lez_path: None,
+            cache_root: None,
+        }
+    }
+}
+
+/// Basecamp flows, mirroring `lgs basecamp <subcommand>`.
+#[derive(Clone, Debug)]
+pub enum BasecampCommand {
+    /// Build/install the pinned basecamp binary and seed profiles.
+    Setup,
+    /// Capture project modules (and dependencies) into `scaffold.toml`.
+    Modules {
+        paths: Vec<PathBuf>,
+        flakes: Vec<String>,
+        /// Only print the captured state; change nothing.
+        show: bool,
+    },
+    /// Build and install everything captured in state.
+    Install,
+    /// Launch a seeded profile.
+    Launch { profile: String },
+    /// Enter a module's Nix dev shell.
+    Develop {
+        module: String,
+        dev_shell: Option<String>,
+    },
+    /// Attr-swap replay producing portable module builds.
+    BuildPortable,
+    /// Basecamp-specific health checks.
+    Doctor,
+}
+
+impl BasecampCommand {
+    fn into_action(self) -> BasecampAction {
+        match self {
+            Self::Setup => BasecampAction::Setup,
+            Self::Modules {
+                paths,
+                flakes,
+                show,
+            } => BasecampAction::Modules {
+                paths,
+                flakes,
+                show,
+            },
+            Self::Install => BasecampAction::Install {
+                print_output: false,
+            },
+            Self::Launch { profile } => BasecampAction::Launch { profile },
+            Self::Develop { module, dev_shell } => BasecampAction::Develop { module, dev_shell },
+            Self::BuildPortable => BasecampAction::BuildPortable,
+            Self::Doctor => BasecampAction::Doctor { json: false },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    /// Minimal valid scaffold.toml for fixture projects, mirroring what
+    /// `lgs new` writes (schema 0.2.0).
+    fn write_fixture_config(root: &Path) {
+        fs::write(
+            root.join("scaffold.toml"),
+            r#"[scaffold]
+version = "0.2.0"
+
+[repos.lez]
+source = "https://github.com/logos-blockchain/logos-execution-zone.git"
+pin = "cf3639d8252040d13b3d4e933feb19b42c76e14a"
+build = "cargo"
+
+[repos.spel]
+source = "https://github.com/logos-co/spel.git"
+pin = "73fc462eb8f0a4d00f1a846437c627ec2e523f83"
+build = "cargo"
+
+[wallet]
+home_dir = ".scaffold/wallet"
+
+[framework]
+kind = "default"
+version = "0.1.0"
+
+[localnet]
+port = 3040
+"#,
+        )
+        .expect("write scaffold.toml");
+    }
+
+    #[test]
+    fn open_loads_project_from_explicit_root() {
+        let temp = tempdir().expect("tempdir");
+        write_fixture_config(temp.path());
+
+        let project = Project::open(temp.path()).expect("open project");
+        assert_eq!(project.root(), temp.path());
+        assert_eq!(project.localnet_rpc_url(), "http://127.0.0.1:3040");
+    }
+
+    #[test]
+    fn open_rejects_directory_without_scaffold_toml() {
+        let temp = tempdir().expect("tempdir");
+        let err = Project::open(temp.path()).expect_err("must fail");
+        match err {
+            Error::Config { message } => {
+                assert!(message.contains("scaffold.toml"), "{message}")
+            }
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn discover_walks_up_to_project_root() {
+        let temp = tempdir().expect("tempdir");
+        write_fixture_config(temp.path());
+        let nested = temp.path().join("src/deep/dir");
+        fs::create_dir_all(&nested).expect("mkdir nested");
+
+        let project = Project::discover(&nested).expect("discover project");
+        assert_eq!(project.root(), temp.path());
+    }
+
+    #[test]
+    fn paths_reports_project_owned_locations() {
+        let temp = tempdir().expect("tempdir");
+        write_fixture_config(temp.path());
+
+        let project = Project::open(temp.path()).expect("open project");
+        let paths = project.paths().expect("paths");
+
+        assert_eq!(paths.root, temp.path());
+        assert_eq!(paths.scaffold_toml, temp.path().join("scaffold.toml"));
+        assert_eq!(paths.wallet_home, temp.path().join(".scaffold/wallet"));
+        assert_eq!(
+            paths.localnet_state,
+            temp.path().join(".scaffold/state/localnet.state")
+        );
+        assert_eq!(
+            paths.sequencer_log,
+            temp.path().join(".scaffold/logs/sequencer.log")
+        );
+        assert!(paths
+            .sequencer_binary
+            .ends_with("target/release/sequencer_service"));
+        assert!(paths.wallet_binary.ends_with("target/release/wallet"));
+        assert!(paths.spel_binary.ends_with("target/release/spel"));
+    }
+
+    #[test]
+    fn localnet_status_on_fresh_project_is_stopped() {
+        let temp = tempdir().expect("tempdir");
+        write_fixture_config(temp.path());
+
+        let project = Project::open(temp.path()).expect("open project");
+        let status = project.localnet_status();
+        assert!(!status.ready);
+        assert!(status.tracked_pid.is_none());
+    }
+
+    #[test]
+    fn localnet_logs_reports_missing_log_file() {
+        let temp = tempdir().expect("tempdir");
+        write_fixture_config(temp.path());
+
+        let project = Project::open(temp.path()).expect("open project");
+        let logs = project.localnet_logs(50).expect("logs report");
+        assert!(!logs.exists);
+        assert!(logs.lines.is_empty());
+    }
+}

--- a/src/api/testnode.rs
+++ b/src/api/testnode.rs
@@ -1,0 +1,123 @@
+//! Isolated sequencer test nodes for integration tests.
+//!
+//! A test node is an independent standalone sequencer with its own RPC port,
+//! config, database, log file, and runtime directory — designed for
+//! repeatable test startup, isolated state, and clean teardown. See the
+//! `lgs test-node` command group for the CLI equivalents.
+//!
+//! ```no_run
+//! use logos_scaffold::api::testnode::{TestNode, TestNodeConfig};
+//! use logos_scaffold::api::Project;
+//! use std::time::Duration;
+//!
+//! fn main() -> logos_scaffold::api::Result<()> {
+//!     let project = Project::open("/path/to/my-app")?;
+//!
+//!     let node = TestNode::start(&project, &TestNodeConfig::default())?;
+//!     node.wait_healthy(Duration::from_secs(30))?;
+//!
+//!     let info = node.info();
+//!     println!("rpc={} state={}", info.rpc_url, info.state_dir.display());
+//!
+//!     node.stop()?;
+//!     Ok(())
+//! }
+//! ```
+
+use std::path::Path;
+use std::time::Duration;
+
+pub use crate::testnode::{
+    PortSelection, PreparedTestNode, TestNodeConfig, TestNodeInfo, TestNodeStatus,
+    DEFAULT_TEST_NODE_TIMEOUT_SEC,
+};
+
+use super::error::{classify, Result};
+use super::Project;
+
+/// Owning handle to a running test-node sequencer.
+///
+/// The node and its runtime directory are cleaned up when the handle is
+/// dropped (unless `preserve_work_dir` was set or [`TestNode::detach`] was
+/// called). Prefer explicit [`TestNode::stop`] in tests so teardown errors
+/// are observable.
+#[derive(Debug)]
+pub struct TestNode {
+    inner: crate::testnode::TestNode,
+}
+
+impl TestNode {
+    /// Start an isolated sequencer test node for `project` and wait until it
+    /// is healthy.
+    pub fn start(project: &Project, config: &TestNodeConfig) -> Result<Self> {
+        crate::testnode::TestNode::start(&project.inner, config)
+            .map(|inner| Self { inner })
+            .map_err(classify)
+    }
+
+    /// Reconnect to a node started earlier (possibly by another process)
+    /// from its runtime directory. The returned handle is detached: dropping
+    /// it does not stop the node.
+    pub fn from_state_dir(state_dir: impl AsRef<Path>) -> Result<Self> {
+        crate::testnode::TestNode::from_state_dir(state_dir.as_ref())
+            .map(|inner| Self { inner })
+            .map_err(classify)
+    }
+
+    /// Static facts about the node (RPC URL, pid, paths, genesis block id,
+    /// current block height).
+    pub fn info(&self) -> TestNodeInfo {
+        self.inner.info()
+    }
+
+    /// The node's JSON-RPC endpoint.
+    pub fn rpc_url(&self) -> &str {
+        self.inner.rpc_url()
+    }
+
+    /// The node's runtime directory.
+    pub fn state_dir(&self) -> &Path {
+        self.inner.state_dir()
+    }
+
+    /// Live status: process running, RPC reachable, current block height.
+    pub fn status(&self) -> TestNodeStatus {
+        self.inner.status()
+    }
+
+    /// Block until the node answers RPC, or fail with the log tail.
+    pub fn wait_healthy(&self, timeout: Duration) -> Result<()> {
+        self.inner.wait_healthy(timeout).map_err(classify)
+    }
+
+    /// Stop the node and remove its runtime directory (unless preservation
+    /// was requested). Consumes the handle.
+    pub fn stop(self) -> Result<()> {
+        self.inner.stop().map_err(classify)
+    }
+
+    /// Detach: the node keeps running after the handle is dropped. Returns
+    /// the node's info so callers can reconnect later via
+    /// [`TestNode::from_state_dir`].
+    pub fn detach(self) -> TestNodeInfo {
+        self.inner.detach()
+    }
+}
+
+/// Verify (and materialise where possible) the test-node prerequisites for
+/// `project`: the standalone sequencer binary and the circuits release.
+pub fn prepare(project: &Project) -> Result<PreparedTestNode> {
+    crate::testnode::prepare_for_project(&project.inner).map_err(classify)
+}
+
+/// Start a node, run `command` with the node's connection details exported
+/// (`LGS_TEST_NODE_RPC_URL`, `LGS_TEST_NODE_PORT`, `LGS_TEST_NODE_STATE_DIR`,
+/// …), forward the child's exit status, and stop the node when the child
+/// exits.
+pub fn run_with_test_node(
+    project: &Project,
+    config: &TestNodeConfig,
+    command: &[String],
+) -> Result<std::process::ExitStatus> {
+    crate::testnode::run_with_test_node(&project.inner, config, command).map_err(classify)
+}

--- a/src/circuits.rs
+++ b/src/circuits.rs
@@ -79,6 +79,20 @@ pub(crate) fn ensure_circuits_for_subprocess(cache_root: &Path) -> DynResult<()>
     Ok(())
 }
 
+/// Resolve the directory the circuits release lives at (or would be
+/// materialised at) for `cache_root`, without downloading anything. The
+/// `LOGOS_BLOCKCHAIN_CIRCUITS` env override wins when it points at a
+/// populated checkout — mirroring `ensure_circuits_for_subprocess`.
+pub(crate) fn circuits_dir_for_cache_root(cache_root: &Path) -> DynResult<PathBuf> {
+    if let Some(path) = circuits_path_from_env() {
+        return Ok(path);
+    }
+    let triple = release_triple()?;
+    Ok(cache_root
+        .join("circuits")
+        .join(format!("v{DEFAULT_CIRCUITS_VERSION}-{triple}")))
+}
+
 fn circuits_path_from_env() -> Option<PathBuf> {
     let raw = std::env::var(LOGOS_BLOCKCHAIN_CIRCUITS_ENV).ok()?;
     let path = PathBuf::from(raw);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,6 +25,7 @@ use crate::commands::report::cmd_report;
 use crate::commands::run::{cmd_run, RunInvocation};
 use crate::commands::setup::cmd_setup;
 use crate::commands::spel::cmd_spel;
+use crate::commands::testnode::{cmd_test_node, TestNodeAction};
 use crate::commands::wallet::{cmd_wallet, WalletAction};
 use crate::constants::{DEFAULT_RUN_LOCALNET_TIMEOUT_SEC, VERSION};
 use crate::process::set_command_echo;
@@ -92,6 +93,11 @@ enum Commands {
     Deploy(DeployArgs),
     #[command(about = "Manage the local sequencer (start, stop, status, logs, reset)")]
     Localnet(LocalnetArgs),
+    #[command(
+        name = "test-node",
+        about = "Manage isolated, short-lived sequencer test nodes for integration tests"
+    )]
+    TestNode(TestNodeArgs),
     #[command(about = "Manage project wallet accounts and faucet top-ups")]
     Wallet(WalletArgs),
     /// `spel` is dispatched via the early `spel_passthrough_args` intercept
@@ -333,6 +339,115 @@ struct RunArgs {
 struct LocalnetArgs {
     #[command(subcommand)]
     command: LocalnetSubcommand,
+}
+
+#[derive(Debug, clap::Args)]
+struct TestNodeArgs {
+    #[command(subcommand)]
+    command: TestNodeSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum TestNodeSubcommand {
+    #[command(
+        about = "Verify the standalone sequencer binary and circuits are available for this project"
+    )]
+    Prepare(TestNodePrepareArgs),
+    #[command(about = "Start an isolated sequencer test node with its own port, state, and logs")]
+    Start(TestNodeStartArgs),
+    #[command(about = "Report whether a test node is healthy and which RPC URL it serves")]
+    Status(TestNodeStatusArgs),
+    #[command(about = "Stop a test node and remove its runtime state")]
+    Stop(TestNodeStopArgs),
+    #[command(
+        about = "Start a node, run a command with its connection exported, then stop the node",
+        long_about = "Start a test node, wait until it is healthy, run the given command with the \
+                      node's connection details exported (LGS_TEST_NODE_RPC_URL, \
+                      LGS_TEST_NODE_PORT, LGS_TEST_NODE_STATE_DIR, ...), forward the command's \
+                      exit status, and stop the node when the command exits.\n\n\
+                      Example:\n  lgs test-node run --serial -- cargo test --test sequencer_it"
+    )]
+    Run(TestNodeRunArgs),
+}
+
+#[derive(Debug, clap::Args)]
+struct TestNodePrepareArgs {
+    /// Project root (default: discover from the current directory).
+    #[arg(long, value_name = "DIR")]
+    project: Option<PathBuf>,
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, clap::Args)]
+struct TestNodeStartArgs {
+    /// Project root (default: discover from the current directory).
+    #[arg(long, value_name = "DIR")]
+    project: Option<PathBuf>,
+    /// Pre-seeded state directory (containing a rocksdb database) to start from.
+    #[arg(long, value_name = "DIR")]
+    state: Option<PathBuf>,
+    /// RPC port. 0 (the default) picks an unused localhost port.
+    #[arg(long, default_value_t = 0)]
+    port: u16,
+    /// Runtime directory for this node (default: .scaffold/test-nodes/<id>).
+    #[arg(long, value_name = "DIR")]
+    work_dir: Option<PathBuf>,
+    /// Keep the runtime directory when the node is stopped.
+    #[arg(long)]
+    preserve_work_dir: bool,
+    /// Seconds to wait for the node to become healthy.
+    #[arg(long, default_value_t = crate::testnode::DEFAULT_TEST_NODE_TIMEOUT_SEC)]
+    timeout_sec: u64,
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, clap::Args)]
+struct TestNodeStatusArgs {
+    /// Node id (directory name under .scaffold/test-nodes/) or runtime dir path.
+    #[arg(long, value_name = "ID|DIR")]
+    node: String,
+    /// Project root (default: discover from the current directory).
+    #[arg(long, value_name = "DIR")]
+    project: Option<PathBuf>,
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, clap::Args)]
+struct TestNodeStopArgs {
+    /// Node id (directory name under .scaffold/test-nodes/) or runtime dir path.
+    #[arg(long, value_name = "ID|DIR")]
+    node: String,
+    /// Project root (default: discover from the current directory).
+    #[arg(long, value_name = "DIR")]
+    project: Option<PathBuf>,
+    /// Keep the runtime directory instead of removing it.
+    #[arg(long)]
+    preserve_work_dir: bool,
+}
+
+#[derive(Debug, clap::Args)]
+struct TestNodeRunArgs {
+    /// Project root (default: discover from the current directory).
+    #[arg(long, value_name = "DIR")]
+    project: Option<PathBuf>,
+    /// Pre-seeded state directory (containing a rocksdb database) to start from.
+    #[arg(long, value_name = "DIR")]
+    state: Option<PathBuf>,
+    /// Low-resource CI path: at most one test node at a time (machine-wide).
+    #[arg(long, conflicts_with = "parallel")]
+    serial: bool,
+    /// Cap concurrent test-node creation at N (machine-wide).
+    #[arg(long, value_name = "N")]
+    parallel: Option<usize>,
+    /// Seconds to wait for the node to become healthy before running the command.
+    #[arg(long, default_value_t = crate::testnode::DEFAULT_TEST_NODE_TIMEOUT_SEC)]
+    timeout_sec: u64,
+    /// Command (after `--`) to run with the node's connection exported.
+    #[arg(last = true, required = true)]
+    command: Vec<String>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -650,6 +765,42 @@ pub(crate) fn run(args: Vec<String>) -> DynResult<()> {
                 },
             };
             cmd_localnet(action)
+        }
+        Some(Commands::TestNode(test_node)) => {
+            let action = match test_node.command {
+                TestNodeSubcommand::Prepare(args) => TestNodeAction::Prepare {
+                    project: args.project,
+                    json: args.json,
+                },
+                TestNodeSubcommand::Start(args) => TestNodeAction::Start {
+                    project: args.project,
+                    state: args.state,
+                    port: args.port,
+                    work_dir: args.work_dir,
+                    preserve_work_dir: args.preserve_work_dir,
+                    timeout_sec: args.timeout_sec,
+                    json: args.json,
+                },
+                TestNodeSubcommand::Status(args) => TestNodeAction::Status {
+                    project: args.project,
+                    node: args.node,
+                    json: args.json,
+                },
+                TestNodeSubcommand::Stop(args) => TestNodeAction::Stop {
+                    project: args.project,
+                    node: args.node,
+                    preserve_work_dir: args.preserve_work_dir,
+                },
+                TestNodeSubcommand::Run(args) => TestNodeAction::Run {
+                    project: args.project,
+                    state: args.state,
+                    serial: args.serial,
+                    parallel: args.parallel,
+                    timeout_sec: args.timeout_sec,
+                    command: args.command,
+                },
+            };
+            cmd_test_node(action)
         }
         Some(Commands::Spel(_)) => {
             // The early `spel_passthrough_args` intercept above always

--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -77,6 +77,15 @@ pub(crate) fn cmd_basecamp(action: BasecampAction) -> DynResult<()> {
     }
 
     let project = load_project()?;
+    basecamp_for_project(project, action)
+}
+
+/// Dispatch a basecamp action against an explicit project. Used by the CLI
+/// (after cwd discovery) and the public API (with a caller-provided root).
+pub(crate) fn basecamp_for_project(project: Project, action: BasecampAction) -> DynResult<()> {
+    if matches!(action, BasecampAction::Docs) {
+        return cmd_basecamp_docs();
+    }
 
     match action {
         BasecampAction::Setup => cmd_basecamp_setup(project),

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -37,14 +37,41 @@ pub(crate) fn cmd_deploy(
     json: bool,
 ) -> DynResult<()> {
     let project = load_project()?;
-    let wallet = load_wallet_runtime(&project)?;
+    let results = deploy_for_project(&project, program_name, program_path, json)?;
+
+    let failed_count = results
+        .iter()
+        .filter(|result| matches!(result.status, DeployStatus::Failed))
+        .count();
+    if failed_count > 0 {
+        if results.len() == 1 {
+            bail!("deploy failed: {}", results[0].detail);
+        }
+        bail!("deploy completed with {failed_count} failed program(s)");
+    }
+
+    Ok(())
+}
+
+/// Deploy guest programs for `project`. Returns one `DeployResult` per
+/// attempted program; the caller decides whether failures are fatal. With
+/// `json = true` the CLI JSON object is printed and `$ <cmd>` echoes are
+/// suppressed; with `json = false` per-program progress lines stream to
+/// stdout (API callers should read the returned results, not the output).
+pub(crate) fn deploy_for_project(
+    project: &crate::model::Project,
+    program_name: Option<String>,
+    program_path: Option<PathBuf>,
+    json: bool,
+) -> DynResult<Vec<DeployResult>> {
+    let wallet = load_wallet_runtime(project)?;
     let spel_bin =
-        resolve_repo_path(&project, &project.config.spel, "spel")?.join(SPEL_BIN_REL_PATH);
+        resolve_repo_path(project, &project.config.spel, "spel")?.join(SPEL_BIN_REL_PATH);
 
     let sequencer_addr = wallet
         .sequencer_addr
         .clone()
-        .unwrap_or_else(|| default_sequencer_http_url_for_project(&project));
+        .unwrap_or_else(|| default_sequencer_http_url_for_project(project));
 
     // --program-path: deploy a single custom ELF directly, skip auto-discovery
     if let Some(custom_path) = program_path {
@@ -56,14 +83,15 @@ pub(crate) fn cmd_deploy(
             .and_then(|s| s.to_str())
             .unwrap_or("unknown")
             .to_string();
-        return deploy_single_program(
+        let result = deploy_single_program(
             &wallet,
             &program_name,
             &custom_path,
             &sequencer_addr,
             &spel_bin,
             json,
-        );
+        )?;
+        return Ok(vec![result]);
     }
 
     let available_programs = discover_deployable_programs(&project.root)?;
@@ -215,11 +243,7 @@ pub(crate) fn cmd_deploy(
         }
     }
 
-    if failed_count > 0 {
-        bail!("deploy completed with {failed_count} failed program(s)");
-    }
-
-    Ok(())
+    Ok(results)
 }
 
 pub(crate) fn render_deploy_result_json(result: &DeployResult) -> serde_json::Value {
@@ -338,7 +362,7 @@ fn deploy_single_program(
     sequencer_addr: &str,
     spel_bin: &Path,
     json: bool,
-) -> DynResult<()> {
+) -> DynResult<DeployResult> {
     preflight_sequencer_reachability(sequencer_addr)?;
 
     let mut command = std::process::Command::new(&wallet.wallet_binary);
@@ -372,7 +396,13 @@ fn deploy_single_program(
             println!("FAIL {program_name} deployment failed");
             println!("  Error: {summary}");
         }
-        bail!("deploy failed: {summary}");
+        return Ok(DeployResult {
+            program: program_name.to_string(),
+            status: DeployStatus::Failed,
+            detail: summary,
+            tx,
+            program_id: None,
+        });
     }
 
     let program_id = extract_program_id(spel_bin, binary_path);
@@ -415,7 +445,13 @@ fn deploy_single_program(
         );
     }
 
-    Ok(())
+    Ok(DeployResult {
+        program: program_name.to_string(),
+        status: DeployStatus::Submitted,
+        detail: "wallet submission command exited successfully".to_string(),
+        tx,
+        program_id,
+    })
 }
 
 /// Wall-clock cap for `spel inspect`. The CLI typically returns in
@@ -493,17 +529,22 @@ fn print_program_id_line(program_id: &Option<String>) {
     }
 }
 
-#[derive(Clone, Debug)]
-pub(crate) struct DeployResult {
-    pub(crate) program: String,
-    pub(crate) status: DeployStatus,
-    pub(crate) detail: String,
-    pub(crate) tx: Option<String>,
-    pub(crate) program_id: Option<String>,
+/// Outcome of one program deployment attempt.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct DeployResult {
+    pub program: String,
+    pub status: DeployStatus,
+    pub detail: String,
+    /// Transaction identifier extracted from the wallet output, when present.
+    pub tx: Option<String>,
+    /// Locally computed risc0 image ID (the on-chain program ID), when the
+    /// vendored `spel` binary was available to compute it.
+    pub program_id: Option<String>,
 }
 
-#[derive(Clone, Debug)]
-pub(crate) enum DeployStatus {
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DeployStatus {
     Submitted,
     Failed,
 }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -12,7 +12,7 @@ use crate::doctor_checks::{
     check_binary, check_container_runtime, check_logos_blockchain_circuits, check_path,
     check_port_warn, check_repo, check_standalone_support, one_line, print_rows,
 };
-use crate::model::{CheckRow, CheckStatus, DoctorReport, DoctorSummary};
+use crate::model::{CheckRow, CheckStatus, DoctorReport, DoctorSummary, Project};
 use crate::process::{pid_running, run_capture, run_with_stdin, set_command_echo};
 use crate::project::{load_project, resolve_cache_root, resolve_repo_path};
 use crate::state::read_localnet_state;
@@ -38,7 +38,8 @@ pub(crate) fn cmd_doctor(as_json: bool) -> DynResult<()> {
 }
 
 fn cmd_doctor_inner(as_json: bool) -> DynResult<()> {
-    let report = build_doctor_report()?;
+    let project = load_project()?;
+    let report = build_doctor_report(&project)?;
 
     if as_json {
         println!("{}", serde_json::to_string_pretty(&report)?);
@@ -69,9 +70,8 @@ fn cmd_doctor_inner(as_json: bool) -> DynResult<()> {
     Ok(())
 }
 
-pub(crate) fn build_doctor_report() -> DynResult<DoctorReport> {
-    let project = load_project()?;
-    let lez = resolve_repo_path(&project, &project.config.lez, "lez")?;
+pub(crate) fn build_doctor_report(project: &Project) -> DynResult<DoctorReport> {
+    let lez = resolve_repo_path(project, &project.config.lez, "lez")?;
     let spel = resolve_repo_path(&project, &project.config.spel, "spel")?;
     let wallet_home = project.root.join(&project.config.wallet_home_dir);
     let localnet_state_path = project.root.join(".scaffold/state/localnet.state");

--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -1061,7 +1061,7 @@ fn verify_block_production(localnet_addr: &str, timeout_sec: u64) -> DynResult<(
 /// rzup-managed extension dir: ~/.risc0/extensions/v<version>-cargo-risczero-<arch>-<os>/r0vm.
 /// Returns None (without guessing) if the version cannot be determined or the exact path
 /// does not exist. The caller should error with a clear diagnostic if None is returned.
-fn find_r0vm_path_for_lez(lez: &std::path::Path) -> Option<std::path::PathBuf> {
+pub(crate) fn find_r0vm_path_for_lez(lez: &std::path::Path) -> Option<std::path::PathBuf> {
     // Read risc0-zkvm version from LEZ Cargo.lock
     let lockfile = lez.join("Cargo.lock");
     let lock_content = std::fs::read_to_string(&lockfile).ok()?;

--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -14,7 +14,10 @@ use crate::error::{LocalnetError, ResetError};
 use crate::model::{
     LocalnetLogsReport, LocalnetOwnership, LocalnetState, LocalnetStatusReport, Project,
 };
-use crate::process::{listener_pid, pid_alive, pid_command, pid_running, port_open, spawn_to_log};
+use crate::process::{
+    command_echo_enabled, listener_pid, pid_alive, pid_command, pid_running, port_open,
+    spawn_to_log,
+};
 use crate::project::{
     ensure_dir_exists, find_project_root, load_project, resolve_cache_root, resolve_repo_path,
 };
@@ -75,15 +78,125 @@ pub(crate) fn build_localnet_status_for_project(project: &Project) -> LocalnetSt
     )
 }
 
-fn cmd_localnet_in_project(project: &Project, action: LocalnetAction) -> DynResult<()> {
+/// Project-derived paths and addresses every localnet operation needs.
+pub(crate) struct LocalnetContext {
+    pub(crate) lez: PathBuf,
+    pub(crate) state_path: PathBuf,
+    pub(crate) log_path: PathBuf,
+    pub(crate) localnet_addr: String,
+    pub(crate) localnet_port: u16,
+    pub(crate) risc0_dev_mode: bool,
+}
+
+pub(crate) fn localnet_context(project: &Project) -> DynResult<LocalnetContext> {
     let localnet_port = project.config.localnet.port;
-    let risc0_dev_mode = project.config.localnet.risc0_dev_mode;
-    let localnet_addr = format!("127.0.0.1:{localnet_port}");
-    let lez = resolve_repo_path(project, &project.config.lez, "lez")?;
-    let state_path = project.root.join(".scaffold/state/localnet.state");
     let logs_dir = project.root.join(".scaffold/logs");
-    let log_path = logs_dir.join("sequencer.log");
     fs::create_dir_all(&logs_dir)?;
+    Ok(LocalnetContext {
+        lez: resolve_repo_path(project, &project.config.lez, "lez")?,
+        state_path: project.root.join(".scaffold/state/localnet.state"),
+        log_path: logs_dir.join("sequencer.log"),
+        localnet_addr: format!("127.0.0.1:{localnet_port}"),
+        localnet_port,
+        risc0_dev_mode: project.config.localnet.risc0_dev_mode,
+    })
+}
+
+/// Result of a localnet start, exposed through the public API.
+#[derive(Clone, Debug)]
+pub(crate) struct LocalnetStartOutcome {
+    pub(crate) pid: u32,
+    /// `true` when a tracked sequencer was already running and was reused
+    /// instead of spawning a new process.
+    pub(crate) reused: bool,
+    pub(crate) rpc_url: String,
+    pub(crate) state_path: PathBuf,
+    pub(crate) log_path: PathBuf,
+}
+
+/// Result of a localnet stop, exposed through the public API.
+#[derive(Clone, Debug)]
+pub enum LocalnetStopOutcome {
+    /// The tracked sequencer was sent TERM and exited.
+    Stopped { pid: u32 },
+    /// State tracked a pid that is no longer running; the stale state file
+    /// was removed.
+    ClearedStaleState { pid: u32 },
+    /// An unmanaged process is listening on the localnet port; it was left
+    /// alone.
+    ForeignListener { addr: String, pid: Option<u32> },
+    /// Nothing tracked and nothing listening.
+    NotRunning,
+}
+
+/// Start (or reuse) the project's localnet sequencer. Non-printing core used
+/// by both the CLI command and the public API.
+pub(crate) fn localnet_start_for_project(
+    project: &Project,
+    timeout_sec: u64,
+) -> DynResult<LocalnetStartOutcome> {
+    let ctx = localnet_context(project)?;
+    let (cache_root, _) = resolve_cache_root(project)?;
+    ensure_circuits_for_subprocess(&cache_root)?;
+    let (pid, reused) = start_localnet(
+        &ctx.lez,
+        &ctx.state_path,
+        &ctx.log_path,
+        timeout_sec,
+        ctx.localnet_port,
+        ctx.risc0_dev_mode,
+        &ctx.localnet_addr,
+    )?;
+    Ok(LocalnetStartOutcome {
+        pid,
+        reused,
+        rpc_url: format!("http://{}", ctx.localnet_addr),
+        state_path: ctx.state_path,
+        log_path: ctx.log_path,
+    })
+}
+
+/// Stop the project's localnet sequencer. Non-printing core used by both the
+/// CLI command and the public API.
+pub(crate) fn localnet_stop_for_project(project: &Project) -> DynResult<LocalnetStopOutcome> {
+    let ctx = localnet_context(project)?;
+    stop_localnet(&ctx.state_path, ctx.localnet_port)
+}
+
+/// Build the logs report for the public API / `--json` output.
+pub(crate) fn localnet_logs_for_project(
+    project: &Project,
+    tail: usize,
+) -> DynResult<LocalnetLogsReport> {
+    let log_path = project.root.join(".scaffold/logs/sequencer.log");
+    build_logs_report(&log_path, tail)
+}
+
+/// Reset the project's localnet (stop, wipe chain DB, restart, verify block
+/// production). Used by the public API; always operates non-interactively.
+pub(crate) fn localnet_reset_for_project(
+    project: &Project,
+    reset_wallet: bool,
+    verify_timeout_sec: u64,
+) -> DynResult<()> {
+    let ctx = localnet_context(project)?;
+    let (cache_root, _) = resolve_cache_root(project)?;
+    ensure_circuits_for_subprocess(&cache_root)?;
+    cmd_localnet_reset(
+        project,
+        &ctx.lez,
+        &ctx.state_path,
+        &ctx.log_path,
+        &ctx.localnet_addr,
+        false,
+        true,
+        reset_wallet,
+        verify_timeout_sec,
+    )
+}
+
+fn cmd_localnet_in_project(project: &Project, action: LocalnetAction) -> DynResult<()> {
+    let ctx = localnet_context(project)?;
 
     // The standalone `sequencer_service` binary calls into the
     // `logos-blockchain-zksign` runtime, which loads circuit witness
@@ -99,20 +212,32 @@ fn cmd_localnet_in_project(project: &Project, action: LocalnetAction) -> DynResu
     }
 
     match action {
-        LocalnetAction::Start { timeout_sec } => cmd_localnet_start(
-            &lez,
-            &state_path,
-            &log_path,
-            timeout_sec,
-            localnet_port,
-            risc0_dev_mode,
-            &localnet_addr,
-        ),
-        LocalnetAction::Stop => cmd_localnet_stop(&state_path, localnet_port),
-        LocalnetAction::Status { json } => {
-            cmd_localnet_status(&state_path, &log_path, json, &localnet_addr, localnet_port)
+        LocalnetAction::Start { timeout_sec } => {
+            let (pid, _) = start_localnet(
+                &ctx.lez,
+                &ctx.state_path,
+                &ctx.log_path,
+                timeout_sec,
+                ctx.localnet_port,
+                ctx.risc0_dev_mode,
+                &ctx.localnet_addr,
+            )?;
+            println!("localnet ready (sequencer pid={pid})");
+            Ok(())
         }
-        LocalnetAction::Logs { tail, json } => cmd_localnet_logs(&log_path, tail, json),
+        LocalnetAction::Stop => {
+            let outcome = stop_localnet(&ctx.state_path, ctx.localnet_port)?;
+            print_stop_outcome(&outcome, &ctx.localnet_addr);
+            Ok(())
+        }
+        LocalnetAction::Status { json } => cmd_localnet_status(
+            &ctx.state_path,
+            &ctx.log_path,
+            json,
+            &ctx.localnet_addr,
+            ctx.localnet_port,
+        ),
+        LocalnetAction::Logs { tail, json } => cmd_localnet_logs(&ctx.log_path, tail, json),
         LocalnetAction::Reset {
             dry_run,
             yes,
@@ -120,10 +245,10 @@ fn cmd_localnet_in_project(project: &Project, action: LocalnetAction) -> DynResu
             verify_timeout_sec,
         } => cmd_localnet_reset(
             project,
-            &lez,
-            &state_path,
-            &log_path,
-            &localnet_addr,
+            &ctx.lez,
+            &ctx.state_path,
+            &ctx.log_path,
+            &ctx.localnet_addr,
             dry_run,
             yes,
             reset_wallet,
@@ -165,7 +290,10 @@ fn cmd_localnet_stop_outside_project() -> DynResult<()> {
     Ok(())
 }
 
-fn cmd_localnet_start(
+/// Spawn (or reuse) the sequencer and wait for readiness. Returns
+/// `(pid, reused)`; does not print success lines so the public API stays
+/// quiet — callers print their own confirmation.
+fn start_localnet(
     lez: &Path,
     state_path: &Path,
     log_path: &Path,
@@ -173,7 +301,7 @@ fn cmd_localnet_start(
     localnet_port: u16,
     risc0_dev_mode: bool,
     localnet_addr: &str,
-) -> DynResult<()> {
+) -> DynResult<(u32, bool)> {
     ensure_dir_exists(lez, "lez")?;
     let sequencer_bin = lez.join(SEQUENCER_BIN_REL_PATH);
     if !sequencer_bin.exists() {
@@ -187,8 +315,7 @@ fn cmd_localnet_start(
     if let Some(pid) = state.sequencer_pid {
         if pid_running(pid) {
             wait_for_readiness(pid, timeout_sec, log_path, localnet_addr)?;
-            println!("localnet ready (sequencer pid={pid})");
-            return Ok(());
+            return Ok((pid, true));
         }
 
         if state_path.exists() {
@@ -268,8 +395,7 @@ fn cmd_localnet_start(
         return Err(err);
     }
 
-    println!("localnet ready (sequencer pid={sequencer_pid})");
-    Ok(())
+    Ok((sequencer_pid, false))
 }
 
 fn wait_for_readiness(
@@ -308,7 +434,10 @@ fn wait_for_readiness(
     }
 }
 
-fn cmd_localnet_stop(state_path: &Path, localnet_port: u16) -> DynResult<()> {
+/// Stop the tracked sequencer (if any). Non-printing core shared by the CLI
+/// command, the reset flow, and the public API. Informational text lives in
+/// `print_stop_outcome`; the `$ kill` echo follows the global echo setting.
+fn stop_localnet(state_path: &Path, localnet_port: u16) -> DynResult<LocalnetStopOutcome> {
     let localnet_addr = format!("127.0.0.1:{localnet_port}");
     let report = build_status_report(
         state_path,
@@ -317,8 +446,10 @@ fn cmd_localnet_stop(state_path: &Path, localnet_port: u16) -> DynResult<()> {
         localnet_port,
     );
     if let Some(pid) = report.tracked_pid {
-        if report.tracked_running {
-            println!("$ kill {pid} # sequencer");
+        let outcome = if report.tracked_running {
+            if command_echo_enabled() {
+                println!("$ kill {pid} # sequencer");
+            }
             let kill_output = Command::new("kill")
                 .arg(pid.to_string())
                 .output()
@@ -351,30 +482,44 @@ fn cmd_localnet_stop(state_path: &Path, localnet_port: u16) -> DynResult<()> {
             // foreign listener that survived our sequencer, and `localnet
             // start` will surface that with a more specific error.
             let _ = wait_for_port_free(&localnet_addr, Duration::from_secs(5));
+            LocalnetStopOutcome::Stopped { pid }
         } else {
-            println!("sequencer state is stale (pid={pid} not running)");
-        }
+            LocalnetStopOutcome::ClearedStaleState { pid }
+        };
 
         if state_path.exists() {
             fs::remove_file(state_path)?;
         }
-        println!("localnet stopped");
-        return Ok(());
+        return Ok(outcome);
     }
 
     if report.listener_present {
-        let pid_text = report
-            .listener_pid
-            .map(|pid| pid.to_string())
-            .unwrap_or_else(|| "unknown".to_string());
-        println!(
-            "foreign listener detected on {localnet_addr} (pid={pid_text}); not stopping unmanaged process"
-        );
-        return Ok(());
+        return Ok(LocalnetStopOutcome::ForeignListener {
+            addr: localnet_addr,
+            pid: report.listener_pid,
+        });
     }
 
-    println!("localnet not running");
-    Ok(())
+    Ok(LocalnetStopOutcome::NotRunning)
+}
+
+fn print_stop_outcome(outcome: &LocalnetStopOutcome, _localnet_addr: &str) {
+    match outcome {
+        LocalnetStopOutcome::Stopped { .. } => println!("localnet stopped"),
+        LocalnetStopOutcome::ClearedStaleState { pid } => {
+            println!("sequencer state is stale (pid={pid} not running)");
+            println!("localnet stopped");
+        }
+        LocalnetStopOutcome::ForeignListener { addr, pid } => {
+            let pid_text = pid
+                .map(|pid| pid.to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+            println!(
+                "foreign listener detected on {addr} (pid={pid_text}); not stopping unmanaged process"
+            );
+        }
+        LocalnetStopOutcome::NotRunning => println!("localnet not running"),
+    }
 }
 
 fn cmd_localnet_status(
@@ -434,60 +579,60 @@ fn ownership_label(ownership: LocalnetOwnership) -> &'static str {
 }
 
 fn cmd_localnet_logs(log_path: &Path, tail: usize, json: bool) -> DynResult<()> {
-    if !log_path.exists() {
-        if json {
-            print_logs_json(log_path, false, tail, Vec::new())?;
-        } else {
-            println!("log file does not exist yet: {}", log_path.display());
-        }
+    let report = build_logs_report(log_path, tail)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
         return Ok(());
     }
 
-    let content = fs::read_to_string(log_path)
-        .with_context(|| format!("failed to read log file {}", log_path.display()))?;
+    if !report.exists {
+        println!("log file does not exist yet: {}", log_path.display());
+        return Ok(());
+    }
 
-    // Treat a whitespace-only log as empty in BOTH modes. Without this, a log
-    // containing only newlines yields `content.lines() == [""]`, so JSON would
-    // report a non-empty `lines` array — contradicting the LocalnetLogsReport
-    // contract (empty when the log is empty) and the plain-text branch below.
-    if content.trim().is_empty() {
-        if json {
-            return print_logs_json(log_path, true, tail, Vec::new());
-        }
+    if report.lines.is_empty() {
         println!("log file is empty: {}", log_path.display());
         return Ok(());
     }
 
-    let all_lines: Vec<&str> = content.lines().collect();
-    let start = all_lines.len().saturating_sub(tail);
-    let tail_lines = &all_lines[start..];
-
-    if json {
-        let lines = tail_lines.iter().map(|l| l.to_string()).collect();
-        return print_logs_json(log_path, true, tail, lines);
-    }
-
-    for line in tail_lines {
+    for line in &report.lines {
         println!("{line}");
     }
 
     Ok(())
 }
 
-fn print_logs_json(
-    log_path: &Path,
-    exists: bool,
-    tail: usize,
-    lines: Vec<String>,
-) -> DynResult<()> {
-    let report = LocalnetLogsReport {
+/// Build the `LocalnetLogsReport` for a sequencer log file. A whitespace-only
+/// log reports as existing-but-empty (`lines` empty) so JSON consumers can
+/// tell an absent log apart from an empty one without parsing prose.
+fn build_logs_report(log_path: &Path, tail: usize) -> DynResult<LocalnetLogsReport> {
+    let mut report = LocalnetLogsReport {
         log_path: log_path.display().to_string(),
-        exists,
+        exists: false,
         tail,
-        lines,
+        lines: Vec::new(),
     };
-    println!("{}", serde_json::to_string_pretty(&report)?);
-    Ok(())
+
+    if !log_path.exists() {
+        return Ok(report);
+    }
+    report.exists = true;
+
+    let content = fs::read_to_string(log_path)
+        .with_context(|| format!("failed to read log file {}", log_path.display()))?;
+
+    // Treat a whitespace-only log as empty. Without this, a log containing
+    // only newlines yields `content.lines() == [""]`, so JSON would report a
+    // non-empty `lines` array — contradicting the LocalnetLogsReport contract.
+    if content.trim().is_empty() {
+        return Ok(report);
+    }
+
+    let all_lines: Vec<&str> = content.lines().collect();
+    let start = all_lines.len().saturating_sub(tail);
+    report.lines = all_lines[start..].iter().map(|l| l.to_string()).collect();
+    Ok(report)
 }
 
 fn build_status_report(
@@ -774,7 +919,8 @@ pub(crate) fn cmd_localnet_reset(
     }
 
     println!("stopping sequencer…");
-    cmd_localnet_stop(state_path, localnet_port)?;
+    let stop_outcome = stop_localnet(state_path, localnet_port)?;
+    print_stop_outcome(&stop_outcome, localnet_addr);
 
     // `cmd_localnet_stop` sends SIGTERM without waiting, so the port may still
     // be held by our own sequencer for a short window. Poll briefly for it to
@@ -790,7 +936,7 @@ pub(crate) fn cmd_localnet_reset(
     reset_cleanup(project, lez, state_path, reset_wallet)?;
 
     println!("starting sequencer…");
-    cmd_localnet_start(
+    let (pid, _) = start_localnet(
         lez,
         state_path,
         log_path,
@@ -799,6 +945,7 @@ pub(crate) fn cmd_localnet_reset(
         project.config.localnet.risc0_dev_mode,
         localnet_addr,
     )?;
+    println!("localnet ready (sequencer pid={pid})");
 
     println!("waiting for block production…");
     verify_block_production(localnet_addr, verify_timeout_sec)

--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -614,7 +614,12 @@ fn build_logs_report(log_path: &Path, tail: usize) -> DynResult<LocalnetLogsRepo
         lines: Vec::new(),
     };
 
-    if !log_path.exists() {
+    // `try_exists()` (not `exists()`): an unreadable log (permission/IO error)
+    // must surface as an error, not be reported as a missing log file.
+    if !log_path
+        .try_exists()
+        .with_context(|| format!("checking sequencer log at {}", log_path.display()))?
+    {
         return Ok(report);
     }
     report.exists = true;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -14,5 +14,6 @@ pub(crate) mod run_state;
 pub(crate) mod self_test;
 pub(crate) mod setup;
 pub(crate) mod spel;
+pub(crate) mod testnode;
 pub(crate) mod wallet;
 pub(crate) mod wallet_support;

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -32,6 +32,15 @@ pub(crate) struct NewCommand {
 }
 
 pub(crate) fn cmd_new(cmd: NewCommand) -> DynResult<()> {
+    let cwd = env::current_dir()?;
+    create_project_in(&cwd, cmd)?;
+    Ok(())
+}
+
+/// Create a new project at `base_dir/<cmd.name>` and return the project root.
+/// Used by the CLI (with the current directory) and the public API (with an
+/// explicit parent directory).
+pub(crate) fn create_project_in(base_dir: &Path, cmd: NewCommand) -> DynResult<PathBuf> {
     let template_variant = match cmd.template.as_str() {
         FRAMEWORK_KIND_DEFAULT | FRAMEWORK_KIND_LEZ_FRAMEWORK => cmd.template.clone(),
         other => {
@@ -39,8 +48,7 @@ pub(crate) fn cmd_new(cmd: NewCommand) -> DynResult<()> {
         }
     };
 
-    let cwd = env::current_dir()?;
-    let target = cwd.join(&cmd.name);
+    let target = base_dir.join(&cmd.name);
 
     if target.exists() {
         bail!("target exists: {}", target.display());
@@ -63,7 +71,7 @@ pub(crate) fn cmd_new(cmd: NewCommand) -> DynResult<()> {
             ),
         }
     }
-    result
+    result.map(|()| target)
 }
 
 fn cmd_new_inner(cmd: &NewCommand, target: &Path, template_variant: &str) -> DynResult<()> {

--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -24,9 +24,34 @@ use crate::DynResult;
 
 const REPORT_WARNING: &str = "WARNING: This diagnostics bundle is sanitized on a best-effort basis and may still contain sensitive data. Inspect every file before sharing it publicly.";
 
+/// Outcome of a diagnostics-report run: the archive that was written plus the
+/// manifest describing what was collected, skipped, and redacted.
+#[derive(Clone, Debug)]
+pub(crate) struct ReportOutcome {
+    pub(crate) archive: PathBuf,
+    pub(crate) manifest: ReportManifest,
+}
+
 pub(crate) fn cmd_report(out: Option<PathBuf>, tail: usize) -> DynResult<()> {
     let project = load_project()?;
+    let outcome = report_for_project(&project, out, tail)?;
 
+    println!("report complete");
+    println!("  archive: {}", outcome.archive.display());
+    println!("  included items: {}", outcome.manifest.include_count);
+    println!("  skipped items: {}", outcome.manifest.skip_count);
+    println!("{REPORT_WARNING}");
+
+    Ok(())
+}
+
+/// Collect and pack the sanitized diagnostics archive for `project`. Returns
+/// the archive path and manifest; prints only incidental warnings.
+pub(crate) fn report_for_project(
+    project: &crate::model::Project,
+    out: Option<PathBuf>,
+    tail: usize,
+) -> DynResult<ReportOutcome> {
     let now = unix_timestamp_now()?;
     let output_path = resolve_output_path(&project.root, out, now)?;
 
@@ -40,7 +65,7 @@ pub(crate) fn cmd_report(out: Option<PathBuf>, tail: usize) -> DynResult<()> {
     let staging_dir = reports_dir.join(format!(".tmp-report-{now}-{}", std::process::id()));
     fs::create_dir_all(&staging_dir)?;
 
-    let collection = collect_report_artifacts(&project, tail, now, &staging_dir, &output_path);
+    let collection = collect_report_artifacts(project, tail, now, &staging_dir, &output_path);
 
     let manifest = match collection {
         Ok(manifest) => manifest,
@@ -67,13 +92,10 @@ pub(crate) fn cmd_report(out: Option<PathBuf>, tail: usize) -> DynResult<()> {
         );
     }
 
-    println!("report complete");
-    println!("  archive: {}", output_path.display());
-    println!("  included items: {}", manifest.include_count);
-    println!("  skipped items: {}", manifest.skip_count);
-    println!("{REPORT_WARNING}");
-
-    Ok(())
+    Ok(ReportOutcome {
+        archive: output_path,
+        manifest,
+    })
 }
 
 fn resolve_home_dir_for_scrubbing() -> Option<PathBuf> {
@@ -169,7 +191,7 @@ fn collect_report_artifacts(
     });
 
     set_command_echo(false);
-    let doctor_result = build_doctor_report();
+    let doctor_result = build_doctor_report(project);
     set_command_echo(true);
     match doctor_result {
         Ok(report) => {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -50,6 +50,14 @@ pub(crate) struct RunInvocation {
 
 pub(crate) fn cmd_run(inv: RunInvocation) -> DynResult<()> {
     let project = load_project()?;
+    run_for_project(&project, inv)
+}
+
+/// Execute the `lgs run` pipeline (build → IDL → localnet → topup → deploy →
+/// hooks) for `project`. Streams step progress to stdout. With `inv.watch`
+/// set, blocks in the watch loop until interrupted — API callers normally
+/// leave `watch` off.
+pub(crate) fn run_for_project(project: &Project, inv: RunInvocation) -> DynResult<()> {
     let resolved = project.config.run.resolve_profile(inv.profile.as_deref())?;
     if let Some(name) = inv.profile.as_deref() {
         println!("Using [run.profiles.{name}]");

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -41,16 +41,23 @@ pub(crate) fn cmd_setup(prebuilt: bool) -> DynResult<()> {
     // gripes (circuits artifact, etc.). Tests assert the migration hint
     // wins on pre-v0.2.0 configs.
     let project = load_project()?;
+    setup_for_project(&project, prebuilt)
+}
+
+/// Sync pinned repos and build project-local binaries (sequencer, wallet,
+/// spel) for `project`. Streams build progress to stdout; failures surface as
+/// typed `CommandFailed` errors where an external command is at fault.
+pub(crate) fn setup_for_project(project: &crate::model::Project, prebuilt: bool) -> DynResult<()> {
     ensure_logos_blockchain_circuits_present()?;
-    let lez = resolve_repo_path(&project, &project.config.lez, "lez")?;
-    let spel = resolve_repo_path(&project, &project.config.spel, "spel")?;
+    let lez = resolve_repo_path(project, &project.config.lez, "lez")?;
+    let spel = resolve_repo_path(project, &project.config.spel, "spel")?;
 
     // Both the LEZ standalone-sequencer build below and (downstream) the
     // user-project workspace build pull in `logos-blockchain-{pol,poc,poq,zksign}`
     // build scripts, which panic when their circuits release isn't visible.
     // Materialise it once before any cargo invocation; the export propagates
     // to every subprocess for the rest of the process.
-    let (cache_root, _) = resolve_cache_root(&project)?;
+    let (cache_root, _) = resolve_cache_root(project)?;
     ensure_circuits_for_subprocess(&cache_root)?;
 
     sync_pinned_repo(&project.config.lez, &lez, "lez")?;

--- a/src/commands/spel.rs
+++ b/src/commands/spel.rs
@@ -13,17 +13,27 @@ use crate::DynResult;
 /// user at `setup` rather than failing with a raw exec error.
 pub(crate) fn cmd_spel(args: Vec<String>) -> DynResult<()> {
     let project = load_project()?;
+    let status = spel_passthrough_for_project(&project, &args)?;
+    if !status.success() {
+        std::process::exit(status.code().unwrap_or(1));
+    }
+    Ok(())
+}
+
+/// Run the project-vendored `spel` binary with `args`, forwarding its output,
+/// and return the exit status. The API path uses the returned status instead
+/// of exiting the process.
+pub(crate) fn spel_passthrough_for_project(
+    project: &crate::model::Project,
+    args: &[String],
+) -> DynResult<std::process::ExitStatus> {
     let spel_bin =
-        resolve_repo_path(&project, &project.config.spel, "spel")?.join(SPEL_BIN_REL_PATH);
+        resolve_repo_path(project, &project.config.spel, "spel")?.join(SPEL_BIN_REL_PATH);
     if !spel_bin.exists() {
         bail!(
             "vendored spel binary not found at `{}`\nNext step: run `logos-scaffold setup` to build it.",
             spel_bin.display()
         );
     }
-    let status = Command::new(&spel_bin).args(&args).status()?;
-    if !status.success() {
-        std::process::exit(status.code().unwrap_or(1));
-    }
-    Ok(())
+    Ok(Command::new(&spel_bin).args(args).status()?)
 }

--- a/src/commands/testnode.rs
+++ b/src/commands/testnode.rs
@@ -1,0 +1,204 @@
+use std::path::PathBuf;
+
+use anyhow::Context;
+
+use crate::model::Project;
+use crate::project::{load_project, load_project_at, resolve_cache_root};
+use crate::testnode::{
+    acquire_run_slot, prepare_for_project, resolve_node_dir, run_with_test_node, stop_node_in_dir,
+    PortSelection, TestNode, TestNodeConfig,
+};
+use crate::DynResult;
+
+#[derive(Debug, Clone)]
+pub(crate) enum TestNodeAction {
+    Prepare {
+        project: Option<PathBuf>,
+        json: bool,
+    },
+    Start {
+        project: Option<PathBuf>,
+        state: Option<PathBuf>,
+        port: u16,
+        work_dir: Option<PathBuf>,
+        preserve_work_dir: bool,
+        timeout_sec: u64,
+        json: bool,
+    },
+    Status {
+        project: Option<PathBuf>,
+        node: String,
+        json: bool,
+    },
+    Stop {
+        project: Option<PathBuf>,
+        node: String,
+        preserve_work_dir: bool,
+    },
+    Run {
+        project: Option<PathBuf>,
+        state: Option<PathBuf>,
+        serial: bool,
+        parallel: Option<usize>,
+        timeout_sec: u64,
+        command: Vec<String>,
+    },
+}
+
+pub(crate) fn cmd_test_node(action: TestNodeAction) -> DynResult<()> {
+    match action {
+        TestNodeAction::Prepare { project, json } => {
+            let project = load_selected_project(project.as_deref())?;
+            let prepared = prepare_for_project(&project)?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&prepared)?);
+            } else {
+                println!("test-node prerequisites ready");
+                println!("  lez: {}", prepared.lez.display());
+                println!(
+                    "  sequencer binary: {}",
+                    prepared.sequencer_binary.display()
+                );
+                println!("  circuits: {}", prepared.circuits_dir.display());
+            }
+            Ok(())
+        }
+        TestNodeAction::Start {
+            project,
+            state,
+            port,
+            work_dir,
+            preserve_work_dir,
+            timeout_sec,
+            json,
+        } => {
+            let project = load_selected_project(project.as_deref())?;
+            let config = TestNodeConfig {
+                state,
+                port: if port == 0 {
+                    PortSelection::Auto
+                } else {
+                    PortSelection::Fixed(port)
+                },
+                work_dir,
+                preserve_work_dir,
+                timeout_sec,
+            };
+            // Detach: the CLI exits but the node keeps running until
+            // `test-node stop`.
+            let node = TestNode::start(&project, &config)?;
+            let info = node.detach();
+            if json {
+                println!("{}", serde_json::to_string_pretty(&info)?);
+            } else {
+                let id = info
+                    .state_dir
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| info.state_dir.display().to_string());
+                println!("test node ready");
+                println!("  node: {id}");
+                println!("  pid: {}", info.pid);
+                println!("  rpc_url: {}", info.rpc_url);
+                println!("  state_dir: {}", info.state_dir.display());
+                println!("  log: {}", info.log_path.display());
+                println!("  genesis_block_id: {}", info.genesis_block_id);
+                println!("  block_height: {}", info.block_height);
+                println!("Stop with: lgs test-node stop --node {id}");
+            }
+            Ok(())
+        }
+        TestNodeAction::Status {
+            project,
+            node,
+            json,
+        } => {
+            let project_root = selected_project_root(project.as_deref())?;
+            let node_dir = resolve_node_dir(&project_root, &node)?;
+            let handle = TestNode::from_state_dir(&node_dir)?;
+            let status = handle.status();
+            if json {
+                println!("{}", serde_json::to_string_pretty(&status)?);
+            } else {
+                println!("healthy: {}", status.healthy);
+                println!("running: {}", status.running);
+                println!("rpc_url: {}", status.rpc_url);
+                println!("pid: {}", status.pid);
+                match status.block_height {
+                    Some(height) => println!("block_height: {height}"),
+                    None => println!("block_height: unreachable"),
+                }
+                println!("state_dir: {}", status.state_dir.display());
+                println!("log: {}", status.log_path.display());
+            }
+            if !status.healthy {
+                anyhow::bail!("test node is not healthy");
+            }
+            Ok(())
+        }
+        TestNodeAction::Stop {
+            project,
+            node,
+            preserve_work_dir,
+        } => {
+            let project_root = selected_project_root(project.as_deref())?;
+            let node_dir = resolve_node_dir(&project_root, &node)?;
+            let preserve_override = preserve_work_dir.then_some(true);
+            stop_node_in_dir(&node_dir, preserve_override)?;
+            println!("test node stopped");
+            if preserve_work_dir {
+                println!("  state preserved at {}", node_dir.display());
+            }
+            Ok(())
+        }
+        TestNodeAction::Run {
+            project,
+            state,
+            serial,
+            parallel,
+            timeout_sec,
+            command,
+        } => {
+            let project = load_selected_project(project.as_deref())?;
+
+            // --serial caps cross-process node creation at 1; --parallel <N>
+            // at N. Held for the whole child run so the node count is the
+            // resource being limited, not just startup.
+            let max_parallel = if serial { Some(1) } else { parallel };
+            let _slot = match max_parallel {
+                Some(max) if max == 0 => anyhow::bail!("--parallel must be at least 1"),
+                Some(max) => {
+                    let (cache_root, _) = resolve_cache_root(&project)?;
+                    Some(acquire_run_slot(&cache_root, max)?)
+                }
+                None => None,
+            };
+
+            let config = TestNodeConfig {
+                state,
+                port: PortSelection::Auto,
+                work_dir: None,
+                preserve_work_dir: false,
+                timeout_sec,
+            };
+            let status = run_with_test_node(&project, &config, &command)?;
+            if !status.success() {
+                std::process::exit(status.code().unwrap_or(1));
+            }
+            Ok(())
+        }
+    }
+}
+
+fn load_selected_project(project: Option<&std::path::Path>) -> DynResult<Project> {
+    match project {
+        Some(root) => load_project_at(root),
+        None => load_project(),
+    }
+}
+
+fn selected_project_root(project: Option<&std::path::Path>) -> DynResult<PathBuf> {
+    Ok(load_selected_project(project)
+        .context("test-node commands need a project (pass --project <root> or run inside one)")?
+        .root)
+}

--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -20,9 +20,87 @@ use super::wallet_support::{
 /// rather than continue with uncertain funding. Standalone `wallet topup`
 /// treats both as success (matching prior behavior).
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum TopupOutcome {
+pub enum TopupOutcome {
     Success,
-    ConfirmationTimeout { message: String },
+    /// The topup was submitted but confirmation timed out — funding is
+    /// uncertain. `message` carries the full diagnostic (address, network,
+    /// tx identifier when known).
+    ConfirmationTimeout {
+        message: String,
+    },
+}
+
+/// Captured output of `wallet account list`, shared by `--json` mode and the
+/// public API.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct WalletListReport {
+    /// Rendered wallet command that produced this output.
+    pub command: String,
+    /// Exit code (`128 + signal` when killed by a signal, `-1` if unknown).
+    pub exit_code: i32,
+    /// Best-effort line split of stdout (trimmed, blanks removed).
+    pub accounts: Vec<String>,
+    /// Raw stdout from the wallet binary.
+    pub stdout: String,
+    /// Raw stderr from the wallet binary.
+    pub stderr: String,
+}
+
+/// Run `wallet account list` for `project` and capture the output. Used by
+/// `wallet list --json` and the public API.
+pub(crate) fn wallet_list_for_project(
+    project: &crate::model::Project,
+    long: bool,
+) -> DynResult<WalletListReport> {
+    let wallet = load_wallet_runtime(project)?;
+
+    let mut command = Command::new(&wallet.wallet_binary);
+    command
+        .env(
+            "NSSA_WALLET_HOME_DIR",
+            wallet.wallet_home.as_os_str().to_string_lossy().to_string(),
+        )
+        .arg("account")
+        .arg("list");
+    if long {
+        command.arg("--long");
+    }
+
+    let rendered_command = render_command(&command);
+    let output = command
+        .output()
+        .context("failed to execute wallet list command")?;
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    // Always emit a number: a wallet killed by a signal has no exit code,
+    // so map that to the shell convention `128 + signal` (else -1) rather
+    // than letting `exit_code` serialize as `null`.
+    let exit_code = output.status.code().unwrap_or_else(|| {
+        use std::os::unix::process::ExitStatusExt;
+        output.status.signal().map(|s| 128 + s).unwrap_or(-1)
+    });
+    let accounts: Vec<String> = stdout
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToString::to_string)
+        .collect();
+
+    Ok(WalletListReport {
+        command: rendered_command,
+        exit_code,
+        accounts,
+        stdout,
+        stderr,
+    })
+}
+
+/// Set the project default wallet address; returns the normalized form.
+pub(crate) fn wallet_default_set_for_project(
+    project: &crate::model::Project,
+    address: &str,
+) -> DynResult<String> {
+    write_default_wallet_address(&project.root, address)
 }
 
 #[derive(Debug, Clone)]
@@ -60,6 +138,21 @@ pub(crate) fn cmd_wallet(action: WalletAction) -> DynResult<()> {
 }
 
 fn cmd_wallet_list(project: &crate::model::Project, long: bool, json: bool) -> DynResult<()> {
+    if json {
+        // Capture the inner wallet output and re-emit a structured envelope so
+        // consumers can read `exit_code` instead of guessing success from text.
+        // `accounts` is the best-effort line split; `stdout`/`stderr` keep the
+        // raw output for callers that need the wallet's own formatting.
+        // `command` is the actual rendered invocation (binary + args, so it
+        // reflects `--long`) rather than a hard-coded label.
+        let report = wallet_list_for_project(project, long)?;
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        if report.exit_code != 0 {
+            bail!("wallet account list failed");
+        }
+        return Ok(());
+    }
+
     let wallet = load_wallet_runtime(project)?;
 
     let mut command = Command::new(&wallet.wallet_binary);
@@ -75,52 +168,13 @@ fn cmd_wallet_list(project: &crate::model::Project, long: bool, json: bool) -> D
         command.arg("--long");
     }
 
-    if json {
-        // Capture the inner wallet output and re-emit a structured envelope so
-        // consumers can read `exit_code` instead of guessing success from text.
-        // `accounts` is the best-effort line split; `stdout`/`stderr` keep the
-        // raw output for callers that need the wallet's own formatting.
-        // `command` is the actual rendered invocation (binary + args, so it
-        // reflects `--long`) rather than a hard-coded label.
-        let rendered_command = render_command(&command);
-        let output = command
-            .output()
-            .context("failed to execute wallet list command")?;
-        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        // Always emit a number: a wallet killed by a signal has no exit code,
-        // so map that to the shell convention `128 + signal` (else -1) rather
-        // than letting `exit_code` serialize as `null`.
-        let exit_code = output.status.code().unwrap_or_else(|| {
-            use std::os::unix::process::ExitStatusExt;
-            output.status.signal().map(|s| 128 + s).unwrap_or(-1)
-        });
-        let accounts: Vec<&str> = stdout
-            .lines()
-            .map(str::trim)
-            .filter(|line| !line.is_empty())
-            .collect();
-        let report = json!({
-            "command": rendered_command,
-            "exit_code": exit_code,
-            "accounts": accounts,
-            "stdout": stdout,
-            "stderr": stderr,
-        });
-        println!("{}", serde_json::to_string_pretty(&report)?);
-        if !output.status.success() {
-            bail!("wallet account list failed");
-        }
-        return Ok(());
-    }
-
     run_forwarded(&mut command, "wallet account list")
         .context("failed to execute wallet list command")?;
 
     Ok(())
 }
 
-fn cmd_wallet_proxy(project: &crate::model::Project, args: &[String]) -> DynResult<()> {
+pub(crate) fn cmd_wallet_proxy(project: &crate::model::Project, args: &[String]) -> DynResult<()> {
     if args.is_empty() {
         bail!("wallet passthrough requires at least one argument after `--`. Example: `logos-scaffold wallet -- account list`");
     }
@@ -428,7 +482,7 @@ fn confirmation_timeout_message(
 }
 
 fn cmd_wallet_default_set(project: &crate::model::Project, address: &str) -> DynResult<()> {
-    let normalized_address = write_default_wallet_address(&project.root, address)?;
+    let normalized_address = wallet_default_set_for_project(project, address)?;
     let state_path = wallet_state_path(&project.root);
 
     println!("default wallet updated");

--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -55,11 +55,10 @@ pub(crate) fn wallet_list_for_project(
     let wallet = load_wallet_runtime(project)?;
 
     let mut command = Command::new(&wallet.wallet_binary);
+    // Pass the path as an `OsStr` (not via `to_string_lossy`) so a non-UTF8
+    // wallet-home path reaches the child verbatim instead of being corrupted.
     command
-        .env(
-            "NSSA_WALLET_HOME_DIR",
-            wallet.wallet_home.as_os_str().to_string_lossy().to_string(),
-        )
+        .env("NSSA_WALLET_HOME_DIR", &wallet.wallet_home)
         .arg("account")
         .arg("list");
     if long {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,33 @@
+use std::path::PathBuf;
+
 use thiserror::Error;
+
+/// Structured failure of an external command (cargo, git, wallet, nix, …).
+///
+/// Carries the rendered command line, the step label scaffold attached to the
+/// invocation, the exit code (when the process exited normally), any captured
+/// stdout/stderr, and the log file when output was redirected to one. The
+/// `Display` output is preserved per call site so existing CLI error text is
+/// unchanged; API consumers should read the structured fields instead of
+/// parsing the message.
+#[derive(Debug, Error)]
+#[error("{message}")]
+pub struct CommandFailed {
+    /// Rendered command line (`program arg1 arg2 …`).
+    pub command: String,
+    /// Human-readable step label (e.g. `build wallet`).
+    pub label: String,
+    /// Exit code if the process exited normally; `None` when killed by a
+    /// signal or the status could not be determined.
+    pub exit_code: Option<i32>,
+    /// Captured stdout (empty when output was streamed or logged to a file).
+    pub stdout: String,
+    /// Captured stderr (empty when output was streamed or logged to a file).
+    pub stderr: String,
+    /// Log file holding the full output, when the step captured to one.
+    pub log_path: Option<PathBuf>,
+    pub(crate) message: String,
+}
 
 #[derive(Debug, Error)]
 pub(crate) enum LocalnetError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub(crate) mod project;
 pub(crate) mod repo;
 pub(crate) mod state;
 pub(crate) mod template;
+pub(crate) mod testnode;
 
 pub fn run(args: Vec<String>) -> DynResult<()> {
     cli::run(args)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 pub(crate) type DynResult<T> = anyhow::Result<T>;
 
+pub mod api;
+
 pub(crate) mod circuits;
 pub(crate) mod cli;
 pub(crate) mod cli_help;

--- a/src/model.rs
+++ b/src/model.rs
@@ -163,18 +163,18 @@ pub(crate) struct BasecampState {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
-pub(crate) enum CheckStatus {
+pub enum CheckStatus {
     Pass,
     Warn,
     Fail,
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct CheckRow {
-    pub(crate) status: CheckStatus,
-    pub(crate) name: String,
-    pub(crate) detail: String,
-    pub(crate) remediation: Option<String>,
+pub struct CheckRow {
+    pub status: CheckStatus,
+    pub name: String,
+    pub detail: String,
+    pub remediation: Option<String>,
 }
 
 pub(crate) struct Captured {
@@ -185,7 +185,7 @@ pub(crate) struct Captured {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum LocalnetOwnership {
+pub enum LocalnetOwnership {
     Managed,
     Foreign,
     StaleState,
@@ -194,15 +194,15 @@ pub(crate) enum LocalnetOwnership {
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct LocalnetStatusReport {
-    pub(crate) tracked_pid: Option<u32>,
-    pub(crate) tracked_running: bool,
-    pub(crate) listener_present: bool,
-    pub(crate) listener_pid: Option<u32>,
-    pub(crate) ownership: LocalnetOwnership,
-    pub(crate) ready: bool,
-    pub(crate) log_path: String,
-    pub(crate) remediation: Vec<String>,
+pub struct LocalnetStatusReport {
+    pub tracked_pid: Option<u32>,
+    pub tracked_running: bool,
+    pub listener_present: bool,
+    pub listener_pid: Option<u32>,
+    pub ownership: LocalnetOwnership,
+    pub ready: bool,
+    pub log_path: String,
+    pub remediation: Vec<String>,
 }
 
 /// Machine-readable shape for `localnet logs --json`. Mirrors the human
@@ -210,68 +210,68 @@ pub(crate) struct LocalnetStatusReport {
 /// when the log is missing or empty), and `exists` lets consumers tell an
 /// absent log file apart from an empty one without parsing prose.
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct LocalnetLogsReport {
-    pub(crate) log_path: String,
-    pub(crate) exists: bool,
-    pub(crate) tail: usize,
-    pub(crate) lines: Vec<String>,
+pub struct LocalnetLogsReport {
+    pub log_path: String,
+    pub exists: bool,
+    pub tail: usize,
+    pub lines: Vec<String>,
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct DoctorSummary {
-    pub(crate) pass: usize,
-    pub(crate) warn: usize,
-    pub(crate) fail: usize,
+pub struct DoctorSummary {
+    pub pass: usize,
+    pub warn: usize,
+    pub fail: usize,
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct DoctorReport {
-    pub(crate) status: String,
-    pub(crate) summary: DoctorSummary,
-    pub(crate) checks: Vec<CheckRow>,
-    pub(crate) next_steps: Vec<String>,
+pub struct DoctorReport {
+    pub status: String,
+    pub summary: DoctorSummary,
+    pub checks: Vec<CheckRow>,
+    pub next_steps: Vec<String>,
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct CollectedItem {
-    pub(crate) path: String,
-    pub(crate) source: String,
-    pub(crate) notes: Option<String>,
+pub struct CollectedItem {
+    pub path: String,
+    pub source: String,
+    pub notes: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct SkippedItem {
-    pub(crate) path: String,
-    pub(crate) reason: String,
+pub struct SkippedItem {
+    pub path: String,
+    pub reason: String,
 }
 
 #[derive(Clone, Debug, Default, Serialize)]
-pub(crate) struct RedactionSummary {
-    pub(crate) files_redacted: usize,
-    pub(crate) replacements: usize,
+pub struct RedactionSummary {
+    pub files_redacted: usize,
+    pub replacements: usize,
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct ToolCommandResult {
-    pub(crate) name: String,
-    pub(crate) command: String,
-    pub(crate) status: Option<i32>,
-    pub(crate) stdout: String,
-    pub(crate) stderr: String,
-    pub(crate) error: Option<String>,
+pub struct ToolCommandResult {
+    pub name: String,
+    pub command: String,
+    pub status: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+    pub error: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct ReportManifest {
-    pub(crate) generated_at_unix: u64,
-    pub(crate) project_root: String,
-    pub(crate) output_archive: String,
-    pub(crate) include_count: usize,
-    pub(crate) skip_count: usize,
-    pub(crate) redaction: RedactionSummary,
-    pub(crate) collected: Vec<CollectedItem>,
-    pub(crate) skipped: Vec<SkippedItem>,
-    pub(crate) warnings: Vec<String>,
+pub struct ReportManifest {
+    pub generated_at_unix: u64,
+    pub project_root: String,
+    pub output_archive: String,
+    pub include_count: usize,
+    pub skip_count: usize,
+    pub redaction: RedactionSummary,
+    pub collected: Vec<CollectedItem>,
+    pub skipped: Vec<SkippedItem>,
+    pub warnings: Vec<String>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/process.rs
+++ b/src/process.rs
@@ -6,8 +6,7 @@ use std::process::{Command, Output, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
-use anyhow::bail;
-
+use crate::error::CommandFailed;
 use crate::model::Captured;
 use crate::DynResult;
 
@@ -45,6 +44,12 @@ fn should_echo() -> bool {
     ECHO_COMMANDS.load(Ordering::Relaxed)
 }
 
+/// Whether `$ <cmd>` echo lines are currently enabled. For call sites that
+/// hand-print an echo line instead of going through `run_*`.
+pub(crate) fn command_echo_enabled() -> bool {
+    should_echo()
+}
+
 pub(crate) fn render_command(cmd: &Command) -> String {
     let mut out = cmd.get_program().to_string_lossy().to_string();
     for arg in cmd.get_args() {
@@ -62,9 +67,19 @@ pub(crate) fn run_forwarded(cmd: &mut Command, label: &str) -> DynResult<()> {
     if should_echo() {
         println!("$ {}", render_command(cmd));
     }
+    let command = render_command(cmd);
     let status = cmd.status()?;
     if !status.success() {
-        bail!("{label} failed with {status}");
+        return Err(CommandFailed {
+            message: format!("{label} failed with {status}"),
+            command,
+            label: label.to_string(),
+            exit_code: status.code(),
+            stdout: String::new(),
+            stderr: String::new(),
+            log_path: None,
+        }
+        .into());
     }
     Ok(())
 }
@@ -177,7 +192,16 @@ pub(crate) fn run_logged(cmd: &mut Command, step: &str, log_path: &Path) -> DynR
                 render_command(cmd)
             ));
         }
-        bail!("{detail}");
+        Err(CommandFailed {
+            message: detail,
+            command: render_command(cmd),
+            label: step.to_string(),
+            exit_code: status.code(),
+            stdout: String::new(),
+            stderr: String::new(),
+            log_path: Some(log_path.to_path_buf()),
+        }
+        .into())
     }
 }
 
@@ -194,7 +218,16 @@ fn run_forwarded_with_status(cmd: &mut Command, step: &str) -> DynResult<()> {
         Ok(())
     } else {
         println!("  ✗ {step} ({duration})");
-        bail!("{step} failed with {status}");
+        Err(CommandFailed {
+            message: format!("{step} failed with {status}"),
+            command: render_command(cmd),
+            label: step.to_string(),
+            exit_code: status.code(),
+            stdout: String::new(),
+            stderr: String::new(),
+            log_path: None,
+        }
+        .into())
     }
 }
 
@@ -491,6 +524,7 @@ pub(crate) fn run_capture(cmd: &mut Command, label: &str) -> DynResult<Captured>
     if should_echo() {
         println!("$ {}", render_command(cmd));
     }
+    let command = render_command(cmd);
     let Output {
         status,
         stdout,
@@ -504,7 +538,16 @@ pub(crate) fn run_capture(cmd: &mut Command, label: &str) -> DynResult<Captured>
     };
 
     if !captured.status.success() {
-        bail!("{label} failed: {}", captured.stderr);
+        return Err(CommandFailed {
+            message: format!("{label} failed: {}", captured.stderr),
+            command,
+            label: label.to_string(),
+            exit_code: captured.status.code(),
+            stdout: captured.stdout,
+            stderr: captured.stderr,
+            log_path: None,
+        }
+        .into());
     }
 
     Ok(captured)

--- a/src/process.rs
+++ b/src/process.rs
@@ -64,10 +64,11 @@ pub(crate) fn run_checked(cmd: &mut Command, label: &str) -> DynResult<()> {
 }
 
 pub(crate) fn run_forwarded(cmd: &mut Command, label: &str) -> DynResult<()> {
-    if should_echo() {
-        println!("$ {}", render_command(cmd));
-    }
+    // Render once and reuse for both the echo line and any `CommandFailed`.
     let command = render_command(cmd);
+    if should_echo() {
+        println!("$ {command}");
+    }
     let status = cmd.status()?;
     if !status.success() {
         return Err(CommandFailed {
@@ -521,10 +522,11 @@ mod logged_tests {
 }
 
 pub(crate) fn run_capture(cmd: &mut Command, label: &str) -> DynResult<Captured> {
-    if should_echo() {
-        println!("$ {}", render_command(cmd));
-    }
+    // Render once and reuse for both the echo line and any `CommandFailed`.
     let command = render_command(cmd);
+    if should_echo() {
+        println!("$ {command}");
+    }
     let Output {
         status,
         stdout,

--- a/src/project.rs
+++ b/src/project.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, bail};
+use anyhow::{anyhow, bail, Context};
 
 use crate::config::{parse_config, serialize_config};
 use crate::model::{Project, RepoRef};
@@ -43,7 +43,12 @@ pub(crate) fn load_project() -> DynResult<Project> {
 /// depending on the process working directory.
 pub(crate) fn load_project_at(root: &Path) -> DynResult<Project> {
     let config_path = root.join("scaffold.toml");
-    if !config_path.exists() {
+    // `try_exists()` (not `exists()`): a permission/IO error on the path must
+    // surface as a real error, not be silently reported as a missing config.
+    if !config_path
+        .try_exists()
+        .with_context(|| format!("checking for {}", config_path.display()))?
+    {
         bail!(
             "no scaffold.toml found at {}. Pass the root directory of a logos-scaffold project.",
             root.display()

--- a/src/project.rs
+++ b/src/project.rs
@@ -35,10 +35,26 @@ pub(crate) fn load_project() -> DynResult<Project> {
         )
     })?;
 
+    load_project_at(&root)
+}
+
+/// Load a project from an explicit root directory (no upward discovery).
+/// The API layer uses this so consumers can target a project without
+/// depending on the process working directory.
+pub(crate) fn load_project_at(root: &Path) -> DynResult<Project> {
     let config_path = root.join("scaffold.toml");
+    if !config_path.exists() {
+        bail!(
+            "no scaffold.toml found at {}. Pass the root directory of a logos-scaffold project.",
+            root.display()
+        );
+    }
     let cfg_text = fs::read_to_string(&config_path)?;
     let cfg = parse_config(&cfg_text)?;
-    Ok(Project { root, config: cfg })
+    Ok(Project {
+        root: root.to_path_buf(),
+        config: cfg,
+    })
 }
 
 pub(crate) fn run_in_project_dir(

--- a/src/testnode.rs
+++ b/src/testnode.rs
@@ -1,0 +1,929 @@
+//! Isolated, short-lived sequencer test nodes.
+//!
+//! Unlike `localnet` — one long-lived developer sequencer per project, on a
+//! fixed port, with state inside the vendored LEZ checkout — a test node is
+//! an independent sequencer instance with its own RPC port, patched config,
+//! database, log file, and runtime directory. Test nodes are designed for
+//! integration tests: repeatable startup, isolated state, dynamic ports,
+//! machine-readable output, and clean teardown.
+//!
+//! Each node lives in a runtime directory (default
+//! `<project>/.scaffold/test-nodes/<id>`) containing:
+//!
+//! - `sequencer_config.json` — patched copy of the pinned LEZ debug config
+//!   with `home` pointed at the runtime directory;
+//! - `rocksdb/` — the node's own chain database (created by the sequencer,
+//!   or pre-seeded from a caller-provided state directory);
+//! - `sequencer.log` — captured stdout/stderr;
+//! - `node.json` — node metadata used by `status` / `stop` and by handles
+//!   reconnecting from another process.
+
+use std::fs;
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, bail, Context};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::circuits::ensure_circuits_for_subprocess;
+use crate::commands::localnet::find_r0vm_path_for_lez;
+use crate::commands::wallet_support::{rpc_get_last_block_id, RpcReachabilityError};
+use crate::constants::{SEQUENCER_BIN_REL_PATH, SEQUENCER_CONFIG_REL_PATH};
+use crate::model::Project;
+use crate::process::{pid_running, port_open, spawn_to_log};
+use crate::project::{resolve_cache_root, resolve_repo_path};
+use crate::DynResult;
+
+/// Project-relative directory holding test-node runtime directories.
+pub(crate) const TEST_NODES_REL_DIR: &str = ".scaffold/test-nodes";
+
+/// Metadata file written into every node runtime directory.
+const NODE_META_FILE: &str = "node.json";
+
+/// Default seconds to wait for a test node to become healthy.
+pub const DEFAULT_TEST_NODE_TIMEOUT_SEC: u64 = 60;
+
+/// How the RPC port for a test node is chosen.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum PortSelection {
+    /// Pick an unused localhost port automatically (reported in
+    /// [`TestNodeInfo::rpc_url`]).
+    #[default]
+    Auto,
+    /// Bind exactly this port; fails fast if it is already in use.
+    Fixed(u16),
+}
+
+/// Configuration for starting a test node.
+#[derive(Clone, Debug, Default)]
+pub struct TestNodeConfig {
+    /// Pre-seeded state directory (containing a `rocksdb/` database) to copy
+    /// into the node's runtime directory before startup. `None` starts from
+    /// the pinned genesis state.
+    pub state: Option<PathBuf>,
+    /// RPC port selection (default: auto).
+    pub port: PortSelection,
+    /// Runtime directory override. Default: a fresh directory under
+    /// `<project>/.scaffold/test-nodes/`.
+    pub work_dir: Option<PathBuf>,
+    /// Keep the runtime directory on stop/cleanup instead of deleting it.
+    pub preserve_work_dir: bool,
+    /// Seconds to wait for the node to become healthy during start
+    /// (0 → default of [`DEFAULT_TEST_NODE_TIMEOUT_SEC`]).
+    pub timeout_sec: u64,
+}
+
+/// Static facts about a running (or started) test node.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TestNodeInfo {
+    /// JSON-RPC endpoint, e.g. `http://127.0.0.1:39041`.
+    pub rpc_url: String,
+    /// Sequencer process id.
+    pub pid: u32,
+    /// Runtime directory owning the node's database, config, and logs.
+    pub state_dir: PathBuf,
+    /// Patched sequencer config the node was started with.
+    pub config_path: PathBuf,
+    /// Captured stdout/stderr of the sequencer process.
+    pub log_path: PathBuf,
+    /// Genesis block id from the node's config.
+    pub genesis_block_id: u64,
+    /// Block height observed when this info was produced.
+    pub block_height: u64,
+}
+
+/// Live status of a test node.
+#[derive(Clone, Debug, Serialize)]
+pub struct TestNodeStatus {
+    /// `true` when the process is running and the RPC endpoint answers.
+    pub healthy: bool,
+    /// Whether the sequencer process is running.
+    pub running: bool,
+    /// JSON-RPC endpoint the node serves.
+    pub rpc_url: String,
+    pub pid: u32,
+    /// Last block id reported over RPC, when reachable.
+    pub block_height: Option<u64>,
+    pub state_dir: PathBuf,
+    pub log_path: PathBuf,
+}
+
+/// Persisted node metadata (`node.json`). Superset of [`TestNodeInfo`] —
+/// carries the preserve flag and project root so `stop` from another process
+/// honors the caller's cleanup intent.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct NodeMeta {
+    pub(crate) pid: u32,
+    pub(crate) port: u16,
+    pub(crate) rpc_url: String,
+    pub(crate) state_dir: PathBuf,
+    pub(crate) config_path: PathBuf,
+    pub(crate) log_path: PathBuf,
+    pub(crate) genesis_block_id: u64,
+    pub(crate) project_root: PathBuf,
+    pub(crate) preserve_work_dir: bool,
+}
+
+/// A handle that owns a running test-node sequencer process and its runtime
+/// directory.
+///
+/// Dropping the handle stops the process and removes the runtime directory
+/// (unless `preserve_work_dir` was requested or [`TestNode::detach`] was
+/// called). Prefer explicit [`TestNode::stop`] in tests so teardown errors
+/// are observable.
+#[derive(Debug)]
+pub struct TestNode {
+    meta: NodeMeta,
+    /// When `true`, `Drop` stops the process and cleans the runtime dir.
+    owned: bool,
+}
+
+impl TestNode {
+    /// Start an isolated sequencer test node for `project`.
+    pub fn start(project: &Project, config: &TestNodeConfig) -> DynResult<Self> {
+        let prepared = verify_prepared(project)?;
+        let timeout_sec = if config.timeout_sec == 0 {
+            DEFAULT_TEST_NODE_TIMEOUT_SEC
+        } else {
+            config.timeout_sec
+        };
+
+        let work_dir = match &config.work_dir {
+            Some(dir) => {
+                fs::create_dir_all(dir)
+                    .with_context(|| format!("create work dir {}", dir.display()))?;
+                ensure_dir_empty_enough(dir)?;
+                dir.clone()
+            }
+            None => allocate_work_dir(&project.root)?,
+        };
+
+        let start = StartGuard::new(&work_dir, config.preserve_work_dir);
+
+        // Seed the database before the sequencer first opens it.
+        if let Some(state_src) = &config.state {
+            seed_state_dir(state_src, &work_dir)?;
+        }
+
+        let port = match config.port {
+            PortSelection::Auto => pick_unused_port()?,
+            PortSelection::Fixed(port) => {
+                let addr = format!("127.0.0.1:{port}");
+                if port_open(&addr) {
+                    bail!(
+                        "cannot start test node: port {port} is already in use. \
+                         Pass --port 0 to choose a free port automatically."
+                    );
+                }
+                port
+            }
+        };
+
+        let (config_path, genesis_block_id) = write_node_config(&prepared.lez, &work_dir, port)?;
+        let log_path = work_dir.join("sequencer.log");
+        let rpc_url = format!("http://127.0.0.1:{port}");
+
+        let mut cmd = Command::new(&prepared.sequencer_binary);
+        cmd.current_dir(&work_dir)
+            .arg(&config_path)
+            .arg("--port")
+            .arg(port.to_string())
+            .env("RUST_LOG", "info")
+            .env(
+                "RISC0_DEV_MODE",
+                if project.config.localnet.risc0_dev_mode {
+                    "1"
+                } else {
+                    "0"
+                },
+            );
+        if std::env::var("RISC0_SERVER_PATH").is_err() {
+            if let Some(r0vm) = find_r0vm_path_for_lez(&prepared.lez) {
+                cmd.env("RISC0_SERVER_PATH", &r0vm);
+            }
+        }
+
+        let pid = spawn_to_log(&mut cmd, &log_path)?;
+
+        let meta = NodeMeta {
+            pid,
+            port,
+            rpc_url,
+            state_dir: work_dir.clone(),
+            config_path,
+            log_path,
+            genesis_block_id,
+            project_root: project.root.clone(),
+            preserve_work_dir: config.preserve_work_dir,
+        };
+        write_node_meta(&meta)?;
+
+        let node = Self { meta, owned: true };
+        if let Err(err) = node.wait_healthy(Duration::from_secs(timeout_sec)) {
+            // Best-effort teardown; the start error is the interesting one.
+            let _ = node.kill_process(Duration::from_secs(5));
+            drop(start); // removes the work dir unless preservation was asked
+            std::mem::forget(node); // teardown already handled above
+            return Err(err);
+        }
+
+        start.disarm();
+        Ok(node)
+    }
+
+    /// Reconnect to a node started earlier (possibly by another process) from
+    /// its runtime directory. The returned handle is detached: dropping it
+    /// does not stop the node.
+    pub fn from_state_dir(state_dir: &Path) -> DynResult<Self> {
+        let meta = read_node_meta(state_dir)?;
+        Ok(Self { meta, owned: false })
+    }
+
+    /// Static facts about the node, refreshing the observed block height.
+    pub fn info(&self) -> TestNodeInfo {
+        let block_height = rpc_get_last_block_id(&self.meta.rpc_url).unwrap_or(0);
+        TestNodeInfo {
+            rpc_url: self.meta.rpc_url.clone(),
+            pid: self.meta.pid,
+            state_dir: self.meta.state_dir.clone(),
+            config_path: self.meta.config_path.clone(),
+            log_path: self.meta.log_path.clone(),
+            genesis_block_id: self.meta.genesis_block_id,
+            block_height,
+        }
+    }
+
+    /// The node's JSON-RPC endpoint.
+    pub fn rpc_url(&self) -> &str {
+        &self.meta.rpc_url
+    }
+
+    /// The node's runtime directory.
+    pub fn state_dir(&self) -> &Path {
+        &self.meta.state_dir
+    }
+
+    /// Live status: process running, RPC reachable, current block height.
+    pub fn status(&self) -> TestNodeStatus {
+        let running = pid_running(self.meta.pid);
+        let block_height = rpc_get_last_block_id(&self.meta.rpc_url).ok();
+        TestNodeStatus {
+            healthy: running && block_height.is_some(),
+            running,
+            rpc_url: self.meta.rpc_url.clone(),
+            pid: self.meta.pid,
+            block_height,
+            state_dir: self.meta.state_dir.clone(),
+            log_path: self.meta.log_path.clone(),
+        }
+    }
+
+    /// Block until the node answers RPC (or fail with a diagnostic carrying
+    /// the log tail).
+    pub fn wait_healthy(&self, timeout: Duration) -> DynResult<()> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if !pid_running(self.meta.pid) {
+                bail!(
+                    "test node exited before becoming ready (pid={})\nlast logs:\n{}",
+                    self.meta.pid,
+                    log_tail(&self.meta.log_path, 60)
+                );
+            }
+            match rpc_get_last_block_id(&self.meta.rpc_url) {
+                Ok(_) => return Ok(()),
+                Err(RpcReachabilityError::Connectivity(_)) => {}
+                // The server is up but answered oddly (e.g. still
+                // initializing); keep polling until the deadline.
+                Err(_) => {}
+            }
+            if Instant::now() >= deadline {
+                bail!(
+                    "test node did not become healthy within {}s (pid={}, rpc={})\nlast logs:\n{}",
+                    timeout.as_secs(),
+                    self.meta.pid,
+                    self.meta.rpc_url,
+                    log_tail(&self.meta.log_path, 60)
+                );
+            }
+            thread::sleep(Duration::from_millis(200));
+        }
+    }
+
+    /// Stop the node and remove its runtime directory (unless the node was
+    /// started with `preserve_work_dir`). Consumes the handle.
+    pub fn stop(mut self) -> DynResult<()> {
+        self.owned = false; // teardown handled here; Drop must not repeat it
+        stop_node_at(&self.meta, None)
+    }
+
+    /// Detach the handle: the node keeps running after the handle is dropped.
+    pub fn detach(mut self) -> TestNodeInfo {
+        self.owned = false;
+        self.info()
+    }
+
+    fn kill_process(&self, wait: Duration) -> DynResult<()> {
+        terminate_pid(self.meta.pid, wait)
+    }
+}
+
+impl Drop for TestNode {
+    fn drop(&mut self) {
+        if !self.owned {
+            return;
+        }
+        let _ = terminate_pid(self.meta.pid, Duration::from_secs(5));
+        if !self.meta.preserve_work_dir {
+            let _ = fs::remove_dir_all(&self.meta.state_dir);
+        }
+    }
+}
+
+/// Result of preparing/verifying the test-node prerequisites for a project.
+#[derive(Clone, Debug, Serialize)]
+pub struct PreparedTestNode {
+    /// Pinned LEZ checkout the sequencer binary comes from.
+    pub lez: PathBuf,
+    /// Standalone sequencer binary.
+    pub sequencer_binary: PathBuf,
+    /// Circuits release directory exported to spawned nodes.
+    pub circuits_dir: PathBuf,
+}
+
+/// Verify the standalone sequencer binary and circuits release are available
+/// for `project`, materialising the circuits release if needed.
+pub fn prepare_for_project(project: &Project) -> DynResult<PreparedTestNode> {
+    let prepared = verify_prepared(project)?;
+    Ok(prepared)
+}
+
+fn verify_prepared(project: &Project) -> DynResult<PreparedTestNode> {
+    let lez = resolve_repo_path(project, &project.config.lez, "lez")?;
+    let sequencer_binary = lez.join(SEQUENCER_BIN_REL_PATH);
+    if !sequencer_binary.exists() {
+        bail!(
+            "missing standalone sequencer binary at {}.\n\
+             Next step: run `lgs setup` (or `lgs test-node prepare`) to build it.",
+            sequencer_binary.display()
+        );
+    }
+    let (cache_root, _) = resolve_cache_root(project)?;
+    ensure_circuits_for_subprocess(&cache_root)?;
+    let circuits_dir = crate::circuits::circuits_dir_for_cache_root(&cache_root)?;
+    Ok(PreparedTestNode {
+        lez,
+        sequencer_binary,
+        circuits_dir,
+    })
+}
+
+/// Start a node, export its connection details to `command`'s environment,
+/// forward the child's exit status, and stop the node when the child exits.
+///
+/// Exported environment: `LGS_TEST_NODE_RPC_URL`, `LGS_TEST_NODE_PORT`,
+/// `LGS_TEST_NODE_PID`, `LGS_TEST_NODE_STATE_DIR`, `LGS_TEST_NODE_CONFIG_PATH`,
+/// `LGS_TEST_NODE_LOG_PATH`, `LGS_TEST_NODE_GENESIS_BLOCK_ID`.
+pub fn run_with_test_node(
+    project: &Project,
+    config: &TestNodeConfig,
+    command: &[String],
+) -> DynResult<std::process::ExitStatus> {
+    let Some((program, args)) = command.split_first() else {
+        bail!("test-node run requires a command after `--`");
+    };
+
+    let node = TestNode::start(project, config)?;
+    let info = node.info();
+
+    let status = Command::new(program)
+        .args(args)
+        .env("LGS_TEST_NODE_RPC_URL", &info.rpc_url)
+        .env("LGS_TEST_NODE_PORT", node.meta.port.to_string())
+        .env("LGS_TEST_NODE_PID", info.pid.to_string())
+        .env("LGS_TEST_NODE_STATE_DIR", &info.state_dir)
+        .env("LGS_TEST_NODE_CONFIG_PATH", &info.config_path)
+        .env("LGS_TEST_NODE_LOG_PATH", &info.log_path)
+        .env(
+            "LGS_TEST_NODE_GENESIS_BLOCK_ID",
+            info.genesis_block_id.to_string(),
+        )
+        .status()
+        .with_context(|| format!("failed to spawn `{program}`"));
+
+    let stop_result = node.stop();
+    let status = status?;
+    stop_result?;
+    Ok(status)
+}
+
+/// Resolve a `--node` selector to a runtime directory: an existing directory
+/// path is used as-is; otherwise it is treated as a node id under the
+/// project's `.scaffold/test-nodes/`.
+pub fn resolve_node_dir(project_root: &Path, selector: &str) -> DynResult<PathBuf> {
+    let as_path = PathBuf::from(selector);
+    if as_path.is_dir() {
+        return Ok(as_path);
+    }
+    let candidate = project_root.join(TEST_NODES_REL_DIR).join(selector);
+    if candidate.is_dir() {
+        return Ok(candidate);
+    }
+    bail!(
+        "unknown test node `{selector}`: not a directory and {} does not exist",
+        candidate.display()
+    )
+}
+
+/// Stop the node whose runtime directory is `state_dir`. `preserve_override`
+/// forces keeping/removing the directory regardless of what the node was
+/// started with.
+pub fn stop_node_in_dir(state_dir: &Path, preserve_override: Option<bool>) -> DynResult<()> {
+    let meta = read_node_meta(state_dir)?;
+    stop_node_at(&meta, preserve_override)
+}
+
+fn stop_node_at(meta: &NodeMeta, preserve_override: Option<bool>) -> DynResult<()> {
+    terminate_pid(meta.pid, Duration::from_secs(10))?;
+    let preserve = preserve_override.unwrap_or(meta.preserve_work_dir);
+    if !preserve {
+        fs::remove_dir_all(&meta.state_dir).with_context(|| {
+            format!(
+                "failed to remove test-node runtime dir {}",
+                meta.state_dir.display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+/// TERM the pid, wait for exit, escalate to KILL after half the deadline.
+/// A pid that is already gone is success (idempotent stop).
+fn terminate_pid(pid: u32, wait: Duration) -> DynResult<()> {
+    if !pid_running(pid) {
+        return Ok(());
+    }
+    let _ = Command::new("kill").arg(pid.to_string()).status();
+    let half = wait / 2;
+    if wait_for_pid_exit(pid, half) {
+        return Ok(());
+    }
+    let _ = Command::new("kill").arg("-9").arg(pid.to_string()).status();
+    if wait_for_pid_exit(pid, half) {
+        return Ok(());
+    }
+    bail!("test node process {pid} did not exit after TERM and KILL");
+}
+
+fn wait_for_pid_exit(pid: u32, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if !pid_running(pid) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Bind port 0 to learn a free port, then release it. There is a small race
+/// window before the sequencer rebinds; callers get a clear port-in-use error
+/// if it is lost.
+fn pick_unused_port() -> DynResult<u16> {
+    let listener =
+        TcpListener::bind("127.0.0.1:0").context("failed to probe for an unused port")?;
+    let port = listener
+        .local_addr()
+        .context("failed to read probed port")?
+        .port();
+    Ok(port)
+}
+
+/// Allocate a fresh runtime directory under `.scaffold/test-nodes/`.
+fn allocate_work_dir(project_root: &Path) -> DynResult<PathBuf> {
+    let base = project_root.join(TEST_NODES_REL_DIR);
+    fs::create_dir_all(&base).with_context(|| format!("create {}", base.display()))?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let pid = std::process::id();
+    for attempt in 0u32..100 {
+        let id = format!("tn-{}-{:05}-{attempt:02}", now.as_secs(), pid % 100_000);
+        let dir = base.join(&id);
+        match fs::create_dir(&dir) {
+            Ok(()) => return Ok(dir),
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(err) => {
+                return Err(err).with_context(|| format!("create node dir {}", dir.display()))
+            }
+        }
+    }
+    bail!(
+        "could not allocate a unique test-node directory under {}",
+        base.display()
+    )
+}
+
+/// A caller-supplied work dir must not already contain another node's state.
+fn ensure_dir_empty_enough(dir: &Path) -> DynResult<()> {
+    if dir.join(NODE_META_FILE).exists() {
+        bail!(
+            "work dir {} already contains a test node (found {}). \
+             Stop it first or pass a fresh directory.",
+            dir.display(),
+            NODE_META_FILE
+        );
+    }
+    Ok(())
+}
+
+/// Copy a caller-provided state directory's database into the node work dir.
+/// Accepts either a directory containing `rocksdb/` or a bare database
+/// directory.
+fn seed_state_dir(state_src: &Path, work_dir: &Path) -> DynResult<()> {
+    if !state_src.is_dir() {
+        bail!("state directory not found at {}", state_src.display());
+    }
+    let src_db = if state_src.join("rocksdb").is_dir() {
+        state_src.join("rocksdb")
+    } else {
+        state_src.to_path_buf()
+    };
+    let dest_db = work_dir.join("rocksdb");
+    copy_dir_recursive(&src_db, &dest_db).with_context(|| {
+        format!(
+            "failed to seed state from {} into {}",
+            src_db.display(),
+            dest_db.display()
+        )
+    })
+}
+
+fn copy_dir_recursive(src: &Path, dest: &Path) -> DynResult<()> {
+    fs::create_dir_all(dest)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let target = dest.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_recursive(&entry.path(), &target)?;
+        } else {
+            fs::copy(entry.path(), &target)?;
+        }
+    }
+    Ok(())
+}
+
+/// Produce the node's sequencer config: the pinned LEZ debug config with
+/// `home` pointed at the node's runtime directory, the port recorded, and
+/// `max_block_size` widened (same rationale as localnet). Returns the config
+/// path and the genesis block id.
+fn write_node_config(lez: &Path, work_dir: &Path, port: u16) -> DynResult<(PathBuf, u64)> {
+    let src_path = lez.join(SEQUENCER_CONFIG_REL_PATH);
+    let text = fs::read_to_string(&src_path)
+        .with_context(|| format!("failed to read {}", src_path.display()))?;
+    let mut doc: Value =
+        serde_json::from_str(&text).context("failed to parse sequencer_config.json")?;
+    let Some(obj) = doc.as_object_mut() else {
+        bail!(
+            "sequencer_config.json is not a JSON object: {}",
+            src_path.display()
+        );
+    };
+
+    obj.insert(
+        "home".to_string(),
+        Value::String(work_dir.display().to_string()),
+    );
+    // Recorded for tooling; the pinned sequencer takes the port via --port.
+    obj.insert("port".to_string(), Value::Number(port.into()));
+    obj.insert(
+        "max_block_size".to_string(),
+        Value::String("8 MiB".to_string()),
+    );
+
+    let genesis_block_id = obj
+        .get("genesis_id")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| {
+            anyhow!(
+                "sequencer config at {} has no numeric `genesis_id`",
+                src_path.display()
+            )
+        })?;
+
+    let dest_path = work_dir.join("sequencer_config.json");
+    let updated = serde_json::to_string_pretty(&doc).context("failed to serialize config")?;
+    fs::write(&dest_path, format!("{updated}\n"))
+        .with_context(|| format!("failed to write {}", dest_path.display()))?;
+    Ok((dest_path, genesis_block_id))
+}
+
+fn write_node_meta(meta: &NodeMeta) -> DynResult<()> {
+    let path = meta.state_dir.join(NODE_META_FILE);
+    let text = serde_json::to_string_pretty(meta).context("serialize node metadata")?;
+    fs::write(&path, format!("{text}\n"))
+        .with_context(|| format!("failed to write {}", path.display()))
+}
+
+pub(crate) fn read_node_meta(state_dir: &Path) -> DynResult<NodeMeta> {
+    let path = state_dir.join(NODE_META_FILE);
+    if !path.exists() {
+        bail!(
+            "{} is not a test-node runtime directory (missing {})",
+            state_dir.display(),
+            NODE_META_FILE
+        );
+    }
+    let text =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    serde_json::from_str(&text)
+        .with_context(|| format!("failed to parse node metadata at {}", path.display()))
+}
+
+fn log_tail(log_path: &Path, tail: usize) -> String {
+    let Ok(content) = fs::read_to_string(log_path) else {
+        return format!("<log file missing: {}>", log_path.display());
+    };
+    let lines: Vec<&str> = content.lines().collect();
+    if lines.is_empty() {
+        return "<no log output yet>".to_string();
+    }
+    let start = lines.len().saturating_sub(tail);
+    lines[start..].join("\n")
+}
+
+/// Removes the work dir on early start failure (unless preservation was
+/// requested); disarmed once the node is healthy.
+struct StartGuard {
+    dir: PathBuf,
+    preserve: bool,
+    armed: std::cell::Cell<bool>,
+}
+
+impl StartGuard {
+    fn new(dir: &Path, preserve: bool) -> Self {
+        Self {
+            dir: dir.to_path_buf(),
+            preserve,
+            armed: std::cell::Cell::new(true),
+        }
+    }
+
+    fn disarm(&self) {
+        self.armed.set(false);
+    }
+}
+
+impl Drop for StartGuard {
+    fn drop(&mut self) {
+        if self.armed.get() && !self.preserve {
+            let _ = fs::remove_dir_all(&self.dir);
+        }
+    }
+}
+
+// ─── cross-process run slots (--serial / --parallel) ────────────────────────
+
+/// Guard for one concurrency slot acquired via `acquire_run_slot`. Releases
+/// the slot file on drop.
+pub struct RunSlot {
+    path: PathBuf,
+}
+
+impl Drop for RunSlot {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+/// Cap concurrent test-node creation across processes by acquiring one of
+/// `max_parallel` slot files under the cache root. `--serial` is
+/// `max_parallel == 1`. Slots held by dead processes are reclaimed.
+pub fn acquire_run_slot(cache_root: &Path, max_parallel: usize) -> DynResult<RunSlot> {
+    let slots_dir = cache_root.join("test-node-slots");
+    fs::create_dir_all(&slots_dir)
+        .with_context(|| format!("create slot dir {}", slots_dir.display()))?;
+    let my_pid = std::process::id().to_string();
+
+    loop {
+        for slot in 0..max_parallel {
+            let path = slots_dir.join(format!("slot-{slot}.lock"));
+
+            // Reclaim slots whose owning process is gone.
+            if let Ok(existing) = fs::read_to_string(&path) {
+                if let Ok(owner) = existing.trim().parse::<u32>() {
+                    if !pid_running(owner) {
+                        let _ = fs::remove_file(&path);
+                    }
+                } else {
+                    let _ = fs::remove_file(&path);
+                }
+            }
+
+            match fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&path)
+            {
+                Ok(mut file) => {
+                    use std::io::Write;
+                    let _ = file.write_all(my_pid.as_bytes());
+                    return Ok(RunSlot { path });
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(err) => {
+                    return Err(err).with_context(|| format!("acquire slot {}", path.display()))
+                }
+            }
+        }
+        thread::sleep(Duration::from_millis(250));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn write_node_config_patches_home_port_and_block_size() {
+        let temp = tempdir().unwrap();
+        let lez = temp.path().join("lez");
+        let work = temp.path().join("node");
+        fs::create_dir_all(&work).unwrap();
+        let config_path = lez.join(SEQUENCER_CONFIG_REL_PATH);
+        fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        fs::write(
+            &config_path,
+            r#"{ "home": ".", "genesis_id": 1, "port": 3040 }"#,
+        )
+        .unwrap();
+
+        let (dest, genesis) = write_node_config(&lez, &work, 41234).unwrap();
+        assert_eq!(genesis, 1);
+        assert_eq!(dest, work.join("sequencer_config.json"));
+
+        let doc: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&dest).unwrap()).unwrap();
+        assert_eq!(doc["home"], serde_json::json!(work.display().to_string()));
+        assert_eq!(doc["port"], serde_json::json!(41234));
+        assert_eq!(doc["max_block_size"], serde_json::json!("8 MiB"));
+
+        // The vendored config must be untouched.
+        let src: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(src["home"], serde_json::json!("."));
+        assert_eq!(src["port"], serde_json::json!(3040));
+    }
+
+    #[test]
+    fn write_node_config_requires_genesis_id() {
+        let temp = tempdir().unwrap();
+        let lez = temp.path().join("lez");
+        let work = temp.path().join("node");
+        fs::create_dir_all(&work).unwrap();
+        let config_path = lez.join(SEQUENCER_CONFIG_REL_PATH);
+        fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        fs::write(&config_path, r#"{ "home": "." }"#).unwrap();
+
+        let err = write_node_config(&lez, &work, 41234).unwrap_err();
+        assert!(err.to_string().contains("genesis_id"), "{err}");
+    }
+
+    #[test]
+    fn node_meta_round_trips_through_state_dir() {
+        let temp = tempdir().unwrap();
+        let meta = NodeMeta {
+            pid: 4242,
+            port: 39000,
+            rpc_url: "http://127.0.0.1:39000".to_string(),
+            state_dir: temp.path().to_path_buf(),
+            config_path: temp.path().join("sequencer_config.json"),
+            log_path: temp.path().join("sequencer.log"),
+            genesis_block_id: 1,
+            project_root: temp.path().join("project"),
+            preserve_work_dir: true,
+        };
+        write_node_meta(&meta).unwrap();
+
+        let loaded = read_node_meta(temp.path()).unwrap();
+        assert_eq!(loaded.pid, 4242);
+        assert_eq!(loaded.port, 39000);
+        assert_eq!(loaded.rpc_url, "http://127.0.0.1:39000");
+        assert!(loaded.preserve_work_dir);
+    }
+
+    #[test]
+    fn read_node_meta_rejects_non_node_dir() {
+        let temp = tempdir().unwrap();
+        let err = read_node_meta(temp.path()).unwrap_err();
+        assert!(err.to_string().contains("node.json"), "{err}");
+    }
+
+    #[test]
+    fn resolve_node_dir_accepts_path_and_id() {
+        let temp = tempdir().unwrap();
+        let project_root = temp.path();
+        let nodes = project_root.join(TEST_NODES_REL_DIR);
+        let node_dir = nodes.join("tn-test-1");
+        fs::create_dir_all(&node_dir).unwrap();
+
+        let by_id = resolve_node_dir(project_root, "tn-test-1").unwrap();
+        assert_eq!(by_id, node_dir);
+
+        let by_path = resolve_node_dir(project_root, node_dir.to_str().unwrap()).unwrap();
+        assert_eq!(by_path, node_dir);
+
+        let err = resolve_node_dir(project_root, "tn-missing").unwrap_err();
+        assert!(err.to_string().contains("tn-missing"), "{err}");
+    }
+
+    #[test]
+    fn allocate_work_dir_creates_unique_dirs() {
+        let temp = tempdir().unwrap();
+        let a = allocate_work_dir(temp.path()).unwrap();
+        let b = allocate_work_dir(temp.path()).unwrap();
+        assert_ne!(a, b);
+        assert!(a.is_dir());
+        assert!(b.is_dir());
+        assert!(a.starts_with(temp.path().join(TEST_NODES_REL_DIR)));
+    }
+
+    #[test]
+    fn seed_state_dir_copies_rocksdb_layouts() {
+        let temp = tempdir().unwrap();
+
+        // Layout A: state dir containing rocksdb/
+        let src_a = temp.path().join("state-a");
+        fs::create_dir_all(src_a.join("rocksdb/sub")).unwrap();
+        fs::write(src_a.join("rocksdb/CURRENT"), "manifest").unwrap();
+        fs::write(src_a.join("rocksdb/sub/file.sst"), "data").unwrap();
+        let work_a = temp.path().join("node-a");
+        fs::create_dir_all(&work_a).unwrap();
+        seed_state_dir(&src_a, &work_a).unwrap();
+        assert_eq!(
+            fs::read_to_string(work_a.join("rocksdb/CURRENT")).unwrap(),
+            "manifest"
+        );
+        assert_eq!(
+            fs::read_to_string(work_a.join("rocksdb/sub/file.sst")).unwrap(),
+            "data"
+        );
+
+        // Layout B: bare database directory
+        let src_b = temp.path().join("state-b");
+        fs::create_dir_all(&src_b).unwrap();
+        fs::write(src_b.join("CURRENT"), "manifest-b").unwrap();
+        let work_b = temp.path().join("node-b");
+        fs::create_dir_all(&work_b).unwrap();
+        seed_state_dir(&src_b, &work_b).unwrap();
+        assert_eq!(
+            fs::read_to_string(work_b.join("rocksdb/CURRENT")).unwrap(),
+            "manifest-b"
+        );
+    }
+
+    #[test]
+    fn seed_state_dir_rejects_missing_source() {
+        let temp = tempdir().unwrap();
+        let work = temp.path().join("node");
+        fs::create_dir_all(&work).unwrap();
+        let err = seed_state_dir(&temp.path().join("nope"), &work).unwrap_err();
+        assert!(err.to_string().contains("state directory"), "{err}");
+    }
+
+    #[test]
+    fn run_slot_reclaims_stale_and_blocks_live() {
+        let temp = tempdir().unwrap();
+
+        // A stale slot (dead pid) must be reclaimed.
+        let slots = temp.path().join("test-node-slots");
+        fs::create_dir_all(&slots).unwrap();
+        fs::write(slots.join("slot-0.lock"), "999999999").unwrap();
+        let slot = acquire_run_slot(temp.path(), 1).unwrap();
+        let content = fs::read_to_string(slots.join("slot-0.lock")).unwrap();
+        assert_eq!(content, std::process::id().to_string());
+
+        // Releasing the guard frees the slot for the next acquire.
+        drop(slot);
+        assert!(!slots.join("slot-0.lock").exists());
+        let _slot2 = acquire_run_slot(temp.path(), 1).unwrap();
+    }
+
+    #[test]
+    fn ensure_dir_empty_enough_rejects_existing_node() {
+        let temp = tempdir().unwrap();
+        fs::write(temp.path().join(NODE_META_FILE), "{}").unwrap();
+        let err = ensure_dir_empty_enough(temp.path()).unwrap_err();
+        assert!(err.to_string().contains("already contains"), "{err}");
+    }
+}


### PR DESCRIPTION
## Summary

Implements #203: a `lgs test-node` command group plus `api::testnode` Rust API for integration tests that need a real standalone LEZ sequencer that is **isolated, short-lived, machine-readable, and CI-safe** — as opposed to `localnet`, which is one long-lived developer sequencer per project on a fixed port.

> Stacked on #212 (public Rust API). Review/merge that first; this PR's own diff is the last commit.

### How isolation works

The pinned LEZ sequencer (v0.1.2) takes its RPC port from the `--port` CLI flag and its storage root from the config's `home` field. Each test node gets a patched copy of the pinned debug config with `home` pointed at the node's own runtime directory (`.scaffold/test-nodes/<id>` by default), so every node has its own port, rocksdb database, log file, and `node.json` metadata — and never touches the vendored LEZ checkout or the developer's localnet.

### Commands

```
lgs test-node prepare [--project <dir>] [--json]
lgs test-node start   [--project <dir>] [--state <dir>] [--port <p|0>] [--work-dir <dir>] [--preserve-work-dir] [--json]
lgs test-node status  --node <id|dir> [--json]
lgs test-node stop    --node <id|dir> [--preserve-work-dir]
lgs test-node run     [--project <dir>] [--state <dir>] [--serial | --parallel <n>] -- <command> [args...]
```

- `prepare` verifies the standalone sequencer binary and materialises the circuits release for the caller project.
- `start --port 0` (default) picks an unused localhost port; `--json` prints `rpc_url`, `pid`, `state_dir`, `config_path`, `log_path`, `genesis_block_id`, and current `block_height`.
- `start --state <dir>` seeds the node's database from a caller-provided state directory (full seeding/validation pipeline is #204).
- `status --json` reports health + served RPC URL, and exits non-zero when unhealthy.
- `stop` terminates only the selected node (TERM → KILL escalation) and removes its runtime state unless preservation was requested.
- `run` starts a node, waits for health, exports `LGS_TEST_NODE_RPC_URL` / `LGS_TEST_NODE_PORT` / `LGS_TEST_NODE_STATE_DIR` / `LGS_TEST_NODE_CONFIG_PATH` / `LGS_TEST_NODE_LOG_PATH` / `LGS_TEST_NODE_GENESIS_BLOCK_ID` to the child, forwards the child's exit status, and stops the node when the child exits. `--serial` / `--parallel <n>` cap machine-wide concurrent node creation via pid-stamped slot files (stale slots from dead processes are reclaimed).
- Clear non-zero failures for missing binaries, missing circuits, explicit-port conflicts, unhealthy nodes (with log tail), and child process failures.

### Rust API (`logos_scaffold::api::testnode`)

```rust
let node = TestNode::start(&project, &TestNodeConfig {
    state: Some(seeded_state_dir),
    port: PortSelection::Auto,
    work_dir: None,
    preserve_work_dir: false,
    ..Default::default()
})?;
let info: TestNodeInfo = node.info();
node.wait_healthy(timeout)?;
let status: TestNodeStatus = node.status()?;
node.stop()?;
```

`TestNode` owns the child process and runtime directory with cleanup on `Drop`; `detach()` opts out, `from_state_dir()` reconnects from another process. `run_with_test_node(&project, &config, &command)` mirrors `test-node run`. CLI commands are thin wrappers over this API.

## Verification

- `cargo fmt --check`, `cargo check` clean
- `cargo test`: 407 lib tests (10 new test-node unit tests covering config patching, metadata round-trips, node-dir resolution, state seeding layouts, slot reclaim) + 168 CLI integration tests + 4 doc examples, all green
- CLI smoke-tested: help surface, outside-project error, `run` arg validation
- Full end-to-end (spawning a real sequencer) requires a built LEZ checkout + circuits release, which isn't reproducible in this environment; the process-lifecycle building blocks reused from `localnet` (spawn_to_log, readiness polling, pid handling) are the ones already exercised in production

Closes #203