### PR TITLE
feat(basecamp): add a module build/run workflow

### DIFF
--- a/DOGFOODING.md
+++ b/DOGFOODING.md
@@ -157,7 +157,8 @@ If any of these is missing, do not "skip the real run" — go back and fix the s
 | B2 | external module project | Core | Module capture, install, and single-instance launch | `basecamp modules`, `basecamp modules --show`, `basecamp install`, `basecamp launch alice` |
 | B3 | external module project | Core | Two-instance p2p dogfooding | `basecamp launch alice`, `basecamp launch bob` (parallel) |
 | B4 | external module project | Advanced | Clean-slate scrub semantics on relaunch | `basecamp launch alice` (×2) |
-| B5 | external module project | Advanced | Portable artefact build for AppImage hand-loading | `basecamp build-portable` |
+| B5 | external module project | Advanced | Module artefact builds by variant | `basecamp build`, `basecamp build-portable`, `--variant`, `--module` |
+| B6 | external module project | Advanced | Captured module run loop | `basecamp run <module>`, `--host standalone|basecamp` |
 | A1 | N/A | Advanced | Public Rust API surface for embedding scaffold in tests/tooling | `logos_scaffold::api::Project`, `cargo doc`, doctests |
 | T1 | `default` | Advanced | Isolated test-node lifecycle and caller-project pins | `test-node pins`, `test-node prepare`, `test-node doctor`, `test-node start`, `test-node status`, `test-node stop`, `test-node run` |
 | T2 | `default` | Advanced | Typed RPC reads against a running test node | `test-node tx submit-and-wait`, `test-node blocks head/range/wait`, `test-node clock read/wait-stable`, `test-node account get/batch-get`, `test-node proof get`, `test-node snapshot accounts` |
@@ -1188,47 +1189,99 @@ test -e .scaffold/basecamp/profiles/alice/.scaffold-xdg-data/scratch/marker.txt 
 - Use a marker filename and timestamp you can search for after the fact; do not rely on visual inspection alone.
 - Clean-slate state is project-local; never test scrub behavior against the user's global Logos directories.
 
-## B5. Build-Portable Artefacts for AppImage Hand-Loading
+## B5. Module Artefact Builds by Variant
 
 ### Goal
 
-Validate that project sources captured under `[modules]` with `role = "project"` can be built against their `#lgx-portable` flake output for hand-loading into a basecamp AppImage, and that runtime `role = "dependency"` entries are skipped.
+Validate that project sources captured under `[modules]` with `role = "project"` can be built against their `#lgx` and `#lgx-portable` flake outputs, that `--module` narrows the build, and that the old `build-portable` command remains a compatibility alias for the portable variant.
 
 ### Preconditions
 
 - B2 completed (project sources are captured and `basecamp install` has succeeded against `.#lgx`).
-- The same flakes also expose `packages.<system>.lgx-portable`.
+- The same flakes expose `packages.<system>.lgx` and, for portable checks, `packages.<system>.lgx-portable`.
 
 ### Commands / Actions
 
 From the module project root:
 
 ```bash
+"$SCAFFOLD_BIN" basecamp build --variant all
+"$SCAFFOLD_BIN" basecamp build --variant lgx --module <module-name>
+"$SCAFFOLD_BIN" basecamp build --variant lgx-portable --module <module-name>
 "$SCAFFOLD_BIN" basecamp build-portable
-ls .scaffold/basecamp/portable 2>/dev/null || find .scaffold -maxdepth 4 -name '*lgx-portable*' -o -name '*.tgz' | sort
+find .scaffold/basecamp -maxdepth 3 -type f -o -type l | sort
 ```
 
 ### Expected Success Signals
 
-- `build-portable` builds `.#lgx-portable` for each `role = "project"` entry in `[modules]`, in dependency order, and writes / symlinks the resulting artefacts under `.scaffold/`.
-- `role = "dependency"` entries are skipped — the target AppImage provides its own copies.
-- A flake that does not expose `.#lgx-portable` fails with a targeted error naming the missing attribute, not a raw nix trace.
+- `basecamp build --variant all` builds both `.#lgx` and `.#lgx-portable` for each `role = "project"` entry in dependency order, then writes/symlinks outputs under `.scaffold/basecamp/<variant-dir>/`.
+- `--module <module-name>` builds only that captured project module and fails clearly for an unknown module.
+- `build-portable` behaves like `basecamp build --variant lgx-portable` and keeps the historical `.scaffold/basecamp/portable/` output directory.
+- `role = "dependency"` entries are skipped by build commands; dependencies are runtime inputs provided by install/basecamp.
+- A flake that does not expose the requested variant fails with a targeted error naming the missing attribute, not a raw nix trace or silent fallback.
 
 ### Failure Signals / Common Pitfalls
 
-- A `build-portable` that silently falls back from `.#lgx-portable` to `.#lgx` is a contract violation — the variant choice is the user's.
+- Any requested variant that silently falls back to another variant is a contract violation.
+- An empty, duplicated, unknown, or path-like variant value through the Rust API must be rejected or normalized before filesystem work.
 - Building dependency entries (those with `role = "dependency"`) is wasted work and a behavior regression.
 - Out-of-order builds that ignore the dependency graph between project sources are a regression introduced by changes to ordering logic.
 
 ### Evidence to Capture
 
-- `basecamp build-portable` output excerpt including the per-source build lines.
+- `basecamp build` and `basecamp build-portable` output excerpts including the per-source build lines.
 - The directory listing of the produced artefacts under `.scaffold/`.
 - For any failure, the exact missing flake attribute and the offending project source.
 
 ### Execution Notes
 
-- This scenario does not exercise the AppImage itself — it stops at producing artefacts. Hand-loading into a basecamp AppImage is owned by the AppImage release, not by scaffold.
+- This scenario does not exercise the AppImage itself. Hand-loading into a basecamp AppImage is owned by the AppImage release, not by scaffold.
+
+## B6. Captured Module Run Loop
+
+### Goal
+
+Validate that `basecamp run` launches a captured module from its flake for the local development loop, and that host selection is predictable.
+
+### Preconditions
+
+- B2 completed and `[modules.<name>]` contains at least one `role = "project"` module captured from a flake, not from a prebuilt `.lgx` file.
+- For standalone UI checks, the module flake exposes `apps.<system>.default` or the attr named by `[modules.<name>].standalone_app`.
+
+### Commands / Actions
+
+From the module project root:
+
+```bash
+"$SCAFFOLD_BIN" basecamp run <module-name> --host standalone
+"$SCAFFOLD_BIN" basecamp run <module-name>
+"$SCAFFOLD_BIN" basecamp run <module-name> --host basecamp
+```
+
+For one negative-path check, capture or hand-edit a module entry that points at a prebuilt `.lgx` path and run:
+
+```bash
+"$SCAFFOLD_BIN" basecamp run <path-captured-module>
+```
+
+### Expected Success Signals
+
+- `--host standalone` invokes `nix run` for the module flake's default app, or `#<standalone_app>` when that config key is set.
+- With no `--host`, `ui_qml` module metadata defaults to `standalone`; other or missing metadata defaults to `basecamp`.
+- A module captured as a prebuilt `.lgx` path is rejected with guidance to edit/remove the entry and capture a flake source; `nix run` is not attempted.
+- `--host basecamp` returns the current guidance for launching through a profile until launch-with-preinstall wiring exists.
+
+### Failure Signals / Common Pitfalls
+
+- Running a `.lgx` path source through `nix run` is a regression; path captures are installable artefacts, not flake apps.
+- A remote flake ref without an explicit fragment must still receive the requested app/build attr when scaffold constructs the Nix command.
+- An omitted `standalone_app` must not serialize back as `standalone_app = ""`.
+
+### Evidence to Capture
+
+- Command output for standalone/default-host/basecamp-host paths.
+- The `[modules.<name>]` excerpt showing `flake`, `role`, optional `standalone_app`, and whether the source is a flake or `.lgx` path.
+- Any rejected `.lgx` path-source error verbatim.
 
 ## A1. Public Rust API Surface
 
@@ -1557,7 +1610,8 @@ HEAD0=$("$SCAFFOLD_BIN" test-node blocks head --url "$URL" --json | jq -r .block
 - Changes to `[modules]` derivation, dependency resolution, sibling `--override-input` handling, or `basecamp install` invocation of `lgpm`: rerun `B2`.
 - Changes to `basecamp launch` (kill-and-scrub semantics, XDG isolation, port-override env vars, p2p surface): rerun `B3`.
 - Changes to clean-slate scrub semantics or the empty `[modules]` guard on `launch`: rerun `B4`.
-- Changes to `basecamp build-portable` (project/dependency role split, ordering, attr selection): rerun `B5`.
+- Changes to `basecamp build`, `basecamp build-portable`, variant normalization, `--module` filtering, or build attr selection: rerun `B5`.
+- Changes to `basecamp run`, `standalone_app`, run host defaulting, or module source validation for run: rerun `B6`.
 - Changes to the public `logos_scaffold::api` surface (entry points, typed result models, categorized errors, `CommandFailed`, or the documented examples/doctests): rerun `A1`, and rerun the matching CLI scenario for any command whose `*_for_project` core changed.
 - Changes to `test-node` lifecycle, pin resolution, prepare/doctor, run-slot concurrency, or caller-checkout validation: rerun `T1` (and `A1` if the `api::testnode` lifecycle types changed).
 - Changes to the `test-node` RPC client (transaction outcomes, block/clock parsing, account/proof reads, or their JSON shapes): rerun `T2`.

--- a/DOGFOODING.md
+++ b/DOGFOODING.md
@@ -158,7 +158,7 @@ If any of these is missing, do not "skip the real run" — go back and fix the s
 | B3 | external module project | Core | Two-instance p2p dogfooding | `basecamp launch alice`, `basecamp launch bob` (parallel) |
 | B4 | external module project | Advanced | Clean-slate scrub semantics on relaunch | `basecamp launch alice` (×2) |
 | B5 | external module project | Advanced | Module artefact builds by variant | `basecamp build`, `basecamp build-portable`, `--variant`, `--module` |
-| B6 | external module project | Advanced | Captured module run loop | `basecamp run <module>`, `--host standalone|basecamp` |
+| B6 | external module project | Advanced | Captured module run loop | `basecamp run <module>`, `--host standalone` |
 | A1 | N/A | Advanced | Public Rust API surface for embedding scaffold in tests/tooling | `logos_scaffold::api::Project`, `cargo doc`, doctests |
 | T1 | `default` | Advanced | Isolated test-node lifecycle and caller-project pins | `test-node pins`, `test-node prepare`, `test-node doctor`, `test-node start`, `test-node status`, `test-node stop`, `test-node run` |
 | T2 | `default` | Advanced | Typed RPC reads against a running test node | `test-node tx submit-and-wait`, `test-node blocks head/range/wait`, `test-node clock read/wait-stable`, `test-node account get/batch-get`, `test-node proof get`, `test-node snapshot accounts` |
@@ -1255,7 +1255,6 @@ From the module project root:
 ```bash
 "$SCAFFOLD_BIN" basecamp run <module-name> --host standalone
 "$SCAFFOLD_BIN" basecamp run <module-name>
-"$SCAFFOLD_BIN" basecamp run <module-name> --host basecamp
 ```
 
 For one negative-path check, capture or hand-edit a module entry that points at a prebuilt `.lgx` path and run:
@@ -1267,9 +1266,9 @@ For one negative-path check, capture or hand-edit a module entry that points at 
 ### Expected Success Signals
 
 - `--host standalone` invokes `nix run` for the module flake's default app, or `#<standalone_app>` when that config key is set.
-- With no `--host`, `ui_qml` module metadata defaults to `standalone`; other or missing metadata defaults to `basecamp`.
+- With no `--host`, the run defaults to `standalone` (the only host today).
 - A module captured as a prebuilt `.lgx` path is rejected with guidance to edit/remove the entry and capture a flake source; `nix run` is not attempted.
-- `--host basecamp` returns the current guidance for launching through a profile until launch-with-preinstall wiring exists.
+- Running a module as a configured Basecamp peer (one-shot build + install + launch) is not yet available; use `basecamp install` then `basecamp launch <profile>`. Tracked as follow-up work.
 
 ### Failure Signals / Common Pitfalls
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -672,6 +672,12 @@ pub enum BasecampCommand {
     /// Attr-swap replay producing portable module builds (alias for
     /// `Build { variants: ["lgx-portable"], module: None }`).
     BuildPortable,
+    /// Run a captured module via `nix run`. `host` is `standalone`/`basecamp`;
+    /// `None` derives it from the module's `metadata.json` `type`.
+    Run {
+        module: String,
+        host: Option<String>,
+    },
     /// Basecamp-specific health checks.
     Doctor,
 }
@@ -699,6 +705,7 @@ impl BasecampCommand {
                 variants: vec!["lgx-portable".to_string()],
                 module: None,
             },
+            Self::Run { module, host } => BasecampAction::Run { module, host },
             Self::Doctor => BasecampAction::Doctor { json: false },
         }
     }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -662,7 +662,15 @@ pub enum BasecampCommand {
         module: String,
         dev_shell: Option<String>,
     },
-    /// Attr-swap replay producing portable module builds.
+    /// Build project-module `.lgx` artefacts for one or more flake variants
+    /// (`lgx`, `lgx-portable`) without installing them. `module` narrows the
+    /// build to a single captured project module.
+    Build {
+        variants: Vec<String>,
+        module: Option<String>,
+    },
+    /// Attr-swap replay producing portable module builds (alias for
+    /// `Build { variants: ["lgx-portable"], module: None }`).
     BuildPortable,
     /// Basecamp-specific health checks.
     Doctor,
@@ -686,7 +694,11 @@ impl BasecampCommand {
             },
             Self::Launch { profile } => BasecampAction::Launch { profile },
             Self::Develop { module, dev_shell } => BasecampAction::Develop { module, dev_shell },
-            Self::BuildPortable => BasecampAction::BuildPortable,
+            Self::Build { variants, module } => BasecampAction::Build { variants, module },
+            Self::BuildPortable => BasecampAction::Build {
+                variants: vec!["lgx-portable".to_string()],
+                module: None,
+            },
             Self::Doctor => BasecampAction::Doctor { json: false },
         }
     }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -672,8 +672,9 @@ pub enum BasecampCommand {
     /// Attr-swap replay producing portable module builds (alias for
     /// `Build { variants: ["lgx-portable"], module: None }`).
     BuildPortable,
-    /// Run a captured module via `nix run`. `host` is `standalone`/`basecamp`;
-    /// `None` derives it from the module's `metadata.json` `type`.
+    /// Run a captured module via `nix run`. `host` accepts `standalone` (the
+    /// only host today, and the default when `None`); running a module as a
+    /// configured Basecamp peer is tracked as separate follow-up work.
     Run {
         module: String,
         host: Option<String>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1125,8 +1125,9 @@ impl BuildVariant {
 
 #[derive(Debug, clap::Args)]
 struct BasecampBuildArgs {
-    /// Flake variant(s) to build. Defaults to `lgx` (the dev artefact).
-    #[arg(long, value_enum, default_value_t = BuildVariant::Lgx)]
+    /// Flake variant(s) to build. Defaults to `all` (both `lgx` and
+    /// `lgx-portable`), per #174.
+    #[arg(long, value_enum, default_value_t = BuildVariant::All)]
     variant: BuildVariant,
     /// Restrict the build to a single captured project module.
     #[arg(long, value_name = "NAME")]
@@ -1175,9 +1176,10 @@ struct BasecampDevelopArgs {
 /// How `basecamp run` runs a module.
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
 enum RunHost {
-    /// The module's own app (`nix run <flake>#<standalone_app|standalone>`).
+    /// The module's own app: `nix run <flake>` (the flake's
+    /// `apps.<system>.default`), or `#<standalone_app>` when configured.
     Standalone,
-    /// The basecamp-hosted app (`nix run <flake>#app`).
+    /// Run inside basecamp — launch a profile with this module preinstalled.
     Basecamp,
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1739,3 +1739,24 @@ fn require_address(
         )
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::BuildVariant;
+
+    #[test]
+    fn build_variant_all_expands_to_both_variants_in_build_order() {
+        // `--variant all` must build BOTH `#lgx` and `#lgx-portable`, in that
+        // order (lgx first), so `cmd_basecamp_build`'s per-variant loop runs
+        // each pass. The single-variant forms select exactly one attr.
+        assert_eq!(BuildVariant::Lgx.attrs(), vec!["lgx".to_string()]);
+        assert_eq!(
+            BuildVariant::LgxPortable.attrs(),
+            vec!["lgx-portable".to_string()]
+        );
+        assert_eq!(
+            BuildVariant::All.attrs(),
+            vec!["lgx".to_string(), "lgx-portable".to_string()]
+        );
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1068,6 +1068,10 @@ enum BasecampSubcommand {
     )]
     BuildPortable(BasecampBuildPortableArgs),
     #[command(
+        about = "Run a captured module via `nix run` — its standalone app or the basecamp-hosted app. See `basecamp docs` for project requirements."
+    )]
+    Run(BasecampRunArgs),
+    #[command(
         about = "Basecamp-specific doctor: captured modules, manifest variants, and state drift. See `basecamp docs` for project requirements."
     )]
     Doctor(BasecampDoctorArgs),
@@ -1166,6 +1170,26 @@ struct BasecampDevelopArgs {
     /// to the flake's default dev shell.
     #[arg(long, value_name = "ATTR")]
     dev_shell: Option<String>,
+}
+
+/// How `basecamp run` runs a module.
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+enum RunHost {
+    /// The module's own app (`nix run <flake>#<standalone_app|standalone>`).
+    Standalone,
+    /// The basecamp-hosted app (`nix run <flake>#app`).
+    Basecamp,
+}
+
+#[derive(Debug, clap::Args)]
+struct BasecampRunArgs {
+    /// Name of the module to run, keyed in `[modules.<name>]`.
+    #[arg(value_name = "MODULE")]
+    module: String,
+    /// How to run the module. Defaults from the module's metadata.json `type`
+    /// (`ui_qml` → standalone, else basecamp).
+    #[arg(long, value_enum)]
+    host: Option<RunHost>,
 }
 
 pub(crate) fn run(args: Vec<String>) -> DynResult<()> {
@@ -1489,6 +1513,13 @@ pub(crate) fn run(args: Vec<String>) -> DynResult<()> {
                 BasecampSubcommand::BuildPortable(args) => BasecampAction::Build {
                     variants: vec!["lgx-portable".to_string()],
                     module: args.module,
+                },
+                BasecampSubcommand::Run(args) => BasecampAction::Run {
+                    module: args.module,
+                    host: args.host.map(|h| match h {
+                        RunHost::Standalone => "standalone".to_string(),
+                        RunHost::Basecamp => "basecamp".to_string(),
+                    }),
                 },
                 BasecampSubcommand::Doctor(args) => BasecampAction::Doctor { json: args.json },
                 BasecampSubcommand::Docs => BasecampAction::Docs,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1068,7 +1068,7 @@ enum BasecampSubcommand {
     )]
     BuildPortable(BasecampBuildPortableArgs),
     #[command(
-        about = "Run a captured module via `nix run` — its standalone app or the basecamp-hosted app. See `basecamp docs` for project requirements."
+        about = "Run a captured module via `nix run` — its standalone app. See `basecamp docs` for project requirements."
     )]
     Run(BasecampRunArgs),
     #[command(
@@ -1173,14 +1173,14 @@ struct BasecampDevelopArgs {
     dev_shell: Option<String>,
 }
 
-/// How `basecamp run` runs a module.
+/// How `basecamp run` runs a module. `standalone` (the module's own app) is
+/// the only host today; running a module as a configured Basecamp peer is
+/// tracked as separate follow-up work, so this stays an enum for that future.
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
 enum RunHost {
     /// The module's own app: `nix run <flake>` (the flake's
     /// `apps.<system>.default`), or `#<standalone_app>` when configured.
     Standalone,
-    /// Run inside basecamp — launch a profile with this module preinstalled.
-    Basecamp,
 }
 
 #[derive(Debug, clap::Args)]
@@ -1188,8 +1188,8 @@ struct BasecampRunArgs {
     /// Name of the module to run, keyed in `[modules.<name>]`.
     #[arg(value_name = "MODULE")]
     module: String,
-    /// How to run the module. Defaults from the module's metadata.json `type`
-    /// (`ui_qml` → standalone, else basecamp).
+    /// How to run the module. `standalone` (the module's own app) is the only
+    /// host today and the default when omitted.
     #[arg(long, value_enum)]
     host: Option<RunHost>,
 }
@@ -1520,7 +1520,6 @@ pub(crate) fn run(args: Vec<String>) -> DynResult<()> {
                     module: args.module,
                     host: args.host.map(|h| match h {
                         RunHost::Standalone => "standalone".to_string(),
-                        RunHost::Basecamp => "basecamp".to_string(),
                     }),
                 },
                 BasecampSubcommand::Doctor(args) => BasecampAction::Doctor { json: args.json },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1059,8 +1059,12 @@ enum BasecampSubcommand {
     )]
     Develop(BasecampDevelopArgs),
     #[command(
+        about = "Build the project's .lgx artefacts for a flake variant (lgx/lgx-portable/all) without installing them. See `basecamp docs` for project requirements."
+    )]
+    Build(BasecampBuildArgs),
+    #[command(
         name = "build-portable",
-        about = "Build the project's .#lgx-portable artefacts for hand-loading into a basecamp AppImage. See `basecamp docs` for project requirements."
+        about = "Build the project's .#lgx-portable artefacts for hand-loading into a basecamp AppImage (alias for `build --variant lgx-portable`). See `basecamp docs` for project requirements."
     )]
     BuildPortable(BasecampBuildPortableArgs),
     #[command(
@@ -1092,11 +1096,47 @@ struct BasecampModulesArgs {
     show: bool,
 }
 
+/// Flake output variant(s) `basecamp build` resolves against per module.
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+enum BuildVariant {
+    /// `#lgx` — the dev artefact (same output `install` builds).
+    Lgx,
+    /// `#lgx-portable` — for hand-loading into a basecamp AppImage.
+    #[value(name = "lgx-portable")]
+    LgxPortable,
+    /// Both `lgx` and `lgx-portable`.
+    All,
+}
+
+impl BuildVariant {
+    /// Flake attr names this selection expands to (build order).
+    fn attrs(self) -> Vec<String> {
+        match self {
+            Self::Lgx => vec!["lgx".to_string()],
+            Self::LgxPortable => vec!["lgx-portable".to_string()],
+            Self::All => vec!["lgx".to_string(), "lgx-portable".to_string()],
+        }
+    }
+}
+
+#[derive(Debug, clap::Args)]
+struct BasecampBuildArgs {
+    /// Flake variant(s) to build. Defaults to `lgx` (the dev artefact).
+    #[arg(long, value_enum, default_value_t = BuildVariant::Lgx)]
+    variant: BuildVariant,
+    /// Restrict the build to a single captured project module.
+    #[arg(long, value_name = "NAME")]
+    module: Option<String>,
+}
+
 #[derive(Debug, clap::Args)]
 struct BasecampBuildPortableArgs {
-    // `build-portable` takes no CLI source flags: it attr-swaps
-    // `state.project_sources` (`#lgx` → `#lgx-portable`) and builds that.
-    // `state.dependencies` are ignored — the target AppImage provides them.
+    // `build-portable` is the alias for `build --variant lgx-portable`. It
+    // attr-swaps `#lgx` → `#lgx-portable` and builds that; `role = dependency`
+    // modules are ignored — the target AppImage provides them.
+    /// Restrict the build to a single captured project module.
+    #[arg(long, value_name = "NAME")]
+    module: Option<String>,
 }
 
 #[derive(Debug, clap::Args)]
@@ -1442,7 +1482,14 @@ pub(crate) fn run(args: Vec<String>) -> DynResult<()> {
                     module: args.module,
                     dev_shell: args.dev_shell,
                 },
-                BasecampSubcommand::BuildPortable(_) => BasecampAction::BuildPortable,
+                BasecampSubcommand::Build(args) => BasecampAction::Build {
+                    variants: args.variant.attrs(),
+                    module: args.module,
+                },
+                BasecampSubcommand::BuildPortable(args) => BasecampAction::Build {
+                    variants: vec!["lgx-portable".to_string()],
+                    module: args.module,
+                },
                 BasecampSubcommand::Doctor(args) => BasecampAction::Doctor { json: args.json },
                 BasecampSubcommand::Docs => BasecampAction::Docs,
             };

--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -63,9 +63,9 @@ pub(crate) enum BasecampAction {
         variants: Vec<String>,
         module: Option<String>,
     },
-    /// Run a captured module via `nix run`. `host` selects the module's
-    /// standalone app vs the basecamp-hosted app; `None` derives it from the
-    /// module's `metadata.json` `type` (`ui_qml` → standalone, else basecamp).
+    /// Run a captured module via `nix run`. `host` accepts `standalone` (the
+    /// module's own app — the only host today, and the default when `None`).
+    /// Running a module as a configured Basecamp peer is follow-up work.
     Run {
         module: String,
         host: Option<String>,
@@ -561,17 +561,16 @@ fn nix_flake_target(project_root: &Path, flake: &str, attr: Option<&str>) -> Str
     }
 }
 
-/// `lgs basecamp run <module> [--host standalone|basecamp]` — run a captured
-/// module via `nix run`, mirroring `develop`'s exec model (resolve the flake
-/// from `[modules.<module>]`, then exec from the project root).
+/// `lgs basecamp run <module> [--host standalone]` — run a captured module via
+/// `nix run`, mirroring `develop`'s exec model (resolve the flake from
+/// `[modules.<module>]`, then exec from the project root).
 ///
-/// Host resolution (explicit `--host` always wins; otherwise derived from the
-/// module's `metadata.json` `type`: `ui_qml` → standalone, else basecamp):
-///   - `standalone` — run the module's own app: `nix run <flake>` (the flake's
-///     `apps.<system>.default`), or `#<standalone_app>` when
-///     `[modules.<name>].standalone_app` is set.
-///   - `basecamp`   — launch a profile with this module preinstalled (not yet
-///     wired; see the bail hint).
+/// `standalone` is the only host today (and the default): run the module's own
+/// app — `nix run <flake>` (the flake's `apps.<system>.default`), or
+/// `#<standalone_app>` when `[modules.<name>].standalone_app` is set. Running a
+/// module as a configured Basecamp peer (build + install + launch a profile in
+/// one shot) is tracked as separate follow-up work; until then, use
+/// `basecamp install` then `basecamp launch <profile>`.
 ///
 /// The module lookup runs before the `nix` presence check so an unknown module
 /// name fails fast with the known-module list even on a host without Nix.
@@ -605,7 +604,10 @@ fn cmd_basecamp_run(project: Project, module: String, host: Option<String>) -> D
 
     ensure_nix_present()?;
 
-    let host = host.unwrap_or_else(|| default_run_host(&project.root, entry));
+    // `standalone` is the only host today; default to it when `--host` is
+    // omitted. The `other` arm still catches a stray host string passed via
+    // the public Rust API (e.g. a not-yet-wired `basecamp`).
+    let host = host.unwrap_or_else(|| "standalone".to_string());
     match host.as_str() {
         "standalone" => {
             // `apps.<system>.default` by default (bare `nix run <flake>`); an
@@ -619,37 +621,8 @@ fn cmd_basecamp_run(project: Project, module: String, host: Option<String>) -> D
             // exec() only returns on failure.
             bail!("failed to exec `nix run {target}`: {err}");
         }
-        "basecamp" => bail!(
-            "`basecamp run {module} --host basecamp` (launch a profile with `{module}` \
-             preinstalled) is not yet wired. Build + install it with \
-             `logos-scaffold basecamp install`, then `logos-scaffold basecamp launch <profile>`."
-        ),
-        other => bail!("unknown --host `{other}`; expected `standalone` or `basecamp`"),
+        other => bail!("unknown --host `{other}`; expected `standalone`"),
     }
-}
-
-/// Default `run` host for a module: `standalone` when its `metadata.json`
-/// `type` is `ui_qml` (a module shipping its own QML app), else `basecamp`.
-/// Falls back to `basecamp` when the manifest can't be read (remote flake or
-/// missing file) — the basecamp host doesn't need a local standalone attr.
-fn default_run_host(project_root: &Path, entry: &ModuleEntry) -> String {
-    let src = module_entry_to_source(project_root, entry);
-    match read_source_metadata_type(&src).as_deref() {
-        Some("ui_qml") => "standalone".to_string(),
-        _ => "basecamp".to_string(),
-    }
-}
-
-/// Read the `type` string from a local source's `metadata.json`. `None` for
-/// remote flakes, `.lgx` path sources, or an absent/unparseable manifest.
-fn read_source_metadata_type(src: &BasecampSource) -> Option<String> {
-    let BasecampSource::Flake(flake_ref) = src else {
-        return None;
-    };
-    let local_path = flake_path_prefix(flake_ref)?;
-    let text = fs::read_to_string(Path::new(local_path).join("metadata.json")).ok()?;
-    let json: serde_json::Value = serde_json::from_str(&text).ok()?;
-    json.get("type")?.as_str().map(|s| s.to_string())
 }
 
 /// Layer scaffold.toml-declared launch env (#163) onto the scaffold-owned
@@ -4106,42 +4079,6 @@ mod tests {
                 .unwrap(),
             vec!["lgx".to_string(), "lgx-portable".to_string()]
         );
-    }
-
-    #[test]
-    fn default_run_host_is_standalone_only_for_ui_qml_modules() {
-        let tmp = tempdir().expect("tempdir");
-        let entry = |sub: &str| ModuleEntry {
-            flake: format!("path:./{sub}#lgx"),
-            role: ModuleRole::Project,
-            standalone_app: None,
-        };
-        let with_metadata = |sub: &str, ty: &str| {
-            let dir = tmp.path().join(sub);
-            fs::create_dir_all(&dir).unwrap();
-            fs::write(dir.join("metadata.json"), format!(r#"{{"type":"{ty}"}}"#)).unwrap();
-        };
-
-        // `ui_qml` → standalone (the module ships its own QML app).
-        with_metadata("ui", "ui_qml");
-        assert_eq!(default_run_host(tmp.path(), &entry("ui")), "standalone");
-
-        // Any other declared type → basecamp.
-        with_metadata("svc", "swap");
-        assert_eq!(default_run_host(tmp.path(), &entry("svc")), "basecamp");
-
-        // Missing/unreadable manifest (local dir, no metadata.json) → basecamp:
-        // we can't prove `ui_qml`, and the basecamp host needs no local attr.
-        fs::create_dir_all(tmp.path().join("bare")).unwrap();
-        assert_eq!(default_run_host(tmp.path(), &entry("bare")), "basecamp");
-
-        // Remote flake (no local metadata) → basecamp.
-        let remote = ModuleEntry {
-            flake: "github:logos-co/swap-ui#lgx".to_string(),
-            role: ModuleRole::Project,
-            standalone_app: None,
-        };
-        assert_eq!(default_run_host(tmp.path(), &remote), "basecamp");
     }
 
     // ---- resolve_sibling_overrides (I1 fix) — exercised via the command paths;

--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -53,10 +53,16 @@ pub(crate) enum BasecampAction {
         module: String,
         dev_shell: Option<String>,
     },
-    /// Attr-swap replay on `state.project_sources` only (`#lgx` →
-    /// `#lgx-portable`). `state.dependencies` is ignored — the target AppImage
-    /// provides those. No CLI source flags.
-    BuildPortable,
+    /// Build project-module `.lgx` artefacts for one or more flake variants
+    /// (`lgx`, `lgx-portable`) and symlink them into `.scaffold/basecamp/<dir>`
+    /// in load order. Idempotent, no install side-effect. `role = Dependency`
+    /// modules are ignored — the target host provides those. `module` narrows
+    /// the build to a single project module. `build-portable` is the
+    /// back-compat alias for `variants = ["lgx-portable"]`.
+    Build {
+        variants: Vec<String>,
+        module: Option<String>,
+    },
     /// Basecamp-specific doctor: captured modules summary, manifest variant
     /// check per seeded profile, and uncaptured-module drift against
     /// auto-discovery.
@@ -104,7 +110,7 @@ pub(crate) fn basecamp_for_project(project: Project, action: BasecampAction) -> 
         BasecampAction::Develop { module, dev_shell } => {
             cmd_basecamp_develop(project, module, dev_shell)
         }
-        BasecampAction::BuildPortable => cmd_basecamp_build_portable(project),
+        BasecampAction::Build { variants, module } => cmd_basecamp_build(project, variants, module),
         BasecampAction::Doctor { json } => cmd_basecamp_doctor(project, json),
         // Handled above via early return (project-context-free).
         BasecampAction::Docs => unreachable!("handled before load_project"),
@@ -833,19 +839,24 @@ fn wait_for_exit(pid: u32, timeout: Duration) -> bool {
     false
 }
 
-/// Build portable `.lgx` artefacts for hand-loading into a basecamp AppImage.
+/// `lgs basecamp build [--variant lgx|lgx-portable|all] [--module NAME]` —
+/// build the project's `.lgx` artefacts and symlink them into
+/// `.scaffold/basecamp/<variant-dir>/` in load order, without installing them
+/// into any profile (idempotent: no writes to `basecamp.state` or profiles).
 ///
-/// Operates on `state.project_sources` only, with each flake entry's `#lgx`
-/// attribute swapped to `#lgx-portable`. `state.dependencies` is intentionally
-/// ignored — the target AppImage provides its own (release/portable) copies
-/// of companion modules via its in-app Package Manager catalog.
+/// Operates on `role = Project` modules only — `role = Dependency` companions
+/// are skipped (the target basecamp/AppImage provides its own). Each variant
+/// is a flake output attr: `lgx` (dev) builds the captured `#lgx` refs as-is;
+/// `lgx-portable` attr-swaps `#lgx` → `#lgx-portable` first. `module` restricts
+/// the build to a single captured project module.
 ///
-/// No CLI source flags: the source set lives in `state`, managed by
-/// `basecamp modules`. If you want to produce a portable variant of something
-/// that isn't a project source, `basecamp modules --flake <ref>#lgx` it first,
-/// run `build-portable`, then revert with another `modules` call.
-fn cmd_basecamp_build_portable(project: Project) -> DynResult<()> {
-    let project_modules: std::collections::BTreeMap<String, ModuleEntry> = project
+/// `build-portable` is the back-compat alias for `build --variant lgx-portable`.
+fn cmd_basecamp_build(
+    project: Project,
+    variants: Vec<String>,
+    module: Option<String>,
+) -> DynResult<()> {
+    let mut project_modules: std::collections::BTreeMap<String, ModuleEntry> = project
         .config
         .modules
         .iter()
@@ -853,11 +864,27 @@ fn cmd_basecamp_build_portable(project: Project) -> DynResult<()> {
         .map(|(k, v)| (k.clone(), v.clone()))
         .collect();
 
+    if let Some(name) = &module {
+        if !project_modules.contains_key(name) {
+            let known: Vec<&str> = project_modules.keys().map(String::as_str).collect();
+            let known = if known.is_empty() {
+                "none captured".to_string()
+            } else {
+                known.join(", ")
+            };
+            bail!(
+                "no project module `{name}` in scaffold.toml [modules] \
+                 (project modules: {known})"
+            );
+        }
+        project_modules.retain(|k, _| k == name);
+    }
+
     if project_modules.is_empty() {
         bail!(
             "no project modules captured in scaffold.toml; run `basecamp modules` \
              first (auto-discover) or `basecamp modules --flake <ref>#lgx \
-             --path <file.lgx>` to capture explicitly. `build-portable` \
+             --path <file.lgx>` to capture explicitly. `build` \
              operates on captured project sources only — it never discovers."
         );
     }
@@ -873,49 +900,62 @@ fn cmd_basecamp_build_portable(project: Project) -> DynResult<()> {
     // already resolved by the time basecamp tries to resolve its symbols.
     let ordered_names = topo_order_project_modules(&project.root, &project_modules);
 
-    // Rewrite each project source: attr-swap `#lgx` → `#lgx-portable` on
-    // flake refs; pass Path sources through unchanged (they're pre-built).
-    let portable_sources: Vec<BasecampSource> = ordered_names
+    for variant in &variants {
+        build_modules_for_variant(&project, &project_modules, &ordered_names, variant)?;
+    }
+    Ok(())
+}
+
+/// Build every (topo-ordered) project module for a single flake `variant` and
+/// symlink the outputs into `.scaffold/basecamp/<variant-dir>/` with
+/// load-ordered, human-readable `<NN>-<module>.lgx` names. The directory is
+/// wiped and recreated so a re-run never leaves stale symlinks from modules
+/// that have since been removed.
+fn build_modules_for_variant(
+    project: &Project,
+    project_modules: &std::collections::BTreeMap<String, ModuleEntry>,
+    ordered_names: &[String],
+    variant: &str,
+) -> DynResult<()> {
+    // Rewrite each project source for this variant: attr-swap `#lgx` →
+    // `#<variant>` on flake refs; pass Path sources through unchanged (they're
+    // pre-built). The swap is a no-op when variant == "lgx".
+    let sources: Vec<BasecampSource> = ordered_names
         .iter()
-        .map(|name| {
-            let entry = &project_modules[name];
-            let src = module_entry_to_source(&project.root, entry);
-            match src {
+        .map(
+            |name| match module_entry_to_source(&project.root, &project_modules[name]) {
                 BasecampSource::Path(p) => BasecampSource::Path(p),
                 BasecampSource::Flake(f) => {
-                    BasecampSource::Flake(swap_flake_attr(&f, "lgx", "lgx-portable"))
+                    BasecampSource::Flake(swap_flake_attr(&f, "lgx", variant))
                 }
-            }
-        })
+            },
+        )
         .collect();
 
     // Local symlink dir: basecamp's AppImage "install lgx" button opens a
     // file picker starting in the project, and /nix/store/…-source paths
-    // are painful to navigate by hand. Wipe + recreate so a re-run doesn't
-    // leave stale symlinks from modules that have since been removed.
-    let portable_dir = project.root.join(".scaffold/basecamp/portable");
-    let _ = fs::remove_dir_all(&portable_dir);
-    fs::create_dir_all(&portable_dir)
-        .with_context(|| format!("create {}", portable_dir.display()))?;
+    // are painful to navigate by hand.
+    let out_dir = project
+        .root
+        .join(".scaffold/basecamp")
+        .join(variant_output_subdir(variant));
+    let _ = fs::remove_dir_all(&out_dir);
+    fs::create_dir_all(&out_dir).with_context(|| format!("create {}", out_dir.display()))?;
 
     let mut outputs: Vec<PathBuf> = Vec::new();
-    for (index, (name, src)) in ordered_names
-        .iter()
-        .zip(portable_sources.iter())
-        .enumerate()
-    {
+    for (index, (name, src)) in ordered_names.iter().zip(sources.iter()).enumerate() {
         let store_paths: Vec<PathBuf> = match src {
             BasecampSource::Path(p) => vec![build_portable_resolve_path(Path::new(p))?],
             BasecampSource::Flake(flake_ref) => {
-                // Sibling overrides still computed against the post-swap set
-                // so path-sibling inputs resolve locally like they do at install.
-                let overrides = resolve_sibling_overrides(src, &portable_sources, flake_ref);
-                let inv = build_portable_nix_invocation(flake_ref, &overrides);
-                run_build_portable_nix(&project.root, flake_ref, &inv)?
+                // Sibling overrides computed against the post-swap set so
+                // path-sibling inputs resolve locally like they do at install.
+                let overrides = resolve_sibling_overrides(src, &sources, flake_ref);
+                let inv = build_portable_nix_invocation(flake_ref, &overrides, variant);
+                run_build_portable_nix(&project.root, flake_ref, &inv, variant)?
             }
         };
 
-        // Symlink each store path into `portable_dir` with a load-ordered,
+        // Symlink each store path into `out_dir` with a load-ordered,
         // human-readable name. Two-digit index so a file-browser sorts the
         // list the same way the user should load them in basecamp.
         let load_order = format!("{:02}", index + 1);
@@ -930,7 +970,7 @@ fn cmd_basecamp_build_portable(project: Project) -> DynResult<()> {
             } else {
                 format!("{load_order}-{name}.lgx")
             };
-            let link_path = portable_dir.join(&link_name);
+            let link_path = out_dir.join(&link_name);
             std::os::unix::fs::symlink(store_path, &link_path).with_context(|| {
                 format!(
                     "symlink {} -> {}",
@@ -943,13 +983,23 @@ fn cmd_basecamp_build_portable(project: Project) -> DynResult<()> {
     }
 
     println!(
-        "Portable .lgx artefacts (in load order, symlinked into {}):",
-        portable_dir.display()
+        "{variant} .lgx artefacts (in load order, symlinked into {}):",
+        out_dir.display()
     );
     for out in &outputs {
         println!("  {}", out.display());
     }
     Ok(())
+}
+
+/// Subdir under `.scaffold/basecamp/` for a build variant. `lgx-portable`
+/// keeps the historical `portable` name (the docs and the AppImage hand-load
+/// workflow reference it); other variants use their bare attr name.
+fn variant_output_subdir(variant: &str) -> &str {
+    match variant {
+        "lgx-portable" => "portable",
+        other => other,
+    }
 }
 
 /// Order `project_modules` so each module appears AFTER every
@@ -1055,13 +1105,14 @@ struct NixBuildInvocation {
 fn build_portable_nix_invocation(
     flake_ref: &str,
     overrides: &[(String, String)],
+    default_attr: &str,
 ) -> NixBuildInvocation {
     let (cwd_override, ref_arg) = match flake_path_prefix(flake_ref) {
         Some(abs) => {
             let attr = flake_ref
                 .split_once('#')
                 .map(|(_, a)| a)
-                .unwrap_or("lgx-portable");
+                .unwrap_or(default_attr);
             (Some(PathBuf::from(abs)), format!(".#{attr}"))
         }
         None => (None, flake_ref.to_string()),
@@ -1090,6 +1141,7 @@ fn run_build_portable_nix(
     project_root: &Path,
     flake_ref: &str,
     inv: &NixBuildInvocation,
+    variant: &str,
 ) -> DynResult<Vec<PathBuf>> {
     println!("building {flake_ref}");
     let mut cmd = Command::new("nix");
@@ -1110,14 +1162,12 @@ fn run_build_portable_nix(
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         if (stderr.contains("does not provide attribute") || stderr.contains("missing attribute"))
-            && stderr.contains("lgx-portable")
+            && stderr.contains(variant)
         {
             bail!(
-                "flake `{flake_ref}` does not expose `lgx-portable`. Either:\n\
-                 (a) add a `packages.<system>.lgx-portable` output to your module's flake.nix, or\n\
-                 (b) if you don't need a portable build, skip `basecamp build-portable` — \
-                 `basecamp install` uses `.#lgx` and works without it.\n\
-                 {COMPAT_DOCS_BREADCRUMB}"
+                "flake `{flake_ref}` does not expose `{variant}`. Add a \
+                 `packages.<system>.{variant}` output to your module's flake.nix, \
+                 or build a different `--variant`.\n{COMPAT_DOCS_BREADCRUMB}"
             );
         }
         bail!(
@@ -3658,7 +3708,7 @@ mod tests {
 
     #[test]
     fn build_portable_nix_invocation_path_ref_cds_into_flake_dir() {
-        let inv = build_portable_nix_invocation("path:/abs/to/foo#lgx-portable", &[]);
+        let inv = build_portable_nix_invocation("path:/abs/to/foo#lgx-portable", &[], "lgx-portable");
         assert_eq!(inv.cwd_override.as_deref(), Some(Path::new("/abs/to/foo")));
         assert_eq!(
             inv.args,
@@ -3668,7 +3718,7 @@ mod tests {
 
     #[test]
     fn build_portable_nix_invocation_remote_ref_stays_in_project_root() {
-        let inv = build_portable_nix_invocation("github:foo/bar#lgx-portable", &[]);
+        let inv = build_portable_nix_invocation("github:foo/bar#lgx-portable", &[], "lgx-portable");
         assert!(
             inv.cwd_override.is_none(),
             "remote refs must not override cwd"
@@ -3683,7 +3733,7 @@ mod tests {
     fn build_portable_nix_invocation_does_not_use_out_link() {
         // Spec: `nix build` without `-o`, so the default `./result-<attr>` symlink
         // lands next to the flake. No `--out-link`, no `--no-link`.
-        let inv = build_portable_nix_invocation("path:/abs/a#lgx-portable", &[]);
+        let inv = build_portable_nix_invocation("path:/abs/a#lgx-portable", &[], "lgx-portable");
         for forbidden in ["-o", "--out-link", "--no-link"] {
             assert!(
                 !inv.args.iter().any(|a| a == forbidden),
@@ -3698,6 +3748,7 @@ mod tests {
         let inv = build_portable_nix_invocation(
             "path:/abs/ui#lgx-portable",
             &[("core".to_string(), "path:/abs/core".to_string())],
+            "lgx-portable",
         );
         assert_eq!(
             inv.args,

--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -947,20 +947,36 @@ fn wait_for_exit(pid: u32, timeout: Duration) -> bool {
 /// the build to a single captured project module.
 ///
 /// `build-portable` is the back-compat alias for `build --variant lgx-portable`.
-fn cmd_basecamp_build(
-    project: Project,
-    variants: Vec<String>,
-    module: Option<String>,
-) -> DynResult<()> {
-    // Validate variants before anything touches the filesystem: each value
-    // becomes both a `.scaffold/basecamp/<dir>` path component (wiped via
-    // `remove_dir_all`) and a nix attr. The CLI constrains this to a
-    // `ValueEnum`, but the public Rust API takes a free-form `Vec<String>`.
+/// Validate, reject-empty, and de-duplicate the requested build variants. The
+/// CLI constrains these to a `ValueEnum`, but the public Rust API takes a
+/// free-form `Vec<String>`, so an unexpected value (empty list, unknown attr,
+/// or one with path separators — each becomes a `.scaffold/basecamp/<dir>`
+/// component wiped via `remove_dir_all`) must be rejected here. Duplicates are
+/// dropped (first-seen order preserved) so the same output dir isn't wiped and
+/// rebuilt twice.
+fn normalize_build_variants(variants: Vec<String>) -> DynResult<Vec<String>> {
+    if variants.is_empty() {
+        bail!("no build variant requested; expected at least one of `lgx`, `lgx-portable`");
+    }
     for variant in &variants {
         if variant != "lgx" && variant != "lgx-portable" {
             bail!("unknown build variant `{variant}`; expected `lgx` or `lgx-portable`");
         }
     }
+    let mut seen = std::collections::HashSet::new();
+    let mut out = variants;
+    out.retain(|v| seen.insert(v.clone()));
+    Ok(out)
+}
+
+fn cmd_basecamp_build(
+    project: Project,
+    variants: Vec<String>,
+    module: Option<String>,
+) -> DynResult<()> {
+    // Reject empty/unknown input and drop duplicates before anything touches
+    // the filesystem (see `normalize_build_variants`).
+    let variants = normalize_build_variants(variants)?;
 
     let mut project_modules: std::collections::BTreeMap<String, ModuleEntry> = project
         .config
@@ -4069,6 +4085,23 @@ mod tests {
         // bare attr name.
         assert_eq!(variant_output_subdir("lgx-portable"), "portable");
         assert_eq!(variant_output_subdir("lgx"), "lgx");
+    }
+
+    #[test]
+    fn normalize_build_variants_rejects_empty_unknown_and_dedupes() {
+        // Empty (public-API misuse) is rejected rather than silently building
+        // nothing.
+        assert!(normalize_build_variants(vec![]).is_err());
+        // Unknown attrs — including path-separator values that would escape
+        // `.scaffold/basecamp/` via `remove_dir_all` — are rejected.
+        assert!(normalize_build_variants(vec!["bogus".into()]).is_err());
+        assert!(normalize_build_variants(vec!["../escape".into()]).is_err());
+        // Duplicates collapse, first-seen order preserved.
+        assert_eq!(
+            normalize_build_variants(vec!["lgx".into(), "lgx".into(), "lgx-portable".into(),])
+                .unwrap(),
+            vec!["lgx".to_string(), "lgx-portable".to_string()]
+        );
     }
 
     #[test]

--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -4062,6 +4062,51 @@ mod tests {
         }
     }
 
+    #[test]
+    fn variant_output_subdir_keeps_portable_name_for_backcompat() {
+        // `lgx-portable` must keep the historical `portable/` dir (docs + the
+        // AppImage hand-load workflow reference it); other variants use the
+        // bare attr name.
+        assert_eq!(variant_output_subdir("lgx-portable"), "portable");
+        assert_eq!(variant_output_subdir("lgx"), "lgx");
+    }
+
+    #[test]
+    fn default_run_host_is_standalone_only_for_ui_qml_modules() {
+        let tmp = tempdir().expect("tempdir");
+        let entry = |sub: &str| ModuleEntry {
+            flake: format!("path:./{sub}#lgx"),
+            role: ModuleRole::Project,
+            standalone_app: None,
+        };
+        let with_metadata = |sub: &str, ty: &str| {
+            let dir = tmp.path().join(sub);
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(dir.join("metadata.json"), format!(r#"{{"type":"{ty}"}}"#)).unwrap();
+        };
+
+        // `ui_qml` → standalone (the module ships its own QML app).
+        with_metadata("ui", "ui_qml");
+        assert_eq!(default_run_host(tmp.path(), &entry("ui")), "standalone");
+
+        // Any other declared type → basecamp.
+        with_metadata("svc", "swap");
+        assert_eq!(default_run_host(tmp.path(), &entry("svc")), "basecamp");
+
+        // Missing/unreadable manifest (local dir, no metadata.json) → basecamp:
+        // we can't prove `ui_qml`, and the basecamp host needs no local attr.
+        fs::create_dir_all(tmp.path().join("bare")).unwrap();
+        assert_eq!(default_run_host(tmp.path(), &entry("bare")), "basecamp");
+
+        // Remote flake (no local metadata) → basecamp.
+        let remote = ModuleEntry {
+            flake: "github:logos-co/swap-ui#lgx".to_string(),
+            role: ModuleRole::Project,
+            standalone_app: None,
+        };
+        assert_eq!(default_run_host(tmp.path(), &remote), "basecamp");
+    }
+
     // ---- resolve_sibling_overrides (I1 fix) — exercised via the command paths;
     //      a focused test pins the helper's Path-source short-circuit ----
 

--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -595,8 +595,11 @@ fn cmd_basecamp_run(project: Project, module: String, host: Option<String>) -> D
     if let BasecampSource::Path(p) = module_entry_to_source(&project.root, entry) {
         bail!(
             "module `{module}` was captured as a prebuilt `.lgx` path (`{p}`), which \
-             `basecamp run` cannot launch. Re-capture it from its flake with \
-             `basecamp modules --flake <ref>#lgx`."
+             `basecamp run` cannot launch. Point `[modules.{module}]` at a flake \
+             source instead: edit its entry in scaffold.toml, or remove it and \
+             re-capture with `basecamp modules --flake <ref>#lgx` (re-running \
+             `basecamp modules` keeps existing entries, so it won't replace a path \
+             capture on its own)."
         );
     }
 
@@ -1005,9 +1008,10 @@ fn cmd_basecamp_build(
     if project_modules.is_empty() {
         bail!(
             "no project modules captured in scaffold.toml; run `basecamp modules` \
-             first (auto-discover) or `basecamp modules --flake <ref>#lgx \
-             --path <file.lgx>` to capture explicitly. `build` \
-             operates on captured project sources only — it never discovers."
+             first (auto-discover), or capture explicitly with \
+             `basecamp modules --flake <ref>#lgx` or `basecamp modules --path \
+             <file.lgx>`. `build` operates on captured project sources only — it \
+             never discovers."
         );
     }
 

--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -63,6 +63,13 @@ pub(crate) enum BasecampAction {
         variants: Vec<String>,
         module: Option<String>,
     },
+    /// Run a captured module via `nix run`. `host` selects the module's
+    /// standalone app vs the basecamp-hosted app; `None` derives it from the
+    /// module's `metadata.json` `type` (`ui_qml` → standalone, else basecamp).
+    Run {
+        module: String,
+        host: Option<String>,
+    },
     /// Basecamp-specific doctor: captured modules summary, manifest variant
     /// check per seeded profile, and uncaptured-module drift against
     /// auto-discovery.
@@ -111,6 +118,7 @@ pub(crate) fn basecamp_for_project(project: Project, action: BasecampAction) -> 
             cmd_basecamp_develop(project, module, dev_shell)
         }
         BasecampAction::Build { variants, module } => cmd_basecamp_build(project, variants, module),
+        BasecampAction::Run { module, host } => cmd_basecamp_run(project, module, host),
         BasecampAction::Doctor { json } => cmd_basecamp_doctor(project, json),
         // Handled above via early return (project-context-free).
         BasecampAction::Docs => unreachable!("handled before load_project"),
@@ -519,7 +527,7 @@ fn cmd_basecamp_develop(
 
     ensure_nix_present()?;
 
-    let target = nix_develop_target(&project.root, &entry.flake, dev_shell.as_deref());
+    let target = nix_flake_target(&project.root, &entry.flake, dev_shell.as_deref());
     println!("entering dev shell for module `{module}` ({target})");
 
     let mut cmd = Command::new("nix");
@@ -540,17 +548,89 @@ fn cmd_basecamp_develop(
     bail!("failed to exec `nix develop {target}`: {err}");
 }
 
-/// Build the `nix develop` target from a module's stored flake ref. Strips any
-/// output fragment after `#` (e.g. `#lgx`), absolutizes path-style refs the
-/// same way `launch`/`install` do, then re-attaches the requested dev-shell
-/// attr (if any). `None` selects the flake's default dev shell.
-fn nix_develop_target(project_root: &Path, flake: &str, dev_shell: Option<&str>) -> String {
+/// Build a `nix develop`/`nix run` target from a module's stored flake ref.
+/// Strips any output fragment after `#` (e.g. `#lgx`), absolutizes path-style
+/// refs the same way `launch`/`install` do, then re-attaches the requested
+/// attr (if any). `None` selects the flake's default output.
+fn nix_flake_target(project_root: &Path, flake: &str, attr: Option<&str>) -> String {
     let bare = flake.split_once('#').map_or(flake, |(b, _)| b);
     let normalized = normalize_flake_ref(project_root, bare);
-    match dev_shell {
+    match attr {
         Some(attr) => format!("{normalized}#{attr}"),
         None => normalized,
     }
+}
+
+/// `lgs basecamp run <module> [--host standalone|basecamp]` — run a captured
+/// module via `nix run`, mirroring `develop`'s exec model (resolve the flake
+/// from `[modules.<module>]`, then exec from the project root).
+///
+/// Host resolution (explicit `--host` always wins; otherwise derived from the
+/// module's `metadata.json` `type`: `ui_qml` → standalone, else basecamp):
+///   - `standalone` — the module's own app. Flake attr =
+///     `[modules.<name>].standalone_app` if set, else `standalone`.
+///   - `basecamp`   — the basecamp-hosted app. Flake attr = `app`.
+///
+/// The module lookup runs before the `nix` presence check so an unknown module
+/// name fails fast with the known-module list even on a host without Nix.
+fn cmd_basecamp_run(project: Project, module: String, host: Option<String>) -> DynResult<()> {
+    let entry = project.config.modules.get(&module).ok_or_else(|| {
+        let known: Vec<&str> = project.config.modules.keys().map(String::as_str).collect();
+        let known = if known.is_empty() {
+            "none captured yet".to_string()
+        } else {
+            known.join(", ")
+        };
+        anyhow!(
+            "no module `{module}` in scaffold.toml [modules] (known: {known}). \
+             Capture project sources with `logos-scaffold basecamp modules`."
+        )
+    })?;
+
+    ensure_nix_present()?;
+
+    let host = host.unwrap_or_else(|| default_run_host(&project.root, entry));
+    let attr = match host.as_str() {
+        "standalone" => entry
+            .standalone_app
+            .clone()
+            .unwrap_or_else(|| "standalone".to_string()),
+        "basecamp" => "app".to_string(),
+        other => bail!("unknown --host `{other}`; expected `standalone` or `basecamp`"),
+    };
+
+    let target = nix_flake_target(&project.root, &entry.flake, Some(&attr));
+    println!("running module `{module}` ({host} host: {target})");
+
+    let mut cmd = Command::new("nix");
+    cmd.current_dir(&project.root).arg("run").arg(&target);
+    let err = cmd.exec();
+    // exec() only returns on failure.
+    bail!("failed to exec `nix run {target}`: {err}");
+}
+
+/// Default `run` host for a module: `standalone` when its `metadata.json`
+/// `type` is `ui_qml` (a module shipping its own QML app), else `basecamp`.
+/// Falls back to `basecamp` when the manifest can't be read (remote flake or
+/// missing file) — the basecamp host doesn't need a local standalone attr.
+fn default_run_host(project_root: &Path, entry: &ModuleEntry) -> String {
+    let src = module_entry_to_source(project_root, entry);
+    match read_source_metadata_type(&src).as_deref() {
+        Some("ui_qml") => "standalone".to_string(),
+        _ => "basecamp".to_string(),
+    }
+}
+
+/// Read the `type` string from a local source's `metadata.json`. `None` for
+/// remote flakes, `.lgx` path sources, or an absent/unparseable manifest.
+fn read_source_metadata_type(src: &BasecampSource) -> Option<String> {
+    let BasecampSource::Flake(flake_ref) = src else {
+        return None;
+    };
+    let local_path = flake_path_prefix(flake_ref)?;
+    let text = fs::read_to_string(Path::new(local_path).join("metadata.json")).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&text).ok()?;
+    json.get("type")?.as_str().map(|s| s.to_string())
 }
 
 /// Layer scaffold.toml-declared launch env (#163) onto the scaffold-owned
@@ -1326,6 +1406,7 @@ fn cmd_basecamp_modules(
         new_modules.entry(name).or_insert_with(|| ModuleEntry {
             flake: relativize_flake_ref(&project.root, &flake_ref(src)),
             role: ModuleRole::Project,
+            standalone_app: None,
         });
     }
 
@@ -1613,6 +1694,7 @@ fn resolve_manifest_dependencies(
                     ModuleEntry {
                         flake: resolved,
                         role: ModuleRole::Dependency,
+                        standalone_app: None,
                     },
                 );
                 continue;
@@ -1624,6 +1706,7 @@ fn resolve_manifest_dependencies(
                 ModuleEntry {
                     flake: (*flake_ref).to_string(),
                     role: ModuleRole::Dependency,
+                    standalone_app: None,
                 },
             );
             continue;
@@ -3924,6 +4007,7 @@ mod tests {
         let entry = ModuleEntry {
             flake: "path:./sub#lgx".to_string(),
             role: ModuleRole::Project,
+            standalone_app: None,
         };
         match module_entry_to_source(tmp.path(), &entry) {
             BasecampSource::Flake(f) => {
@@ -4061,6 +4145,7 @@ mod tests {
         ModuleEntry {
             flake: flake.to_string(),
             role: ModuleRole::Project,
+            standalone_app: None,
         }
     }
 
@@ -4437,6 +4522,7 @@ mod tests {
             ModuleEntry {
                 flake: "github:logos-co/logos-storage-module/abc123#lgx".to_string(),
                 role: ModuleRole::Project,
+                standalone_app: None,
             },
         );
 
@@ -4493,6 +4579,7 @@ mod tests {
             ModuleEntry {
                 flake: format!("path:{}#lgx", tmp_a.path().display()),
                 role: ModuleRole::Project,
+                standalone_app: None,
             },
         );
         captured.insert(
@@ -4500,6 +4587,7 @@ mod tests {
             ModuleEntry {
                 flake: format!("path:{}#lgx", tmp_b.path().display()),
                 role: ModuleRole::Project,
+                standalone_app: None,
             },
         );
 
@@ -4901,7 +4989,7 @@ role = "dependency"
         // develop` wants the bare flake (default dev shell).
         let root = Path::new("/proj");
         assert_eq!(
-            nix_develop_target(root, "github:logos-co/swap-module/1.0.0#lgx", None),
+            nix_flake_target(root, "github:logos-co/swap-module/1.0.0#lgx", None),
             "github:logos-co/swap-module/1.0.0"
         );
     }
@@ -4910,7 +4998,7 @@ role = "dependency"
     fn nix_develop_target_appends_requested_dev_shell_attr() {
         let root = Path::new("/proj");
         assert_eq!(
-            nix_develop_target(root, "github:logos-co/swap-module#lgx", Some("dev")),
+            nix_flake_target(root, "github:logos-co/swap-module#lgx", Some("dev")),
             "github:logos-co/swap-module#dev"
         );
     }
@@ -4923,11 +5011,11 @@ role = "dependency"
         let tmp = tempfile::tempdir().expect("tempdir");
         let sub = tmp.path().join("swap-module");
         std::fs::create_dir_all(&sub).unwrap();
-        let target = nix_develop_target(tmp.path(), "path:./swap-module#lgx", None);
+        let target = nix_flake_target(tmp.path(), "path:./swap-module#lgx", None);
         let expected = format!("path:{}", sub.canonicalize().unwrap().display());
         assert_eq!(target, expected);
         // Dev-shell attr is re-attached after absolutization.
-        let with_attr = nix_develop_target(tmp.path(), "path:./swap-module#lgx", Some("dev"));
+        let with_attr = nix_flake_target(tmp.path(), "path:./swap-module#lgx", Some("dev"));
         assert_eq!(with_attr, format!("{expected}#dev"));
     }
 

--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -567,9 +567,11 @@ fn nix_flake_target(project_root: &Path, flake: &str, attr: Option<&str>) -> Str
 ///
 /// Host resolution (explicit `--host` always wins; otherwise derived from the
 /// module's `metadata.json` `type`: `ui_qml` → standalone, else basecamp):
-///   - `standalone` — the module's own app. Flake attr =
-///     `[modules.<name>].standalone_app` if set, else `standalone`.
-///   - `basecamp`   — the basecamp-hosted app. Flake attr = `app`.
+///   - `standalone` — run the module's own app: `nix run <flake>` (the flake's
+///     `apps.<system>.default`), or `#<standalone_app>` when
+///     `[modules.<name>].standalone_app` is set.
+///   - `basecamp`   — launch a profile with this module preinstalled (not yet
+///     wired; see the bail hint).
 ///
 /// The module lookup runs before the `nix` presence check so an unknown module
 /// name fails fast with the known-module list even on a host without Nix.
@@ -587,26 +589,40 @@ fn cmd_basecamp_run(project: Project, module: String, host: Option<String>) -> D
         )
     })?;
 
+    // `nix run` needs a flake. A module captured via `--path <file.lgx>` is a
+    // prebuilt artefact with no runnable app — reject it with a fix-it hint
+    // rather than letting `nix run path:/…/file.lgx` fail opaquely.
+    if let BasecampSource::Path(p) = module_entry_to_source(&project.root, entry) {
+        bail!(
+            "module `{module}` was captured as a prebuilt `.lgx` path (`{p}`), which \
+             `basecamp run` cannot launch. Re-capture it from its flake with \
+             `basecamp modules --flake <ref>#lgx`."
+        );
+    }
+
     ensure_nix_present()?;
 
     let host = host.unwrap_or_else(|| default_run_host(&project.root, entry));
-    let attr = match host.as_str() {
-        "standalone" => entry
-            .standalone_app
-            .clone()
-            .unwrap_or_else(|| "standalone".to_string()),
-        "basecamp" => "app".to_string(),
+    match host.as_str() {
+        "standalone" => {
+            // `apps.<system>.default` by default (bare `nix run <flake>`); an
+            // explicit `standalone_app` overrides the app attr.
+            let target =
+                nix_flake_target(&project.root, &entry.flake, entry.standalone_app.as_deref());
+            println!("running module `{module}` (standalone host: {target})");
+            let mut cmd = Command::new("nix");
+            cmd.current_dir(&project.root).arg("run").arg(&target);
+            let err = cmd.exec();
+            // exec() only returns on failure.
+            bail!("failed to exec `nix run {target}`: {err}");
+        }
+        "basecamp" => bail!(
+            "`basecamp run {module} --host basecamp` (launch a profile with `{module}` \
+             preinstalled) is not yet wired. Build + install it with \
+             `logos-scaffold basecamp install`, then `logos-scaffold basecamp launch <profile>`."
+        ),
         other => bail!("unknown --host `{other}`; expected `standalone` or `basecamp`"),
-    };
-
-    let target = nix_flake_target(&project.root, &entry.flake, Some(&attr));
-    println!("running module `{module}` ({host} host: {target})");
-
-    let mut cmd = Command::new("nix");
-    cmd.current_dir(&project.root).arg("run").arg(&target);
-    let err = cmd.exec();
-    // exec() only returns on failure.
-    bail!("failed to exec `nix run {target}`: {err}");
+    }
 }
 
 /// Default `run` host for a module: `standalone` when its `metadata.json`
@@ -936,6 +952,16 @@ fn cmd_basecamp_build(
     variants: Vec<String>,
     module: Option<String>,
 ) -> DynResult<()> {
+    // Validate variants before anything touches the filesystem: each value
+    // becomes both a `.scaffold/basecamp/<dir>` path component (wiped via
+    // `remove_dir_all`) and a nix attr. The CLI constrains this to a
+    // `ValueEnum`, but the public Rust API takes a free-form `Vec<String>`.
+    for variant in &variants {
+        if variant != "lgx" && variant != "lgx-portable" {
+            bail!("unknown build variant `{variant}`; expected `lgx` or `lgx-portable`");
+        }
+    }
+
     let mut project_modules: std::collections::BTreeMap<String, ModuleEntry> = project
         .config
         .modules
@@ -1195,7 +1221,11 @@ fn build_portable_nix_invocation(
                 .unwrap_or(default_attr);
             (Some(PathBuf::from(abs)), format!(".#{attr}"))
         }
-        None => (None, flake_ref.to_string()),
+        // Remote ref (github:, git+, …). Pin the requested variant attr when
+        // the captured ref omits a `#<attr>` fragment — otherwise nix would
+        // build the flake's default package, ignoring `--variant`.
+        None if flake_ref.contains('#') => (None, flake_ref.to_string()),
+        None => (None, format!("{flake_ref}#{default_attr}")),
     };
 
     let mut args = vec!["build".to_string(), ref_arg];
@@ -3791,7 +3821,8 @@ mod tests {
 
     #[test]
     fn build_portable_nix_invocation_path_ref_cds_into_flake_dir() {
-        let inv = build_portable_nix_invocation("path:/abs/to/foo#lgx-portable", &[], "lgx-portable");
+        let inv =
+            build_portable_nix_invocation("path:/abs/to/foo#lgx-portable", &[], "lgx-portable");
         assert_eq!(inv.cwd_override.as_deref(), Some(Path::new("/abs/to/foo")));
         assert_eq!(
             inv.args,
@@ -3809,6 +3840,18 @@ mod tests {
         assert_eq!(
             inv.args,
             vec!["build", "github:foo/bar#lgx-portable", "--print-out-paths"]
+        );
+    }
+
+    #[test]
+    fn build_portable_nix_invocation_remote_ref_without_fragment_pins_variant() {
+        // A captured remote ref that omits `#<attr>` must still build the
+        // requested variant — otherwise nix builds the flake's default package.
+        let inv = build_portable_nix_invocation("github:foo/bar", &[], "lgx");
+        assert!(inv.cwd_override.is_none());
+        assert_eq!(
+            inv.args,
+            vec!["build", "github:foo/bar#lgx", "--print-out-paths"]
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1226,6 +1226,50 @@ role = "dependency"
     }
 
     #[test]
+    fn module_standalone_app_parses_and_round_trips() {
+        let toml = minimal_v0_2_0()
+            + r#"
+[modules.swap_ui]
+flake = "path:./swap-ui#lgx"
+role = "project"
+standalone_app = "swap-ui-standalone"
+
+[modules.swap]
+flake = "path:./swap#lgx"
+role = "project"
+"#;
+        let cfg = parse_config(toml.as_str()).expect("parse");
+        assert_eq!(
+            cfg.modules
+                .get("swap_ui")
+                .expect("swap_ui")
+                .standalone_app
+                .as_deref(),
+            Some("swap-ui-standalone")
+        );
+        // A module that omits the field must stay `None` (not `Some("")`).
+        assert_eq!(cfg.modules.get("swap").expect("swap").standalone_app, None);
+
+        let serialized = serialize_config(&cfg).expect("serialize");
+        let cfg2 = parse_config(&serialized).expect("re-parse");
+        assert_eq!(
+            cfg2.modules
+                .get("swap_ui")
+                .expect("swap_ui")
+                .standalone_app
+                .as_deref(),
+            Some("swap-ui-standalone"),
+            "standalone_app must survive serialize→parse so setup never clobbers it"
+        );
+        assert_eq!(cfg2.modules.get("swap").expect("swap").standalone_app, None);
+        // An omitted/empty value must not be persisted as `standalone_app = ""`.
+        assert!(
+            !serialized.contains("standalone_app = \"\""),
+            "empty standalone_app should be omitted: {serialized}"
+        );
+    }
+
+    #[test]
     fn rejects_basecamp_pin_field_with_init_hint() {
         let toml = minimal_v0_2_0()
             + r#"

--- a/src/config.rs
+++ b/src/config.rs
@@ -402,7 +402,18 @@ fn parse_modules(doc: &DocumentMut) -> DynResult<std::collections::BTreeMap<Stri
             ),
         };
         check_toml_value(&format!("modules.{name}.flake"), &flake)?;
-        out.insert(name.to_string(), ModuleEntry { flake, role });
+        let standalone_app = read_string(table, "standalone_app").filter(|s| !s.is_empty());
+        if let Some(app) = &standalone_app {
+            check_toml_value(&format!("modules.{name}.standalone_app"), app)?;
+        }
+        out.insert(
+            name.to_string(),
+            ModuleEntry {
+                flake,
+                role,
+                standalone_app,
+            },
+        );
     }
     Ok(out)
 }
@@ -615,6 +626,10 @@ pub(crate) fn serialize_config(cfg: &Config) -> DynResult<String> {
         let table = ensure_subtable(&mut doc, "modules", name);
         table["flake"] = value(&entry.flake);
         table["role"] = value(role_str);
+        if let Some(app) = &entry.standalone_app {
+            check_toml_value(&format!("modules.{name}.standalone_app"), app)?;
+            table["standalone_app"] = value(app);
+        }
         // Defensive: the function's check above already covered both fields.
         let _ = path;
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -103,6 +103,10 @@ pub(crate) enum ModuleRole {
 pub(crate) struct ModuleEntry {
     pub(crate) flake: String,
     pub(crate) role: ModuleRole,
+    /// `[modules.<name>].standalone_app` — optional flake output attr that
+    /// `basecamp run --host standalone` invokes via `nix run`. `None` falls
+    /// back to the `standalone` attr.
+    pub(crate) standalone_app: Option<String>,
 }
 
 /// `[basecamp]` runtime config only. Pin and source moved to

--- a/src/model.rs
+++ b/src/model.rs
@@ -103,9 +103,9 @@ pub(crate) enum ModuleRole {
 pub(crate) struct ModuleEntry {
     pub(crate) flake: String,
     pub(crate) role: ModuleRole,
-    /// `[modules.<name>].standalone_app` — optional flake output attr that
-    /// `basecamp run --host standalone` invokes via `nix run`. `None` falls
-    /// back to the `standalone` attr.
+    /// `[modules.<name>].standalone_app` — optional flake app attr that
+    /// `basecamp run --host standalone` invokes via `nix run <flake>#<attr>`.
+    /// `None` runs the flake's default app (`apps.<system>.default`).
     pub(crate) standalone_app: Option<String>,
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2860,6 +2860,65 @@ fn basecamp_develop_unknown_module_errors_with_known_list() {
         );
 }
 
+#[test]
+fn basecamp_build_without_captured_modules_errors_before_nix() {
+    // The empty-modules guard runs before the `nix` presence check, so this is
+    // deterministic in CI: `build` never discovers, it only builds captured
+    // project sources.
+    let temp = tempdir().expect("tempdir");
+    fs::write(temp.path().join("scaffold.toml"), MINIMAL_SCAFFOLD_TOML)
+        .expect("write scaffold.toml");
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .args(["basecamp", "build"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("no project modules captured"));
+}
+
+#[test]
+fn basecamp_build_unknown_module_errors_with_project_list() {
+    // The `--module` filter is validated before the `nix` presence check, so
+    // an unknown name fails fast and lists the captured project modules.
+    let temp = tempdir().expect("tempdir");
+    let toml = format!(
+        "{MINIMAL_SCAFFOLD_TOML}\n[modules.swap_module]\nflake = \"github:logos-co/swap-module#lgx\"\nrole = \"project\"\n"
+    );
+    fs::write(temp.path().join("scaffold.toml"), toml).expect("write scaffold.toml");
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .args(["basecamp", "build", "--module", "nonexistent"])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("no project module `nonexistent`")
+                .and(predicate::str::contains("swap_module")),
+        );
+}
+
+#[test]
+fn basecamp_run_unknown_module_errors_with_known_list() {
+    // `run`'s module lookup runs before the `nix` presence check (mirrors
+    // `develop`), so an unknown module name is deterministic in CI.
+    let temp = tempdir().expect("tempdir");
+    let toml = format!(
+        "{MINIMAL_SCAFFOLD_TOML}\n[modules.swap_module]\nflake = \"github:logos-co/swap-module#lgx\"\nrole = \"project\"\n"
+    );
+    fs::write(temp.path().join("scaffold.toml"), toml).expect("write scaffold.toml");
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .args(["basecamp", "run", "nonexistent"])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("no module `nonexistent`")
+                .and(predicate::str::contains("swap_module")),
+        );
+}
+
 #[cfg(unix)]
 #[test]
 fn self_test_run_logged_success_shape() {


### PR DESCRIPTION
Implements scaffold **#174** for the Phase 2 atomic-swaps work: move the missing Basecamp module build/run loop out of project-specific scripts and into Scaffold.

## Feature outcome

Developers can now use Scaffold itself to build Basecamp module artifacts and run captured modules during local development.

For atomic-swaps, this replaces the manual Makefile targets and shell logic that currently know how to build portable/non-portable module outputs and run modules from their flakes. Once this lands, that workflow becomes a normal Scaffold capability instead of atomic-swaps-specific glue.

## Before / after

Before this PR, `lgs basecamp` was already the place for Basecamp project setup and launch workflows. It could:
- `setup`: fetch/build Basecamp and LGPM, then seed the standard profiles
- `modules`: capture project modules and dependencies into `scaffold.toml`
- `install`: replay the captured modules into Basecamp profiles
- `launch`: start Basecamp for a profile with clean-slate state
- `develop`: enter a captured module's Nix dev shell
- `build-portable`: build captured project modules as `lgx-portable` artifacts for hand-loading into a portable Basecamp build
- `doctor` / `docs`: inspect Basecamp project state and print compatibility guidance

The missing part was the normal module inner loop. Atomic-swaps still needed its own Makefile/script logic for "build this module output" and "run this captured module from its flake."

With this PR:
- `lgs basecamp build` generalizes module artifact builds beyond the old portable-only helper
- `--variant lgx|lgx-portable|all` selects the output type, and `--module NAME` scopes the build to one module
- `build-portable` remains as a backward-compatible alias for the portable variant
- `lgs basecamp run <module>` launches a captured module from its flake for the local inner loop
- future Scaffold projects get the same Basecamp module workflow without copying atomic-swaps scripts

## Implementation notes

### `lgs basecamp build [--variant lgx|lgx-portable|all] [--module NAME]`

- Builds project-module `.lgx` artifacts per flake variant.
- Symlinks outputs into `.scaffold/basecamp/<variant-dir>/` in load order.
- Defaults `--variant` to `all`.
- Keeps `build-portable` as a backward-compatible alias for `--variant lgx-portable`.
- Validates and de-duplicates variants before filesystem work.

### `lgs basecamp run <module> [--host standalone|basecamp]`

- Resolves the module flake from `[modules.<name>]` and runs it from the project root.
- Defaults the host from module metadata: `ui_qml` -> `standalone`, otherwise `basecamp`.
- Adds optional `[modules.<name>].standalone_app`.
- Rejects prebuilt `.lgx` path captures with a clearer re-capture/editing hint.

Both verbs are mirrored into the public Rust API via `BasecampCommand::Build` and `BasecampCommand::Run`.

## Verification

- `cargo test` (462 lib + 171 CLI integration + 5 doc tests) passed on `danisharora099/basecamp-verb-granularity`; existing warnings are the pre-existing `sha2` cfg warnings in `setup.rs`.
- DOGFOODING `B5`/`B6` runbook updated: `B5` now covers `basecamp build --variant lgx|lgx-portable|all`, `--module`, and `build-portable`; `B6` covers `basecamp run <module> [--host standalone|basecamp]` and `.lgx` path rejection.
- DOGFOODING `E1`/Basecamp command smoke: verified `basecamp build --help`, `basecamp build-portable --help`, and `basecamp run --help` from the freshly built binary.
- Outside-project smoke: `basecamp run missing` fails with the scaffold project-scoped error and `create/new` remediation.
- Full Nix/Basecamp artefact builds and GUI run-loop dogfooding were not rerun in this docs follow-up.

> Note: branched off `origin/master`. The Phase 2 sibling work (#173 circuits, #171 profiles) lives on separate branches; this PR is scoped to #174 only.

---

## Merge order (scaffold Phase 2)

Part of the scaffold Phase 2 trio for atomic-swaps [#27](https://github.com/logos-co/eth-lez-atomic-swaps/issues/27). Land in order:

**#221 (circuits) -> #222 (verbs) -> #223 (profiles)**

- #221 is independent of the other two.
- #222 and #223 both extend the same `basecamp` enums / subcommands (and #223 also changes the `Launch` variant), so **whichever merges second needs a small rebase**.
- Each PR is isolated by concern and individually mergeable against `master`.
