### PR TITLE
feat(basecamp): support configurable multi-peer profiles

### DIFF
--- a/DOGFOODING.md
+++ b/DOGFOODING.md
@@ -154,9 +154,9 @@ If any of these is missing, do not "skip the real run" — go back and fix the s
 | E2 | N/A | Advanced | Project creation with advanced flags and invalid inputs | `new --template`, `new --vendor-deps`, `new --cache-root` |
 | E3 | N/A | Core | AI skills materialized into generated and adopted projects | `new`, `new --template lez-framework`, `init`, `init` re-run |
 | B1 | external module project | Core | Basecamp + lgpm setup and idempotent re-run | `init`, `basecamp setup`, `basecamp doctor`, `basecamp docs` |
-| B2 | external module project | Core | Module capture, install, and single-instance launch | `basecamp modules`, `basecamp modules --show`, `basecamp install`, `basecamp launch alice` |
-| B3 | external module project | Core | Two-instance p2p dogfooding | `basecamp launch alice`, `basecamp launch bob` (parallel) |
-| B4 | external module project | Advanced | Clean-slate scrub semantics on relaunch | `basecamp launch alice` (×2) |
+| B2 | external module project | Core | Module capture, install, paths, and single-instance launch | `basecamp modules`, `basecamp modules --show`, `basecamp install`, `basecamp paths`, `basecamp launch <profile>` |
+| B3 | external module project | Core | Two-instance p2p dogfooding | `basecamp launch <profile>` (parallel) |
+| B4 | external module project | Advanced | Clean-slate and profile safety on relaunch | `basecamp launch <profile>` (×2), custom profile names |
 | B5 | external module project | Advanced | Module artefact builds by variant | `basecamp build`, `basecamp build-portable`, `--variant`, `--module` |
 | B6 | external module project | Advanced | Captured module run loop | `basecamp run <module>`, `--host standalone` |
 | A1 | N/A | Advanced | Public Rust API surface for embedding scaffold in tests/tooling | `logos_scaffold::api::Project`, `cargo doc`, doctests |
@@ -966,7 +966,7 @@ ls dogfood-skills-default/AGENTS.md dogfood-skills-lez/AGENTS.md dogfood-skills-
 
 ### Goal
 
-Validate that a module project can fetch the pinned basecamp + `lgpm` binaries, seed the `alice` and `bob` profiles, and that re-running `setup` is idempotent.
+Validate that a module project can fetch the pinned basecamp + `lgpm` binaries, seed the default profiles, preserve configurable profile schema, and re-run `setup` idempotently.
 
 ### Preconditions
 
@@ -984,6 +984,7 @@ cd "$MODULE_PROJECT"
 test -f scaffold.toml || "$SCAFFOLD_BIN" init
 "$SCAFFOLD_BIN" basecamp --help
 "$SCAFFOLD_BIN" basecamp docs | head
+grep -n '^\[repos.basecamp.attr\]\|^\[basecamp.profiles' scaffold.toml || true
 "$SCAFFOLD_BIN" basecamp setup
 ls .scaffold/basecamp/profiles
 "$SCAFFOLD_BIN" basecamp doctor
@@ -993,9 +994,10 @@ ls .scaffold/basecamp/profiles
 
 ### Expected Success Signals
 
-- `basecamp --help` lists `setup`, `modules`, `install`, `launch`, `build-portable`, `doctor`, and `docs`.
-- `basecamp docs` prints the canonical project-compatibility rules (mirrors `docs/basecamp-module-requirements.md`).
+- `basecamp --help` lists `setup`, `modules`, `install`, `launch`, `paths`, `build-portable`, `doctor`, and `docs`.
+- `basecamp docs` prints the canonical project-compatibility rules, including per-profile `env_file`, `runtime_dir`, `log_file`, custom profile names, and per-platform `[repos.basecamp.attr]`.
 - First `basecamp setup` clones the pinned basecamp repo into a pin-isolated cache path, builds `basecamp` and `lgpm` via Nix, seeds `.scaffold/basecamp/profiles/alice/` and `.scaffold/basecamp/profiles/bob/`, and reports completion.
+- If `[repos.basecamp.attr]` is a per-platform map, setup uses the current host's attr and preserves the map plus scalar fallback on serialize.
 - `basecamp doctor` reports the basecamp + lgpm binaries as present and both profiles as seeded; `--json` returns parseable JSON with the same checks.
 - Second `basecamp setup` is idempotent: pin unchanged → no rebuild reported, exit 0.
 - All commands run only inside the project; running them from outside the project must fail with the existing scaffold "not a logos-scaffold project" message.
@@ -1014,6 +1016,7 @@ ls .scaffold/basecamp/profiles
 - First and second `basecamp setup` output (to compare rebuild vs. no-rebuild).
 - `basecamp doctor` and `basecamp doctor --json` output.
 - Listing of `.scaffold/basecamp/profiles/`.
+- Relevant `scaffold.toml` excerpt for `[repos.basecamp.attr]` and `[basecamp.profiles.*]` when present.
 
 ### Execution Notes
 
@@ -1024,7 +1027,7 @@ ls .scaffold/basecamp/profiles
 
 ### Goal
 
-Validate the per-project source of truth for module identity (`[modules]` in `scaffold.toml`), the install pipeline that builds `.lgx` artefacts and loads them via `lgpm`, and a single-profile launch.
+Validate the per-project source of truth for module identity (`[modules]` in `scaffold.toml`), the install pipeline that builds `.lgx` artefacts and loads them via `lgpm`, resolved profile paths, and a single-profile launch.
 
 ### Preconditions
 
@@ -1043,7 +1046,27 @@ grep -n '^\[modules\.' scaffold.toml
 "$SCAFFOLD_BIN" basecamp install
 "$SCAFFOLD_BIN" basecamp install --print-output
 "$SCAFFOLD_BIN" basecamp doctor
+"$SCAFFOLD_BIN" basecamp paths alice
+"$SCAFFOLD_BIN" basecamp paths alice --json
 "$SCAFFOLD_BIN" basecamp launch alice
+```
+
+To validate custom profile schema, add one profile and inspect it before launch:
+
+```toml
+[basecamp.profiles.maker]
+env_file = ".scaffold/basecamp/maker.env"
+runtime_dir = "/tmp/lgs-maker"
+log_file = ".scaffold/basecamp/profiles/maker/basecamp.log"
+
+[basecamp.profiles.maker.env]
+LOGOS_PROFILE_ROLE = "maker"
+```
+
+```bash
+printf 'MAKER_ONLY=1\nLOGOS_PROFILE_ROLE=env-file\n' > .scaffold/basecamp/maker.env
+"$SCAFFOLD_BIN" basecamp paths maker --json
+"$SCAFFOLD_BIN" basecamp launch maker --log-file
 ```
 
 If your project does not auto-discover correctly, capture explicit sources:
@@ -1061,6 +1084,8 @@ If your project does not auto-discover correctly, capture explicit sources:
 - `basecamp modules --show` prints the captured set without mutating state.
 - `basecamp install` builds each project source (sibling `--override-input` rewrites apply for `path:../<sibling>` inputs in multi-flake projects) and shells out to `lgpm` to install into both `alice` and `bob`. By default it logs to `.scaffold/logs/<ts>-install.log` and prints a one-line status; `--print-output` (or `LOGOS_SCAFFOLD_PRINT_OUTPUT=1`) streams nix output directly.
 - `basecamp doctor` reports each profile's installed modules matching the captured set; drift between `[modules]` and on-disk profile state is flagged, not hidden.
+- `basecamp paths <profile> --json` is pure path resolution: it emits parseable JSON for XDG config/data/cache, runtime dir, module/plugin dirs, launch state, log file, and env file without building or mutating anything.
+- Custom profile names launch like default profiles when they are a single safe path component; `env_file` is sourced before global/profile inline env, `runtime_dir` is exported as both `TMPDIR` and `XDG_RUNTIME_DIR`, and `--log-file` overrides the configured `log_file`.
 - `basecamp launch alice` kills any prior `logos_host` / `logos-basecamp` descendants for that profile, scrubs the profile's XDG dirs under `.scaffold/basecamp/profiles/alice/`, reinstalls each captured source for that profile, sets `XDG_{CONFIG,DATA,CACHE}_HOME` plus `LOGOS_PROFILE=alice`, and `exec`s basecamp.
 
 ### Failure Signals / Common Pitfalls
@@ -1070,6 +1095,8 @@ If your project does not auto-discover correctly, capture explicit sources:
 - An unresolved transitive `logos-module-builder` input that fails without naming the missing `follows` is a regression.
 - `install` succeeding when a build or `lgpm install` step actually failed is a fail; exit codes must be non-zero on any source failure.
 - `launch alice` with an empty `[modules]` must bail (rather than scrubbing the profile and leaving it empty).
+- Custom profile names that are empty, absolute, `.`, `..`, separator-containing, or contain control characters must be rejected before any filesystem work.
+- An env file key containing control characters must fail before spawning basecamp.
 - Sibling `--override-input` not being applied at probe time would surface as a build that resolves the wrong sibling pin during `basecamp modules` auto-discovery; record any such mismatch with the exact derived module names.
 
 ### Evidence to Capture
@@ -1078,7 +1105,9 @@ If your project does not auto-discover correctly, capture explicit sources:
 - `basecamp modules --show` output.
 - `basecamp install` log path under `.scaffold/logs/` plus the printed one-line status, or the `--print-output` stream.
 - `basecamp doctor` output post-install.
+- `basecamp paths <profile> --json` output for both a default profile and one configured profile.
 - The first lines of `basecamp launch alice` showing the kill → scrub → reinstall → exec sequence.
+- For log checks, the log path and first lines proving stdout/stderr were tee'd to file and terminal.
 
 ### Execution Notes
 
@@ -1113,11 +1142,14 @@ Terminal 2:
 "$SCAFFOLD_BIN" basecamp launch bob
 ```
 
+If the project defines custom profiles such as `maker` and `taker`, repeat the same two-terminal check with those names.
+
 Within the running UIs, exercise whatever p2p surface the module exposes (chat exchange, delivery between peers, storage round-trip). Capture screenshots or short transcripts.
 
 ### Expected Success Signals
 
 - Both basecamp windows open against their own profile dirs under `.scaffold/basecamp/profiles/{alice,bob}/`.
+- Custom profile pairs open against their own profile dirs under `.scaffold/basecamp/profiles/<profile>/` and their configured runtime/log/env paths.
 - Each window shows the project's `.lgx` modules installed and ready.
 - `LOGOS_PROFILE=alice` and `LOGOS_PROFILE=bob` are visible in each respective process environment (helpful for debugging).
 - The two instances do not collide on Qt remote-objects or any non-module port; per-profile port-override env vars (per the spec) are set on each `launch`.
@@ -1137,6 +1169,7 @@ Within the running UIs, exercise whatever p2p surface the module exposes (chat e
 - A short transcript or screenshot pair showing a p2p interaction propagating from one instance to the other.
 - The env block of each running process (e.g., `tr '\0' '\n' < /proc/<pid>/environ | grep -E 'XDG_|LOGOS_'`).
 - Any port-collision error text verbatim, with the module that owns the colliding port.
+- If custom profiles are used, `basecamp paths <profile> --json` for each profile and the resolved log/runtime dirs.
 
 ### Execution Notes
 
@@ -1147,7 +1180,7 @@ Within the running UIs, exercise whatever p2p surface the module exposes (chat e
 
 ### Goal
 
-Validate that `basecamp launch <profile>` scrubs profile state on every invocation — clean-slate is the v1 contract.
+Validate that `basecamp launch <profile>` scrubs profile state on every invocation and that profile/path safety guards bound all filesystem work to the project.
 
 ### Preconditions
 
@@ -1159,11 +1192,13 @@ From the module project root:
 
 ```bash
 "$SCAFFOLD_BIN" basecamp launch alice    # let it come up, then close it
+"$SCAFFOLD_BIN" basecamp paths alice --json
 ls .scaffold/basecamp/profiles/alice
 mkdir -p .scaffold/basecamp/profiles/alice/.scaffold-xdg-data/scratch
 echo "marker-$(date -u +%s)" > .scaffold/basecamp/profiles/alice/.scaffold-xdg-data/scratch/marker.txt
 "$SCAFFOLD_BIN" basecamp launch alice    # scrub-and-reinstall
 test -e .scaffold/basecamp/profiles/alice/.scaffold-xdg-data/scratch/marker.txt && echo "REGRESSION: marker survived clean launch" || echo "OK: marker scrubbed"
+"$SCAFFOLD_BIN" basecamp paths ../escape
 ```
 
 ### Expected Success Signals
@@ -1171,18 +1206,21 @@ test -e .scaffold/basecamp/profiles/alice/.scaffold-xdg-data/scratch/marker.txt 
 - `launch alice` removes any user-introduced files under the alice profile XDG dirs and reinstalls each captured source before `exec`ing basecamp.
 - `rm -rf` on `launch` is bounded to `<project>/.scaffold/basecamp/profiles/<profile>/`. Never any path outside that root.
 - A `launch` that finds no modules in `[modules]` bails before scrubbing (the empty-install + scrubbed profile combination is the regression we're guarding against).
+- `basecamp paths` rejects the same unsafe profile names as `launch` and remains non-mutating for valid profiles.
 
 ### Failure Signals / Common Pitfalls
 
 - The `marker.txt` file surviving `launch alice` is a regression: clean-slate is the v1 contract.
 - A `launch` scrubbing a path outside the profile's XDG dirs is a severe safety regression — capture the offending path and stop.
 - An empty `[modules]` plus a `launch` that wipes the profile and leaves it empty is a real regression; the empty-modules bail must fire first.
+- A custom `runtime_dir` on macOS that makes `<runtime_dir>/logos_token_<module>_<pid>` exceed the 104-byte Unix socket path budget is a dogfooding finding; keep custom values short, preferably under `/tmp`.
 
 ### Evidence to Capture
 
 - The marker write and the post-launch listing showing it was scrubbed.
 - The exact path under which the marker was placed and the path basecamp scrubbed (verify they match the profile root).
 - Any unexpected paths touched by `launch` outside `.scaffold/basecamp/profiles/<profile>/`.
+- The unsafe-profile rejection output from `basecamp paths ../escape`.
 
 ### Execution Notes
 
@@ -1605,12 +1643,13 @@ HEAD0=$("$SCAFFOLD_BIN" test-node blocks head --url "$URL" --json | jq -r .block
 - Changes to CLI argument parsing, help text, or error messages: rerun `E1`.
 - Changes to `create`/`new` flags or template selection logic: rerun `E2`.
 - Changes to AI skill materialization (`apply_skills`, the canonical `skills/` source, frontmatter rewrite, `AGENTS.md` template, or `init` re-run semantics): rerun `E3`.
-- Changes to `basecamp setup` (pin sync, lgpm build, profile seeding, idempotency) or `basecamp doctor`: rerun `B1`.
+- Changes to `basecamp setup` (pin sync, lgpm build, profile seeding, idempotency), per-platform `[repos.basecamp.attr]`, or `basecamp doctor`: rerun `B1`.
 - Changes to `[modules]` derivation, dependency resolution, sibling `--override-input` handling, or `basecamp install` invocation of `lgpm`: rerun `B2`.
-- Changes to `basecamp launch` (kill-and-scrub semantics, XDG isolation, port-override env vars, p2p surface): rerun `B3`.
-- Changes to clean-slate scrub semantics or the empty `[modules]` guard on `launch`: rerun `B4`.
+- Changes to `basecamp paths`, `[basecamp.profiles.*]`, `env_file`, `runtime_dir`, `log_file`, `launch --log-file`, or single-profile launch path resolution: rerun `B2`.
+- Changes to `basecamp launch` (kill-and-scrub semantics, XDG isolation, runtime/log/env export, port-override env vars, p2p surface): rerun `B3`.
+- Changes to clean-slate scrub semantics, profile-name validation, path-root bounds, or the empty `[modules]` guard on `launch`: rerun `B4`.
 - Changes to `basecamp build`, `basecamp build-portable`, variant normalization, `--module` filtering, or build attr selection: rerun `B5`.
-- Changes to `basecamp run`, `standalone_app`, run host defaulting, or module source validation for run: rerun `B6`.
+- Changes to `basecamp run`, `standalone_app`, or module source validation for run: rerun `B6`.
 - Changes to the public `logos_scaffold::api` surface (entry points, typed result models, categorized errors, `CommandFailed`, or the documented examples/doctests): rerun `A1`, and rerun the matching CLI scenario for any command whose `*_for_project` core changed.
 - Changes to `test-node` lifecycle, pin resolution, prepare/doctor, run-slot concurrency, or caller-checkout validation: rerun `T1` (and `A1` if the `api::testnode` lifecycle types changed).
 - Changes to the `test-node` RPC client (transaction outcomes, block/clock parsing, account/proof reads, or their JSON shapes): rerun `T2`.

--- a/docs/basecamp-module-requirements.md
+++ b/docs/basecamp-module-requirements.md
@@ -179,6 +179,50 @@ The `.scaffold/basecamp/portable/` directory is wiped and recreated on every `bu
 
 If a flake exposes only `lgx` (not `lgx-portable`), `build-portable` fails with a targeted hint — mirror of the `install` portable-only failure, in reverse.
 
+## Per-profile launch configuration
+
+`launch` defaults to the pre-seeded `alice` / `bob` profiles, but a project can declare its own profiles — with domain names — under `[basecamp.profiles.<name>]` in `scaffold.toml`. Any declared profile launches; unknown profiles are seeded on first launch. When `[basecamp.profiles.*]` is omitted entirely, the `alice` / `bob` default is preserved.
+
+```toml
+[basecamp.profiles.maker]
+env_file    = ".env"                          # dotenv KEY=VALUE, sourced before `env`
+env         = { SWAP_UI_AUTO_ROLE = "maker" }  # per-profile overrides (win over [basecamp.env])
+runtime_dir = "/tmp/lgs-maker"                 # see the socket-path budget below
+log_file    = ".scaffold/basecamp/profiles/maker/basecamp.log"
+
+[basecamp.profiles.taker]
+env_file    = ".env.taker"
+env         = { SWAP_UI_AUTO_ROLE = "taker" }
+```
+
+- **`env_file`** is sourced first, then `[basecamp.env]`/`[basecamp.env_append]`, then the profile's inline `env` (last writer wins).
+- **`launch --log-file[=PATH]`** tees basecamp's stdout/stderr to the terminal *and* a file (bare `--log-file` → `.scaffold/basecamp/profiles/<profile>/basecamp.log`; overrides `log_file`). Without it, `launch` `exec`s as before.
+- **`lgs basecamp paths <profile> [--json]`** prints the resolved per-profile path manifest (xdg dirs, runtime dir, module/plugin dirs, `launch.state`, log file, env file) without building or mutating anything.
+
+A project that ships more than one basecamp variant can map the flake attr per host instead of hard-coding one:
+
+```toml
+[repos.basecamp.attr]              # scalar `attr = "app"` still works as the fallback
+aarch64-darwin = "bin-macos-app"
+aarch64-linux  = "bin-appimage"
+```
+
+### The macOS `sun_path == 104` socket-path budget
+
+When a module loads, liblogos opens a Unix-domain socket (a `QLocalServer` named `logos_token_<module>_<pid>`) under `XDG_RUNTIME_DIR`. macOS caps the full socket path (`sockaddr_un.sun_path`) at **104 bytes**, so a long runtime root overflows it and basecamp aborts module loading with:
+
+```
+[SubprocessContainer] Unix socket path too long (122 >= 104)
+```
+
+scaffold's default per-profile runtime root is the long in-profile `…/.scaffold/basecamp/profiles/<profile>/xdg-tmp`, which for a typical project path plus the `logos_token_<module>_<pid>` socket name easily blows the 104-byte budget. To avoid that, `launch` resolves `runtime_dir` with this precedence and exports it as both `TMPDIR` and `XDG_RUNTIME_DIR`:
+
+1. **`[basecamp.profiles.<name>].runtime_dir`** if set (project-relative paths are joined to the project root).
+2. **`/tmp/lgs-<profile>`** — the automatic default on macOS (short, well under the budget).
+3. The in-profile `xdg-tmp` on Linux, where the path budget is far larger and not a practical concern.
+
+If you override `runtime_dir` on macOS, keep it short (a `/tmp/…` root is safest) — a deep or project-relative path can still exceed 104 bytes once the socket name is appended.
+
 ## Quick checklist
 
 - [ ] `scaffold.toml` exists at the project root.
@@ -187,3 +231,4 @@ If a flake exposes only `lgx` (not `lgx-portable`), `build-portable` fails with 
 - [ ] Sibling sub-flake URLs use the `path:../<sibling-dir>` form, declared on a single `<name>.url = "…"` line (not split across multiple lines inside a nested attrset — parser limitation).
 - [ ] Transitive `logos-module-builder` references are unified with a `follows` onto the top-level pin (see "Transitive inputs must `follows` …" above).
 - [ ] No project relies on `lgx-portable` as the only output without passing `--flake` explicitly.
+- [ ] On macOS, the per-profile `runtime_dir` stays short enough that `<runtime_dir>/logos_token_<module>_<pid>` fits the 104-byte `sun_path` budget (the `/tmp/lgs-<profile>` default does; a custom override must too).

--- a/docs/basecamp-module-requirements.md
+++ b/docs/basecamp-module-requirements.md
@@ -215,7 +215,7 @@ When a module loads, liblogos opens a Unix-domain socket (a `QLocalServer` named
 [SubprocessContainer] Unix socket path too long (122 >= 104)
 ```
 
-scaffold's default per-profile runtime root is the long in-profile `…/.scaffold/basecamp/profiles/<profile>/xdg-tmp`, which for a typical project path plus the `logos_token_<module>_<pid>` socket name easily blows the 104-byte budget. To avoid that, `launch` resolves `runtime_dir` with this precedence and exports it as both `TMPDIR` and `XDG_RUNTIME_DIR`:
+the in-profile runtime root `…/.scaffold/basecamp/profiles/<profile>/xdg-tmp` is long: for a typical project path plus the `logos_token_<module>_<pid>` socket name it easily blows the 104-byte budget. To avoid that, `launch` resolves `runtime_dir` with this precedence and exports it as both `TMPDIR` and `XDG_RUNTIME_DIR`:
 
 1. **`[basecamp.profiles.<name>].runtime_dir`** if set (project-relative paths are joined to the project root).
 2. **`/tmp/lgs-<profile>`** — the automatic default on macOS (short, well under the budget).

--- a/docs/basecamp-module-requirements.md
+++ b/docs/basecamp-module-requirements.md
@@ -195,7 +195,7 @@ env_file    = ".env.taker"
 env         = { SWAP_UI_AUTO_ROLE = "taker" }
 ```
 
-- **`env_file`** is sourced first, then `[basecamp.env]`/`[basecamp.env_append]`, then the profile's inline `env` (last writer wins).
+- **Env layering** (last writer wins): `[basecamp.env_append]` path joins first, then the per-profile **`env_file`**, then `[basecamp.env]` globals, then the profile's inline **`env`**.
 - **`launch --log-file[=PATH]`** tees basecamp's stdout/stderr to the terminal *and* a file (bare `--log-file` → `.scaffold/basecamp/profiles/<profile>/basecamp.log`; overrides `log_file`). Without it, `launch` `exec`s as before.
 - **`lgs basecamp paths <profile> [--json]`** prints the resolved per-profile path manifest (xdg dirs, runtime dir, module/plugin dirs, `launch.state`, log file, env file) without building or mutating anything.
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -699,7 +699,12 @@ impl BasecampCommand {
             Self::Install => BasecampAction::Install {
                 print_output: false,
             },
-            Self::Launch { profile } => BasecampAction::Launch { profile },
+            // The public API doesn't surface `--log-file`; default to no log
+            // (falls back to `[basecamp.profiles.<name>].log_file` if set).
+            Self::Launch { profile } => BasecampAction::Launch {
+                profile,
+                log_file: None,
+            },
             Self::Develop { module, dev_shell } => BasecampAction::Develop { module, dev_shell },
             Self::Build { variants, module } => BasecampAction::Build { variants, module },
             Self::BuildPortable => BasecampAction::Build {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1160,6 +1160,11 @@ struct BasecampInstallArgs {
 struct BasecampLaunchArgs {
     #[arg(value_name = "PROFILE")]
     profile: String,
+    /// Tee basecamp's stdout/stderr to a log file. Bare `--log-file` uses
+    /// `.scaffold/basecamp/profiles/<profile>/basecamp.log`; `--log-file=PATH`
+    /// picks a path. Overrides `[basecamp.profiles.<profile>].log_file`.
+    #[arg(long, value_name = "PATH", num_args = 0..=1, require_equals = true)]
+    log_file: Option<Option<PathBuf>>,
 }
 
 #[derive(Debug, clap::Args)]
@@ -1503,6 +1508,7 @@ pub(crate) fn run(args: Vec<String>) -> DynResult<()> {
                 },
                 BasecampSubcommand::Launch(args) => BasecampAction::Launch {
                     profile: args.profile,
+                    log_file: args.log_file,
                 },
                 BasecampSubcommand::Develop(args) => BasecampAction::Develop {
                     module: args.module,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1076,6 +1076,10 @@ enum BasecampSubcommand {
     )]
     Doctor(BasecampDoctorArgs),
     #[command(
+        about = "Print the resolved per-profile path manifest (xdg dirs, runtime dir, module/plugin dirs, log file)."
+    )]
+    Paths(BasecampPathsArgs),
+    #[command(
         about = "Print the canonical project-compatibility rules (embedded copy of docs/basecamp-module-requirements.md)"
     )]
     Docs,
@@ -1165,6 +1169,14 @@ struct BasecampLaunchArgs {
     /// picks a path. Overrides `[basecamp.profiles.<profile>].log_file`.
     #[arg(long, value_name = "PATH", num_args = 0..=1, require_equals = true)]
     log_file: Option<Option<PathBuf>>,
+}
+
+#[derive(Debug, clap::Args)]
+struct BasecampPathsArgs {
+    #[arg(value_name = "PROFILE")]
+    profile: String,
+    #[arg(long)]
+    json: bool,
 }
 
 #[derive(Debug, clap::Args)]
@@ -1529,6 +1541,10 @@ pub(crate) fn run(args: Vec<String>) -> DynResult<()> {
                     }),
                 },
                 BasecampSubcommand::Doctor(args) => BasecampAction::Doctor { json: args.json },
+                BasecampSubcommand::Paths(args) => BasecampAction::Paths {
+                    profile: args.profile,
+                    json: args.json,
+                },
                 BasecampSubcommand::Docs => BasecampAction::Docs,
             };
             cmd_basecamp(action)

--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -361,27 +361,15 @@ fn cmd_basecamp_launch(project: Project, profile: String) -> DynResult<()> {
         bail!("basecamp not set up yet; run: logos-scaffold basecamp setup");
     }
 
-    if profile != BASECAMP_PROFILE_ALICE && profile != BASECAMP_PROFILE_BOB {
-        bail!(
-            "unknown profile `{profile}`; v1 only supports `{}` and `{}`",
-            BASECAMP_PROFILE_ALICE,
-            BASECAMP_PROFILE_BOB
-        );
-    }
-    // Defense-in-depth against a future caller bypassing the allowlist: refuse
-    // any profile name that could escape the profiles root via path separators.
+    // Any profile name is accepted (custom profiles beyond the alice/bob pair
+    // setup seeds); an unknown profile is seeded on first launch below. Still
+    // refuse names that could escape the profiles root via path separators.
     if profile.contains('/') || profile.contains(MAIN_SEPARATOR) {
         bail!("profile name `{profile}` must not contain path separators");
     }
 
     let profiles_root = project.root.join(BASECAMP_PROFILES_REL);
     let profile_dir = profiles_root.join(&profile);
-    if !profile_dir.is_dir() {
-        bail!(
-            "profile `{profile}` missing under {}; re-run `logos-scaffold basecamp setup`",
-            profiles_root.display()
-        );
-    }
 
     let launch_state_path = profile_dir.join("launch.state");
     let expected_comm = basecamp_comm_name(&state.basecamp_bin);
@@ -447,10 +435,17 @@ fn cmd_basecamp_launch(project: Project, profile: String) -> DynResult<()> {
 
     let mut env = launch_env(&profile_dir, &profile);
     // Layer scaffold.toml-declared launch env on top of the scaffold-owned
-    // base (#163): [basecamp.env_append] path joins, then [basecamp.env]
-    // globals, then [basecamp.profiles.<profile>.env] (profile wins).
+    // base (#163): [basecamp.env_append] path joins, then the per-profile
+    // env_file, then [basecamp.env] globals, then
+    // [basecamp.profiles.<profile>.env] (profile wins).
     if let Some(bc) = project.config.basecamp.as_ref() {
-        apply_launch_env_overrides(&mut env, bc, &profile, |k| std::env::var_os(k));
+        let env_file_vars = match bc.profiles.get(&profile).and_then(|p| p.env_file.as_deref()) {
+            Some(rel) => load_env_file(&project.root, rel)?,
+            None => BTreeMap::new(),
+        };
+        apply_launch_env_overrides(&mut env, bc, &profile, &env_file_vars, |k| {
+            std::env::var_os(k)
+        });
     }
     println!("launching basecamp for profile {profile}");
     let mut cmd = Command::new(&state.basecamp_bin);
@@ -633,14 +628,17 @@ fn cmd_basecamp_run(project: Project, module: String, host: Option<String>) -> D
 /// `launch_env` base. Resolution order, last-writer-wins per key:
 ///   1. `[basecamp.env_append]` — `:`-join each list onto the value `lgs`
 ///      inherited (`inherited(key)`), so basecamp's own paths aren't clobbered.
-///   2. `[basecamp.env]` — global plain replace.
-///   3. `[basecamp.profiles.<profile>.env]` — per-profile plain replace (wins).
+///   2. `[basecamp.profiles.<profile>.env_file]` — already parsed into
+///      `env_file_vars` by the caller; sourced before the `env` layers.
+///   3. `[basecamp.env]` — global plain replace.
+///   4. `[basecamp.profiles.<profile>.env]` — per-profile plain replace (wins).
 /// `inherited` is injected (real caller passes `std::env::var_os`) so the
 /// append semantics are unit-testable without touching the process environment.
 fn apply_launch_env_overrides(
     env: &mut BTreeMap<String, OsString>,
     cfg: &BasecampConfig,
     profile: &str,
+    env_file_vars: &BTreeMap<String, String>,
     inherited: impl Fn(&str) -> Option<OsString>,
 ) {
     for (key, paths) in &cfg.env_append {
@@ -663,14 +661,50 @@ fn apply_launch_env_overrides(
         combined.push(paths.join(":"));
         env.insert(key.clone(), combined);
     }
+    for (key, val) in env_file_vars {
+        env.insert(key.clone(), OsString::from(val));
+    }
     for (key, val) in &cfg.env {
         env.insert(key.clone(), OsString::from(val));
     }
-    if let Some(profile_env) = cfg.profile_env.get(profile) {
-        for (key, val) in profile_env {
+    if let Some(p) = cfg.profiles.get(profile) {
+        for (key, val) in &p.env {
             env.insert(key.clone(), OsString::from(val));
         }
     }
+}
+
+/// Parse a per-profile `env_file` (dotenv-style `KEY=VALUE` lines) into a map,
+/// resolved relative to the project root. Blank lines and `#` comments are
+/// skipped, an optional leading `export ` is stripped, and matching single or
+/// double quotes around the value are removed.
+fn load_env_file(project_root: &Path, rel: &str) -> DynResult<BTreeMap<String, String>> {
+    let path = project_root.join(rel);
+    let text = fs::read_to_string(&path)
+        .with_context(|| format!("read basecamp profile env_file {}", path.display()))?;
+    let mut out = BTreeMap::new();
+    for (i, raw) in text.lines().enumerate() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let line = line.strip_prefix("export ").unwrap_or(line);
+        let Some((k, v)) = line.split_once('=') else {
+            bail!("{}:{}: expected KEY=VALUE, got {raw:?}", path.display(), i + 1);
+        };
+        let key = k.trim();
+        if key.is_empty() {
+            bail!("{}:{}: empty env var name", path.display(), i + 1);
+        }
+        let val = v.trim();
+        let val = val
+            .strip_prefix('"')
+            .and_then(|s| s.strip_suffix('"'))
+            .or_else(|| val.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')))
+            .unwrap_or(val);
+        out.insert(key.to_string(), val.to_string());
+    }
+    Ok(out)
 }
 
 /// Remove a profile's `xdg-data` and `xdg-cache` trees. Refuses to operate on any
@@ -3603,15 +3637,18 @@ mod tests {
             "QT_PLUGIN_PATH".into(),
             vec!["/nix/store/a/plugins".into(), "/nix/store/b/plugins".into()],
         );
-        cfg.profile_env.insert(
+        cfg.profiles.insert(
             "alice".into(),
-            [("LOGOS_STORAGE_API_PORT".to_string(), "8081".to_string())]
-                .into_iter()
-                .collect(),
+            crate::model::BasecampProfile {
+                env: [("LOGOS_STORAGE_API_PORT".to_string(), "8081".to_string())]
+                    .into_iter()
+                    .collect(),
+                ..Default::default()
+            },
         );
 
         let mut env = launch_env(Path::new("/p/alice"), "alice");
-        apply_launch_env_overrides(&mut env, &cfg, "alice", |k| {
+        apply_launch_env_overrides(&mut env, &cfg, "alice", &BTreeMap::new(), |k| {
             (k == "QT_PLUGIN_PATH").then(|| OsString::from("/usr/lib/qt/plugins"))
         });
 
@@ -3632,12 +3669,61 @@ mod tests {
     }
 
     #[test]
+    fn launch_env_file_vars_sourced_before_env_overrides() {
+        // env_file is a base layer: global [basecamp.env] and per-profile env
+        // both override it, while keys only in env_file pass through.
+        let mut cfg = BasecampConfig::default();
+        cfg.env.insert("SHARED".into(), "from-global".into());
+        cfg.profiles.insert(
+            "alice".into(),
+            crate::model::BasecampProfile {
+                env: [("PROFILE_ONLY".to_string(), "from-profile".to_string())]
+                    .into_iter()
+                    .collect(),
+                ..Default::default()
+            },
+        );
+        let env_file_vars: BTreeMap<String, String> = [
+            ("SHARED".to_string(), "from-file".to_string()),
+            ("FILE_ONLY".to_string(), "kept".to_string()),
+        ]
+        .into_iter()
+        .collect();
+        let mut env = launch_env(Path::new("/p/alice"), "alice");
+        apply_launch_env_overrides(&mut env, &cfg, "alice", &env_file_vars, |_| None);
+        // global env wins over env_file for the shared key.
+        assert_eq!(env.get("SHARED").unwrap(), &OsString::from("from-global"));
+        // env_file-only key survives.
+        assert_eq!(env.get("FILE_ONLY").unwrap(), &OsString::from("kept"));
+        // per-profile env applied.
+        assert_eq!(
+            env.get("PROFILE_ONLY").unwrap(),
+            &OsString::from("from-profile")
+        );
+    }
+
+    #[test]
+    fn load_env_file_parses_dotenv_lines() {
+        let tmp = tempdir().expect("tempdir");
+        let root = tmp.path();
+        fs::write(
+            root.join("alice.env"),
+            "# comment\n\nexport FOO=bar\nQUOTED=\"a b\"\nSINGLE='x'\n",
+        )
+        .unwrap();
+        let vars = load_env_file(root, "alice.env").expect("load");
+        assert_eq!(vars.get("FOO").map(String::as_str), Some("bar"));
+        assert_eq!(vars.get("QUOTED").map(String::as_str), Some("a b"));
+        assert_eq!(vars.get("SINGLE").map(String::as_str), Some("x"));
+    }
+
+    #[test]
     fn launch_env_append_uses_only_configured_when_no_inherited_value() {
         let mut cfg = BasecampConfig::default();
         cfg.env_append
             .insert("LD_LIBRARY_PATH".into(), vec!["/nix/store/x/lib".into()]);
         let mut env = launch_env(Path::new("/p/bob"), "bob");
-        apply_launch_env_overrides(&mut env, &cfg, "bob", |_| None);
+        apply_launch_env_overrides(&mut env, &cfg, "bob", &BTreeMap::new(), |_| None);
         assert_eq!(
             env.get("LD_LIBRARY_PATH").unwrap(),
             &OsString::from("/nix/store/x/lib")
@@ -3655,7 +3741,7 @@ mod tests {
             .insert("LD_LIBRARY_PATH".into(), vec!["/nix/store/x/lib".into()]);
         let mut env = launch_env(Path::new("/p/bob"), "bob");
         let weird_for_closure = weird.clone();
-        apply_launch_env_overrides(&mut env, &cfg, "bob", move |k| {
+        apply_launch_env_overrides(&mut env, &cfg, "bob", &BTreeMap::new(), move |k| {
             (k == "LD_LIBRARY_PATH").then(|| weird_for_closure.clone())
         });
         let mut expected = weird;
@@ -3666,14 +3752,17 @@ mod tests {
     #[test]
     fn launch_env_profile_env_does_not_leak_across_profiles() {
         let mut cfg = BasecampConfig::default();
-        cfg.profile_env.insert(
+        cfg.profiles.insert(
             "alice".into(),
-            [("PORT".to_string(), "1".to_string())]
-                .into_iter()
-                .collect(),
+            crate::model::BasecampProfile {
+                env: [("PORT".to_string(), "1".to_string())]
+                    .into_iter()
+                    .collect(),
+                ..Default::default()
+            },
         );
         let mut bob_env = launch_env(Path::new("/p/bob"), "bob");
-        apply_launch_env_overrides(&mut bob_env, &cfg, "bob", |_| None);
+        apply_launch_env_overrides(&mut bob_env, &cfg, "bob", &BTreeMap::new(), |_| None);
         assert!(
             bob_env.get("PORT").is_none(),
             "alice's profile env must not leak to bob"

--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -475,7 +475,11 @@ fn cmd_basecamp_launch(
     // env_file, then [basecamp.env] globals, then
     // [basecamp.profiles.<profile>.env] (profile wins).
     if let Some(bc) = project.config.basecamp.as_ref() {
-        let env_file_vars = match bc.profiles.get(&profile).and_then(|p| p.env_file.as_deref()) {
+        let env_file_vars = match bc
+            .profiles
+            .get(&profile)
+            .and_then(|p| p.env_file.as_deref())
+        {
             Some(rel) => load_env_file(&project.root, rel)?,
             None => BTreeMap::new(),
         };
@@ -526,7 +530,8 @@ fn run_with_log_tee(
     use std::sync::{Arc, Mutex};
 
     if let Some(parent) = log_path.parent() {
-        fs::create_dir_all(parent).with_context(|| format!("create log dir {}", parent.display()))?;
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create log dir {}", parent.display()))?;
     }
     let log = fs::File::create(log_path)
         .with_context(|| format!("create log file {}", log_path.display()))?;
@@ -580,7 +585,11 @@ fn run_with_log_tee(
         let _ = h.join();
     }
     let _ = fs::remove_file(launch_state_path);
-    std::process::exit(status.code().unwrap_or(if status.success() { 0 } else { 1 }));
+    std::process::exit(
+        status
+            .code()
+            .unwrap_or(if status.success() { 0 } else { 1 }),
+    );
 }
 
 /// Resolved per-profile path manifest emitted by `basecamp paths`.
@@ -711,7 +720,10 @@ fn launch_env(
             env.insert("XDG_RUNTIME_DIR".into(), rt.as_os_str().to_owned());
         }
         None => {
-            env.insert("TMPDIR".into(), profile_dir.join("xdg-tmp").into_os_string());
+            env.insert(
+                "TMPDIR".into(),
+                profile_dir.join("xdg-tmp").into_os_string(),
+            );
         }
     }
     env.insert("LOGOS_PROFILE".into(), profile_name.into());
@@ -931,7 +943,11 @@ fn load_env_file(project_root: &Path, rel: &str) -> DynResult<BTreeMap<String, S
         }
         let line = line.strip_prefix("export ").unwrap_or(line);
         let Some((k, v)) = line.split_once('=') else {
-            bail!("{}:{}: expected KEY=VALUE, got {raw:?}", path.display(), i + 1);
+            bail!(
+                "{}:{}: expected KEY=VALUE, got {raw:?}",
+                path.display(),
+                i + 1
+            );
         };
         let key = k.trim();
         if key.is_empty() {
@@ -4023,7 +4039,10 @@ mod tests {
     fn launch_env_runtime_dir_sets_tmpdir_and_xdg_runtime_dir() {
         let rt = Path::new("/tmp/lgs-alice");
         let env = launch_env(Path::new("/p/alice"), "alice", Some(rt));
-        assert_eq!(env.get("TMPDIR").unwrap(), &OsString::from("/tmp/lgs-alice"));
+        assert_eq!(
+            env.get("TMPDIR").unwrap(),
+            &OsString::from("/tmp/lgs-alice")
+        );
         assert_eq!(
             env.get("XDG_RUNTIME_DIR").unwrap(),
             &OsString::from("/tmp/lgs-alice")

--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -380,6 +380,12 @@ fn validate_profile_name(profile: &str) -> DynResult<()> {
              (no `/`, `..`, `.`, or absolute paths)"
         );
     }
+    // A control char (e.g. a newline) passes the `Component::Normal` check but
+    // yields surprising filesystem paths (`launch.state` under a `\n` name) and
+    // unsafe terminal output.
+    if profile.chars().any(char::is_control) {
+        bail!("invalid profile name `{profile}`: must not contain control characters");
+    }
     Ok(())
 }
 
@@ -971,6 +977,16 @@ fn load_env_file(project_root: &Path, rel: &str) -> DynResult<BTreeMap<String, S
         let key = k.trim();
         if key.is_empty() {
             bail!("{}:{}: empty env var name", path.display(), i + 1);
+        }
+        // A control char in the name reaches `Command::env` and fails opaquely
+        // at spawn; reject it here with a located, deterministic error. (`=`
+        // can't occur — `split_once('=')` already consumed the first one.)
+        if key.chars().any(char::is_control) {
+            bail!(
+                "{}:{}: env var name {key:?} must not contain control characters",
+                path.display(),
+                i + 1
+            );
         }
         let val = v.trim();
         let val = val
@@ -3994,6 +4010,20 @@ mod tests {
     }
 
     #[test]
+    fn load_env_file_rejects_control_char_in_key() {
+        let tmp = tempdir().expect("tempdir");
+        let root = tmp.path();
+        // A tab inside the key reaches `Command::env` and fails opaquely; the
+        // loader must reject it up front with a located error.
+        fs::write(root.join("bad.env"), "FO\tO=bar\n").unwrap();
+        let err = load_env_file(root, "bad.env").unwrap_err();
+        assert!(
+            format!("{err}").contains("control characters"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
     fn launch_env_append_uses_only_configured_when_no_inherited_value() {
         let mut cfg = BasecampConfig::default();
         cfg.env_append
@@ -4073,8 +4103,11 @@ mod tests {
         for ok in ["alice", "bob", "carol-1", "team_2"] {
             assert!(validate_profile_name(ok).is_ok(), "should accept {ok:?}");
         }
-        // Single-component names that would escape or misbehave when joined.
-        for bad in ["", "..", ".", "a/b", "/abs", "../evil", "sub/../x"] {
+        // Single-component names that would escape or misbehave when joined,
+        // plus single-component names carrying control characters.
+        for bad in [
+            "", "..", ".", "a/b", "/abs", "../evil", "sub/../x", "a\nb", "a\tb",
+        ] {
             assert!(validate_profile_name(bad).is_err(), "should reject {bad:?}");
         }
     }

--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -45,6 +45,9 @@ pub(crate) enum BasecampAction {
     },
     Launch {
         profile: String,
+        /// `--log-file` selector: `None` = flag absent (fall back to config);
+        /// `Some(None)` = bare flag (default path); `Some(Some(p))` = explicit.
+        log_file: Option<Option<PathBuf>>,
     },
     /// Enter a module's Nix dev shell. Resolves the module's flake from
     /// `[modules.<name>]`, strips its output fragment, and execs
@@ -113,7 +116,9 @@ pub(crate) fn basecamp_for_project(project: Project, action: BasecampAction) -> 
             }
             cmd_basecamp_install(project, &NixLgxProbe)
         }
-        BasecampAction::Launch { profile } => cmd_basecamp_launch(project, profile),
+        BasecampAction::Launch { profile, log_file } => {
+            cmd_basecamp_launch(project, profile, log_file)
+        }
         BasecampAction::Develop { module, dev_shell } => {
             cmd_basecamp_develop(project, module, dev_shell)
         }
@@ -351,7 +356,11 @@ fn resolve_basecamp_binary(app_link: &Path) -> DynResult<PathBuf> {
 
 // Concurrent `launch <same-profile>` is undefined: no lock; two racing
 // invocations leave partial state.
-fn cmd_basecamp_launch(project: Project, profile: String) -> DynResult<()> {
+fn cmd_basecamp_launch(
+    project: Project,
+    profile: String,
+    log_file: Option<Option<PathBuf>>,
+) -> DynResult<()> {
     let state_path = project.root.join(".scaffold/state/basecamp.state");
     let state = match read_basecamp_state(&state_path).ok() {
         Some(s) if !s.basecamp_bin.is_empty() && !s.lgpm_bin.is_empty() => s,
@@ -370,6 +379,21 @@ fn cmd_basecamp_launch(project: Project, profile: String) -> DynResult<()> {
 
     let profiles_root = project.root.join(BASECAMP_PROFILES_REL);
     let profile_dir = profiles_root.join(&profile);
+
+    // Resolve the optional log destination: `--log-file` wins over the
+    // per-profile `[basecamp.profiles.<profile>].log_file`. A bare `--log-file`
+    // defaults to `<profile_dir>/basecamp.log`; `None` means no logging (exec).
+    let log_dest: Option<PathBuf> = match log_file {
+        Some(Some(p)) => Some(project.root.join(p)),
+        Some(None) => Some(profile_dir.join("basecamp.log")),
+        None => project
+            .config
+            .basecamp
+            .as_ref()
+            .and_then(|bc| bc.profiles.get(&profile))
+            .and_then(|p| p.log_file.as_deref())
+            .map(|rel| project.root.join(rel)),
+    };
 
     let launch_state_path = profile_dir.join("launch.state");
     let expected_comm = basecamp_comm_name(&state.basecamp_bin);
@@ -461,14 +485,95 @@ fn cmd_basecamp_launch(project: Project, profile: String) -> DynResult<()> {
     // via a registry — empty in v1 since no modules have published names.
     // Concurrent alice/bob on the same host may collide on module-level ports
     // until upstreams adopt overrides.
-    write_launch_pid(&launch_state_path, std::process::id())?;
-    let err = cmd.exec();
-    // exec() only returns on failure. On Linux/Unix exec preserves the PID, so
-    // launch.state is valid once exec succeeds — but on failure the PID we wrote
-    // belongs to the scaffold process that's about to exit. Remove the file so a
-    // later launch doesn't kill whatever reuses the PID.
-    let _ = fs::remove_file(&launch_state_path);
-    bail!("failed to exec basecamp at {}: {err}", state.basecamp_bin);
+    match log_dest {
+        // No log file: exec and hand the terminal straight to basecamp. exec
+        // preserves the PID, so launch.state stays valid once it succeeds; on
+        // failure the PID we wrote belongs to this about-to-exit scaffold
+        // process, so remove the file before a later launch can kill whatever
+        // reuses the PID.
+        None => {
+            write_launch_pid(&launch_state_path, std::process::id())?;
+            let err = cmd.exec();
+            let _ = fs::remove_file(&launch_state_path);
+            bail!("failed to exec basecamp at {}: {err}", state.basecamp_bin);
+        }
+        // Log requested: exec can't tee, so spawn and fan output to the
+        // terminal + file, recording the child's PID.
+        Some(dest) => run_with_log_tee(cmd, &state.basecamp_bin, &launch_state_path, &dest),
+    }
+}
+
+/// Spawn basecamp with stdout/stderr teed to both the terminal and `log_path`,
+/// wait for it, and exit with its status. Used instead of `exec` when a log
+/// file is requested — `exec` would replace this process, leaving nowhere to
+/// copy output into a file. The spawned child's PID is what `launch.state`
+/// records.
+fn run_with_log_tee(
+    mut cmd: Command,
+    bin: &str,
+    launch_state_path: &Path,
+    log_path: &Path,
+) -> DynResult<()> {
+    use std::io::{Read, Write};
+    use std::process::Stdio;
+    use std::sync::{Arc, Mutex};
+
+    if let Some(parent) = log_path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("create log dir {}", parent.display()))?;
+    }
+    let log = fs::File::create(log_path)
+        .with_context(|| format!("create log file {}", log_path.display()))?;
+    println!("teeing basecamp output to {}", log_path.display());
+
+    let mut child = cmd
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("spawn basecamp at {bin}"))?;
+    write_launch_pid(launch_state_path, child.id())?;
+
+    let log = Arc::new(Mutex::new(log));
+    // One thread per stream copies bytes to the inherited fd and the shared log.
+    let tee = |mut src: Box<dyn Read + Send>,
+               mut sink: Box<dyn Write + Send>,
+               log: Arc<Mutex<fs::File>>| {
+        thread::spawn(move || {
+            let mut buf = [0u8; 8192];
+            while let Ok(n) = src.read(&mut buf) {
+                if n == 0 {
+                    break;
+                }
+                let _ = sink.write_all(&buf[..n]);
+                let _ = sink.flush();
+                if let Ok(mut f) = log.lock() {
+                    let _ = f.write_all(&buf[..n]);
+                }
+            }
+        })
+    };
+    let mut handles = Vec::new();
+    if let Some(out) = child.stdout.take() {
+        handles.push(tee(
+            Box::new(out),
+            Box::new(std::io::stdout()),
+            Arc::clone(&log),
+        ));
+    }
+    if let Some(err) = child.stderr.take() {
+        handles.push(tee(
+            Box::new(err),
+            Box::new(std::io::stderr()),
+            Arc::clone(&log),
+        ));
+    }
+    let status = child
+        .wait()
+        .with_context(|| format!("wait basecamp at {bin}"))?;
+    for h in handles {
+        let _ = h.join();
+    }
+    let _ = fs::remove_file(launch_state_path);
+    std::process::exit(status.code().unwrap_or(if status.success() { 0 } else { 1 }));
 }
 
 /// Env map exported to the basecamp child on launch. Scaffold-owned names only;

--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -184,10 +184,13 @@ fn cmd_basecamp_setup(mut project: Project) -> DynResult<()> {
     if basecamp_repo.pin.is_empty() {
         basecamp_repo.pin = DEFAULT_BASECAMP_PIN.to_string();
     }
-    // Only fall back to the scalar default when neither the scalar `attr` nor
-    // a per-platform `attr` map was configured — otherwise we'd clobber a
-    // user's `[repos.basecamp.attr]` map on the next `save_project_config`.
-    if basecamp_repo.attr.is_empty() && basecamp_repo.attr_platform.is_empty() {
+    // Always give the scalar `attr` a default when it's unset, even when a
+    // per-platform `attr` map is configured: `effective_attr` falls back to
+    // the scalar on a host the map doesn't cover, so without this the build
+    // below would run `nix build .#` with an empty attr on unmapped systems.
+    // The scalar is a fallback only — serialization still prefers the map, so
+    // the user's `[repos.basecamp.attr]` map is not clobbered.
+    if basecamp_repo.attr.is_empty() {
         basecamp_repo.attr = BASECAMP_ATTR.to_string();
     }
 

--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -172,7 +172,10 @@ fn cmd_basecamp_setup(mut project: Project) -> DynResult<()> {
     if basecamp_repo.pin.is_empty() {
         basecamp_repo.pin = DEFAULT_BASECAMP_PIN.to_string();
     }
-    if basecamp_repo.attr.is_empty() {
+    // Only fall back to the scalar default when neither the scalar `attr` nor
+    // a per-platform `attr` map was configured — otherwise we'd clobber a
+    // user's `[repos.basecamp.attr]` map on the next `save_project_config`.
+    if basecamp_repo.attr.is_empty() && basecamp_repo.attr_platform.is_empty() {
         basecamp_repo.attr = BASECAMP_ATTR.to_string();
     }
 
@@ -216,7 +219,7 @@ fn cmd_basecamp_setup(mut project: Project) -> DynResult<()> {
     let basecamp_bin = build_basecamp_app(
         &project.root,
         &basecamp_repo_path,
-        &basecamp_repo.attr,
+        basecamp_repo.effective_attr(nix_current_system()),
         &pin_artifacts,
     )?;
     // lgpm is built from a flake ref derived from [repos.lgpm].
@@ -252,16 +255,17 @@ fn cmd_basecamp_setup(mut project: Project) -> DynResult<()> {
 /// the legacy `[basecamp].lgpm_flake` string used).
 fn format_flake_ref(repo: &RepoRef) -> String {
     debug_assert!(repo.build == RepoBuild::NixFlake);
-    if repo.attr.is_empty() {
+    let attr = repo.effective_attr(nix_current_system());
+    if attr.is_empty() {
         format!("{}/{}", repo.source, repo.pin)
     } else {
-        format!("{}/{}#{}", repo.source, repo.pin, repo.attr)
+        format!("{}/{}#{}", repo.source, repo.pin, attr)
     }
 }
 
 fn is_portable_basecamp(basecamp_repo: Option<&RepoRef>) -> bool {
     basecamp_repo
-        .map(|r| BASECAMP_PORTABLE_ATTRS.contains(&r.attr.as_str()))
+        .map(|r| BASECAMP_PORTABLE_ATTRS.contains(&r.effective_attr(nix_current_system())))
         .unwrap_or(false)
 }
 
@@ -3336,6 +3340,7 @@ mod tests {
             pin: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string(),
             build: RepoBuild::NixFlake,
             attr: attr.to_string(),
+            attr_platform: std::collections::BTreeMap::new(),
             path: String::new(),
         }
     }

--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -433,7 +433,12 @@ fn cmd_basecamp_launch(project: Project, profile: String) -> DynResult<()> {
         }
     }
 
-    let mut env = launch_env(&profile_dir, &profile);
+    let runtime_dir =
+        resolve_profile_runtime_dir(&project.root, &profile, project.config.basecamp.as_ref());
+    if let Some(rt) = &runtime_dir {
+        fs::create_dir_all(rt).with_context(|| format!("create runtime dir {}", rt.display()))?;
+    }
+    let mut env = launch_env(&profile_dir, &profile, runtime_dir.as_deref());
     // Layer scaffold.toml-declared launch env on top of the scaffold-owned
     // base (#163): [basecamp.env_append] path joins, then the per-profile
     // env_file, then [basecamp.env] globals, then
@@ -467,8 +472,14 @@ fn cmd_basecamp_launch(project: Project, profile: String) -> DynResult<()> {
 }
 
 /// Env map exported to the basecamp child on launch. Scaffold-owned names only;
-/// module port-override vars are not yet registered.
-fn launch_env(profile_dir: &Path, profile_name: &str) -> BTreeMap<String, OsString> {
+/// module port-override vars are not yet registered. `runtime_dir`, when set,
+/// becomes both `TMPDIR` and `XDG_RUNTIME_DIR`; otherwise `TMPDIR` falls back to
+/// the in-profile `xdg-tmp`.
+fn launch_env(
+    profile_dir: &Path,
+    profile_name: &str,
+    runtime_dir: Option<&Path>,
+) -> BTreeMap<String, OsString> {
     let mut env = BTreeMap::new();
     env.insert(
         "XDG_CONFIG_HOME".into(),
@@ -490,12 +501,42 @@ fn launch_env(profile_dir: &Path, profile_name: &str) -> BTreeMap<String, OsStri
     // first profile's Qt RemoteObjects replica then derefs a dangling
     // QMetaObject on its next socket read → SIGSEGV. A distinct temp root per
     // profile removes the race without any upstream change.
-    env.insert(
-        "TMPDIR".into(),
-        profile_dir.join("xdg-tmp").into_os_string(),
-    );
+    //
+    // A short `runtime_dir` (e.g. `/tmp/lgs-<profile>`) additionally dodges the
+    // macOS `sun_path == 104` Unix-socket path limit that the long in-profile
+    // `xdg-tmp` path can exceed; it also sets `XDG_RUNTIME_DIR`.
+    match runtime_dir {
+        Some(rt) => {
+            env.insert("TMPDIR".into(), rt.as_os_str().to_owned());
+            env.insert("XDG_RUNTIME_DIR".into(), rt.as_os_str().to_owned());
+        }
+        None => {
+            env.insert("TMPDIR".into(), profile_dir.join("xdg-tmp").into_os_string());
+        }
+    }
     env.insert("LOGOS_PROFILE".into(), profile_name.into());
     env
+}
+
+/// Resolve the per-profile runtime dir (`TMPDIR` / `XDG_RUNTIME_DIR` root).
+/// Precedence: configured `[basecamp.profiles.<name>].runtime_dir`
+/// (project-relative or absolute) > macOS default `/tmp/lgs-<profile>` > `None`
+/// (Linux keeps the in-profile `xdg-tmp`).
+fn resolve_profile_runtime_dir(
+    project_root: &Path,
+    profile: &str,
+    basecamp: Option<&BasecampConfig>,
+) -> Option<PathBuf> {
+    if let Some(rt) = basecamp
+        .and_then(|bc| bc.profiles.get(profile))
+        .and_then(|p| p.runtime_dir.as_deref())
+    {
+        return Some(project_root.join(rt));
+    }
+    if cfg!(target_os = "macos") {
+        return Some(PathBuf::from(format!("/tmp/lgs-{profile}")));
+    }
+    None
 }
 
 /// `lgs basecamp develop <module>` — enter a module's Nix dev shell.
@@ -3605,7 +3646,7 @@ mod tests {
     #[test]
     fn launch_env_exports_xdg_under_profile_dir_and_profile_name() {
         let profile_dir = Path::new("/p/alice");
-        let env = launch_env(profile_dir, "alice");
+        let env = launch_env(profile_dir, "alice", None);
         assert_eq!(
             env.get("XDG_CONFIG_HOME").unwrap(),
             &OsString::from("/p/alice/xdg-config")
@@ -3647,7 +3688,7 @@ mod tests {
             },
         );
 
-        let mut env = launch_env(Path::new("/p/alice"), "alice");
+        let mut env = launch_env(Path::new("/p/alice"), "alice", None);
         apply_launch_env_overrides(&mut env, &cfg, "alice", &BTreeMap::new(), |k| {
             (k == "QT_PLUGIN_PATH").then(|| OsString::from("/usr/lib/qt/plugins"))
         });
@@ -3689,7 +3730,7 @@ mod tests {
         ]
         .into_iter()
         .collect();
-        let mut env = launch_env(Path::new("/p/alice"), "alice");
+        let mut env = launch_env(Path::new("/p/alice"), "alice", None);
         apply_launch_env_overrides(&mut env, &cfg, "alice", &env_file_vars, |_| None);
         // global env wins over env_file for the shared key.
         assert_eq!(env.get("SHARED").unwrap(), &OsString::from("from-global"));
@@ -3722,7 +3763,7 @@ mod tests {
         let mut cfg = BasecampConfig::default();
         cfg.env_append
             .insert("LD_LIBRARY_PATH".into(), vec!["/nix/store/x/lib".into()]);
-        let mut env = launch_env(Path::new("/p/bob"), "bob");
+        let mut env = launch_env(Path::new("/p/bob"), "bob", None);
         apply_launch_env_overrides(&mut env, &cfg, "bob", &BTreeMap::new(), |_| None);
         assert_eq!(
             env.get("LD_LIBRARY_PATH").unwrap(),
@@ -3739,7 +3780,7 @@ mod tests {
         let mut cfg = BasecampConfig::default();
         cfg.env_append
             .insert("LD_LIBRARY_PATH".into(), vec!["/nix/store/x/lib".into()]);
-        let mut env = launch_env(Path::new("/p/bob"), "bob");
+        let mut env = launch_env(Path::new("/p/bob"), "bob", None);
         let weird_for_closure = weird.clone();
         apply_launch_env_overrides(&mut env, &cfg, "bob", &BTreeMap::new(), move |k| {
             (k == "LD_LIBRARY_PATH").then(|| weird_for_closure.clone())
@@ -3761,7 +3802,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let mut bob_env = launch_env(Path::new("/p/bob"), "bob");
+        let mut bob_env = launch_env(Path::new("/p/bob"), "bob", None);
         apply_launch_env_overrides(&mut bob_env, &cfg, "bob", &BTreeMap::new(), |_| None);
         assert!(
             bob_env.get("PORT").is_none(),
@@ -3773,9 +3814,37 @@ mod tests {
     fn launch_env_tmpdir_is_distinct_per_profile() {
         // The whole point of #89: alice and bob must not share a temp root,
         // or their `logos_token_<module>` sockets collide.
-        let alice = launch_env(Path::new("/p/alice"), "alice");
-        let bob = launch_env(Path::new("/p/bob"), "bob");
+        let alice = launch_env(Path::new("/p/alice"), "alice", None);
+        let bob = launch_env(Path::new("/p/bob"), "bob", None);
         assert_ne!(alice.get("TMPDIR"), bob.get("TMPDIR"));
+    }
+
+    #[test]
+    fn launch_env_runtime_dir_sets_tmpdir_and_xdg_runtime_dir() {
+        let rt = Path::new("/tmp/lgs-alice");
+        let env = launch_env(Path::new("/p/alice"), "alice", Some(rt));
+        assert_eq!(env.get("TMPDIR").unwrap(), &OsString::from("/tmp/lgs-alice"));
+        assert_eq!(
+            env.get("XDG_RUNTIME_DIR").unwrap(),
+            &OsString::from("/tmp/lgs-alice")
+        );
+    }
+
+    #[test]
+    fn resolve_profile_runtime_dir_prefers_config_over_default() {
+        let mut cfg = BasecampConfig::default();
+        cfg.profiles.insert(
+            "alice".into(),
+            crate::model::BasecampProfile {
+                runtime_dir: Some("run/alice".into()),
+                ..Default::default()
+            },
+        );
+        // Configured path wins (project-relative -> joined to root) on any OS.
+        assert_eq!(
+            resolve_profile_runtime_dir(Path::new("/proj"), "alice", Some(&cfg)),
+            Some(PathBuf::from("/proj/run/alice"))
+        );
     }
 
     #[test]

--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::ffi::OsString;
 use std::fs;
 use std::os::unix::process::CommandExt;
-use std::path::{Component, Path, PathBuf, MAIN_SEPARATOR};
+use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -361,6 +361,25 @@ fn resolve_basecamp_binary(app_link: &Path) -> DynResult<PathBuf> {
     )
 }
 
+/// Reject a profile name that isn't exactly one normal path component, so it
+/// can't escape the profiles root when joined: `..`, `.`, an empty name, an
+/// absolute path, or anything containing a separator are all refused. Shared
+/// by `launch` (which seeds/scrubs under the name) and `paths`.
+fn validate_profile_name(profile: &str) -> DynResult<()> {
+    let mut comps = Path::new(profile).components();
+    let single_normal = matches!(
+        (comps.next(), comps.next()),
+        (Some(Component::Normal(_)), None)
+    );
+    if !single_normal {
+        bail!(
+            "invalid profile name `{profile}`: must be a single path component \
+             (no `/`, `..`, `.`, or absolute paths)"
+        );
+    }
+    Ok(())
+}
+
 // Concurrent `launch <same-profile>` is undefined: no lock; two racing
 // invocations leave partial state.
 fn cmd_basecamp_launch(
@@ -378,11 +397,10 @@ fn cmd_basecamp_launch(
     }
 
     // Any profile name is accepted (custom profiles beyond the alice/bob pair
-    // setup seeds); an unknown profile is seeded on first launch below. Still
-    // refuse names that could escape the profiles root via path separators.
-    if profile.contains('/') || profile.contains(MAIN_SEPARATOR) {
-        bail!("profile name `{profile}` must not contain path separators");
-    }
+    // setup seeds); an unknown profile is seeded on first launch below. The
+    // name must be a single normal path component so it can't escape the
+    // profiles root via `..`, a separator, or an absolute path.
+    validate_profile_name(&profile)?;
 
     let profiles_root = project.root.join(BASECAMP_PROFILES_REL);
     let profile_dir = profiles_root.join(&profile);
@@ -618,9 +636,7 @@ struct BasecampProfilePaths {
 /// Pure path resolution: no nix, no filesystem mutation, so it works before
 /// `setup` to preview where a profile's data will live.
 fn cmd_basecamp_paths(project: Project, profile: String, json: bool) -> DynResult<()> {
-    if profile.contains('/') || profile.contains(MAIN_SEPARATOR) {
-        bail!("profile name `{profile}` must not contain path separators");
-    }
+    validate_profile_name(&profile)?;
     let basecamp_repo = project.config.basecamp_repo.as_ref();
     let bc = project.config.basecamp.as_ref();
     let profiles_root = project.root.join(BASECAMP_PROFILES_REL);
@@ -4047,6 +4063,17 @@ mod tests {
             env.get("XDG_RUNTIME_DIR").unwrap(),
             &OsString::from("/tmp/lgs-alice")
         );
+    }
+
+    #[test]
+    fn validate_profile_name_rejects_path_escapes() {
+        for ok in ["alice", "bob", "carol-1", "team_2"] {
+            assert!(validate_profile_name(ok).is_ok(), "should accept {ok:?}");
+        }
+        // Single-component names that would escape or misbehave when joined.
+        for bad in ["", "..", ".", "a/b", "/abs", "../evil", "sub/../x"] {
+            assert!(validate_profile_name(bad).is_err(), "should reject {bad:?}");
+        }
     }
 
     #[test]

--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -79,6 +79,12 @@ pub(crate) enum BasecampAction {
     Doctor {
         json: bool,
     },
+    /// Print the resolved per-profile path manifest (xdg dirs, runtime dir,
+    /// module/plugin dirs, log file). Read-only; no nix.
+    Paths {
+        profile: String,
+        json: bool,
+    },
     /// Print the canonical compatibility doc (`docs/basecamp-module-requirements.md`,
     /// embedded at compile time). Runnable outside a scaffold project so LLMs
     /// exploring the CLI can retrieve the rules before setup.
@@ -125,6 +131,7 @@ pub(crate) fn basecamp_for_project(project: Project, action: BasecampAction) -> 
         BasecampAction::Build { variants, module } => cmd_basecamp_build(project, variants, module),
         BasecampAction::Run { module, host } => cmd_basecamp_run(project, module, host),
         BasecampAction::Doctor { json } => cmd_basecamp_doctor(project, json),
+        BasecampAction::Paths { profile, json } => cmd_basecamp_paths(project, profile, json),
         // Handled above via early return (project-context-free).
         BasecampAction::Docs => unreachable!("handled before load_project"),
     }
@@ -574,6 +581,94 @@ fn run_with_log_tee(
     }
     let _ = fs::remove_file(launch_state_path);
     std::process::exit(status.code().unwrap_or(if status.success() { 0 } else { 1 }));
+}
+
+/// Resolved per-profile path manifest emitted by `basecamp paths`.
+#[derive(Debug, serde::Serialize)]
+struct BasecampProfilePaths {
+    profile: String,
+    profile_dir: String,
+    xdg_config_home: String,
+    xdg_data_home: String,
+    xdg_cache_home: String,
+    /// `TMPDIR` launch would export (runtime_dir if resolved, else `xdg-tmp`).
+    tmpdir: String,
+    /// `XDG_RUNTIME_DIR` launch would export; `None` when no runtime_dir resolves.
+    xdg_runtime_dir: Option<String>,
+    modules_dir: String,
+    plugins_dir: String,
+    launch_state: String,
+    /// Where logs go when logging is enabled (configured `log_file`, else the
+    /// path a bare `--log-file` would use).
+    log_file: String,
+    /// Resolved per-profile `env_file`, if configured.
+    env_file: Option<String>,
+}
+
+/// `basecamp paths <profile>` — print the resolved per-profile path manifest.
+/// Pure path resolution: no nix, no filesystem mutation, so it works before
+/// `setup` to preview where a profile's data will live.
+fn cmd_basecamp_paths(project: Project, profile: String, json: bool) -> DynResult<()> {
+    if profile.contains('/') || profile.contains(MAIN_SEPARATOR) {
+        bail!("profile name `{profile}` must not contain path separators");
+    }
+    let basecamp_repo = project.config.basecamp_repo.as_ref();
+    let bc = project.config.basecamp.as_ref();
+    let profiles_root = project.root.join(BASECAMP_PROFILES_REL);
+    let profile_dir = profiles_root.join(&profile);
+    let (modules_dir, plugins_dir) =
+        profile_modules_and_plugins(&profiles_root, &profile, basecamp_repo);
+    let runtime_dir = resolve_profile_runtime_dir(&project.root, &profile, bc);
+    let tmpdir = runtime_dir
+        .clone()
+        .unwrap_or_else(|| profile_dir.join("xdg-tmp"));
+    let profile_cfg = bc.and_then(|c| c.profiles.get(&profile));
+    let log_file = profile_cfg
+        .and_then(|p| p.log_file.as_deref())
+        .map(|rel| project.root.join(rel))
+        .unwrap_or_else(|| profile_dir.join("basecamp.log"));
+    let env_file = profile_cfg
+        .and_then(|p| p.env_file.as_deref())
+        .map(|rel| project.root.join(rel));
+
+    let paths = BasecampProfilePaths {
+        profile: profile.clone(),
+        profile_dir: profile_dir.display().to_string(),
+        xdg_config_home: profile_dir.join("xdg-config").display().to_string(),
+        xdg_data_home: profile_dir.join("xdg-data").display().to_string(),
+        xdg_cache_home: profile_dir.join("xdg-cache").display().to_string(),
+        tmpdir: tmpdir.display().to_string(),
+        xdg_runtime_dir: runtime_dir.as_ref().map(|p| p.display().to_string()),
+        modules_dir: modules_dir.display().to_string(),
+        plugins_dir: plugins_dir.display().to_string(),
+        launch_state: profile_dir.join("launch.state").display().to_string(),
+        log_file: log_file.display().to_string(),
+        env_file: env_file.as_ref().map(|p| p.display().to_string()),
+    };
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&paths)?);
+    } else {
+        println!("basecamp profile `{}` paths:", paths.profile);
+        println!("  profile_dir:      {}", paths.profile_dir);
+        println!("  xdg_config_home:  {}", paths.xdg_config_home);
+        println!("  xdg_data_home:    {}", paths.xdg_data_home);
+        println!("  xdg_cache_home:   {}", paths.xdg_cache_home);
+        println!("  tmpdir:           {}", paths.tmpdir);
+        println!(
+            "  xdg_runtime_dir:  {}",
+            paths.xdg_runtime_dir.as_deref().unwrap_or("(unset)")
+        );
+        println!("  modules_dir:      {}", paths.modules_dir);
+        println!("  plugins_dir:      {}", paths.plugins_dir);
+        println!("  launch_state:     {}", paths.launch_state);
+        println!("  log_file:         {}", paths.log_file);
+        println!(
+            "  env_file:         {}",
+            paths.env_file.as_deref().unwrap_or("(unset)")
+        );
+    }
+    Ok(())
 }
 
 /// Env map exported to the basecamp child on launch. Scaffold-owned names only;

--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -1142,6 +1142,7 @@ mod tests {
                 pin: String::new(),
                 build: crate::model::RepoBuild::Cargo,
                 attr: String::new(),
+                attr_platform: std::collections::BTreeMap::new(),
                 path: lez_dir.display().to_string(),
             },
             spel: RepoRef::default(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -317,7 +317,11 @@ fn parse_repo_ref(doc: &DocumentMut, name: &str) -> DynResult<Option<RepoRef>> {
         })?,
         None => RepoBuild::default(),
     };
+    // `attr` is either a scalar (`attr = "app"`) or a per-platform map
+    // (`[repos.<name>.attr]` / inline `attr = { aarch64-darwin = "…" }`).
+    // `read_string` returns None for the table form, leaving `attr` empty.
     let attr = read_string(table, "attr").unwrap_or_default();
+    let attr_platform = parse_attr_platform(table, name)?;
     let path = read_string(table, "path").unwrap_or_default();
 
     check_toml_value(&format!("repos.{name}.source"), &source)?;
@@ -331,8 +335,30 @@ fn parse_repo_ref(doc: &DocumentMut, name: &str) -> DynResult<Option<RepoRef>> {
         pin,
         build,
         attr,
+        attr_platform,
         path,
     }))
+}
+
+/// Parse a per-platform `[repos.<name>.attr]` map. Returns an empty map when
+/// `attr` is absent or given in scalar form (handled by the caller's
+/// `read_string`). Keys are nix system triples (`aarch64-darwin`, etc.).
+fn parse_attr_platform(
+    repo_table: &Table,
+    name: &str,
+) -> DynResult<std::collections::BTreeMap<String, String>> {
+    let mut out = std::collections::BTreeMap::new();
+    let Some(tbl) = repo_table.get("attr").and_then(Item::as_table_like) else {
+        return Ok(out);
+    };
+    for (system, v) in tbl.iter() {
+        let s = v.as_str().ok_or_else(|| {
+            anyhow!("invalid scaffold.toml: [repos.{name}.attr].{system} must be a string")
+        })?;
+        check_toml_value(&format!("repos.{name}.attr.{system}"), s)?;
+        out.insert(system.to_string(), s.to_string());
+    }
+    Ok(out)
 }
 
 /// Reject `[repos.<name>].source` values that would let a malicious
@@ -829,6 +855,9 @@ fn write_repo_ref(doc: &mut DocumentMut, name: &str, repo: &RepoRef) -> DynResul
     check_toml_value(&format!("repos.{name}.source"), &repo.source)?;
     check_toml_value(&format!("repos.{name}.pin"), &repo.pin)?;
     check_toml_value(&format!("repos.{name}.attr"), &repo.attr)?;
+    for (system, a) in &repo.attr_platform {
+        check_toml_value(&format!("repos.{name}.attr.{system}"), a)?;
+    }
     check_toml_value(&format!("repos.{name}.path"), &repo.path)?;
     let table = ensure_subtable(doc, "repos", name);
     table["source"] = value(&repo.source);
@@ -838,7 +867,16 @@ fn write_repo_ref(doc: &mut DocumentMut, name: &str, repo: &RepoRef) -> DynResul
     } else {
         table.remove("build");
     }
-    if !repo.attr.is_empty() {
+    // Per-platform map wins over the scalar form; render it as an inline table
+    // (`attr = { aarch64-darwin = "…" }`) so it stays a value under the
+    // `[repos.<name>]` header rather than a dotted/child table.
+    if !repo.attr_platform.is_empty() {
+        let mut inline = toml_edit::InlineTable::new();
+        for (system, a) in &repo.attr_platform {
+            inline.insert(system, a.as_str().into());
+        }
+        table["attr"] = value(inline);
+    } else if !repo.attr.is_empty() {
         table["attr"] = value(&repo.attr);
     } else {
         table.remove("attr");
@@ -910,6 +948,7 @@ pub(crate) fn default_lez_repo(pin: &str) -> RepoRef {
         pin: pin.to_string(),
         build: RepoBuild::Cargo,
         attr: String::new(),
+        attr_platform: std::collections::BTreeMap::new(),
         path: String::new(),
     }
 }
@@ -920,6 +959,7 @@ pub(crate) fn default_spel_repo(pin: &str) -> RepoRef {
         pin: pin.to_string(),
         build: RepoBuild::Cargo,
         attr: String::new(),
+        attr_platform: std::collections::BTreeMap::new(),
         path: String::new(),
     }
 }
@@ -930,6 +970,7 @@ pub(crate) fn default_basecamp_repo(pin: &str) -> RepoRef {
         pin: pin.to_string(),
         build: RepoBuild::NixFlake,
         attr: BASECAMP_ATTR.to_string(),
+        attr_platform: std::collections::BTreeMap::new(),
         path: String::new(),
     }
 }
@@ -940,6 +981,7 @@ pub(crate) fn default_lgpm_repo(pin: &str) -> RepoRef {
         pin: pin.to_string(),
         build: RepoBuild::NixFlake,
         attr: LGPM_ATTR.to_string(),
+        attr_platform: std::collections::BTreeMap::new(),
         path: String::new(),
     }
 }
@@ -1034,6 +1076,43 @@ attr = "cli"
         let lgpm = cfg.lgpm_repo.expect("lgpm present");
         assert_eq!(lgpm.build, RepoBuild::NixFlake);
         assert_eq!(lgpm.attr, "cli");
+    }
+
+    #[test]
+    fn repos_basecamp_attr_per_platform_map_parses_resolves_and_round_trips() {
+        let toml = minimal_v0_2_0()
+            + &format!(
+                r#"
+[repos.basecamp]
+source = "{}"
+pin = "{}"
+build = "nix-flake"
+
+[repos.basecamp.attr]
+aarch64-darwin = "bin-macos-app"
+x86_64-linux = "app"
+"#,
+                BASECAMP_SOURCE, DEFAULT_BASECAMP_PIN,
+            );
+        let cfg = parse_config(&toml).expect("parse");
+        let bc = cfg.basecamp_repo.clone().expect("basecamp present");
+        // Scalar `attr` stays empty for the table form; the map carries the values.
+        assert!(bc.attr.is_empty());
+        assert_eq!(bc.effective_attr("aarch64-darwin"), "bin-macos-app");
+        assert_eq!(bc.effective_attr("x86_64-linux"), "app");
+        // Unmapped platform falls back to the (empty) scalar.
+        assert_eq!(bc.effective_attr("riscv64-linux"), "");
+
+        // The per-platform map survives a serialize -> parse round-trip so
+        // `save_project_config` (run by `setup`) never clobbers it.
+        let serialized = serialize_config(&cfg).expect("serialize");
+        let bc2 = parse_config(&serialized)
+            .expect("re-parse")
+            .basecamp_repo
+            .expect("basecamp present after round-trip");
+        assert_eq!(bc2.effective_attr("aarch64-darwin"), "bin-macos-app");
+        assert_eq!(bc2.effective_attr("x86_64-linux"), "app");
+        assert!(bc2.attr.is_empty());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -352,6 +352,13 @@ fn parse_attr_platform(
         return Ok(out);
     };
     for (system, v) in tbl.iter() {
+        if system.is_empty() {
+            bail!("invalid scaffold.toml: [repos.{name}.attr] has an empty system key");
+        }
+        // Validate the key, not just the value: a quoted TOML key carrying
+        // control characters would otherwise corrupt the line-oriented
+        // serializer on the next `save_project_config`.
+        check_toml_value(&format!("repos.{name}.attr system key {system:?}"), system)?;
         let s = v.as_str().ok_or_else(|| {
             anyhow!("invalid scaffold.toml: [repos.{name}.attr].{system} must be a string")
         })?;
@@ -903,6 +910,7 @@ fn write_repo_ref(doc: &mut DocumentMut, name: &str, repo: &RepoRef) -> DynResul
     check_toml_value(&format!("repos.{name}.pin"), &repo.pin)?;
     check_toml_value(&format!("repos.{name}.attr"), &repo.attr)?;
     for (system, a) in &repo.attr_platform {
+        check_toml_value(&format!("repos.{name}.attr system key {system:?}"), system)?;
         check_toml_value(&format!("repos.{name}.attr.{system}"), a)?;
     }
     check_toml_value(&format!("repos.{name}.path"), &repo.path)?;
@@ -1160,6 +1168,20 @@ x86_64-linux = "app"
         assert_eq!(bc2.effective_attr("aarch64-darwin"), "bin-macos-app");
         assert_eq!(bc2.effective_attr("x86_64-linux"), "app");
         assert!(bc2.attr.is_empty());
+    }
+
+    #[test]
+    fn repos_basecamp_attr_map_rejects_control_char_system_key() {
+        // A quoted TOML key carrying a control char must be rejected at parse
+        // so it can't corrupt the line-oriented serializer on the next save.
+        let toml = minimal_v0_2_0()
+            + &format!(
+                "\n[repos.basecamp]\nsource = \"{}\"\npin = \"{}\"\nbuild = \"nix-flake\"\n",
+                BASECAMP_SOURCE, DEFAULT_BASECAMP_PIN,
+            )
+            + "\n[repos.basecamp.attr]\n\"bad\\nkey\" = \"app\"\n";
+        let err = parse_config(&toml).unwrap_err();
+        assert!(err.to_string().contains("attr"), "{err}");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -722,6 +722,11 @@ pub(crate) fn serialize_config(cfg: &Config) -> DynResult<String> {
             }
         }
         for (profile, p) in &bc.profiles {
+            // The profile name is itself a serialized table header, so guard it
+            // like every other emitted name key (cf. `run.profiles.{name}`,
+            // `modules.{name}`) — a control char in the key would corrupt the
+            // line-oriented writer.
+            check_toml_value(&format!("basecamp.profiles.{profile}"), profile)?;
             for (k, v) in &p.env {
                 check_toml_value(&format!("basecamp.profiles.{profile}.env.{k}"), v)?;
             }
@@ -1393,6 +1398,20 @@ LOGOS_STORAGE_API_PORT = "8083"
         let toml2 = minimal_v0_2_0() + "[basecamp.profiles.alice.env]\n\"\" = \"1\"\n";
         let err2 = parse_config(&toml2).unwrap_err();
         assert!(err2.to_string().contains("must not be empty"), "{err2}");
+    }
+
+    #[test]
+    fn serialize_rejects_control_char_in_basecamp_profile_name() {
+        // Profile names aren't validated at parse, so a quoted key with a
+        // control char parses — but it must be rejected before it can corrupt
+        // the serializer, like every other emitted name key.
+        let toml = minimal_v0_2_0() + "[basecamp.profiles.\"bad\\nname\".env]\nFOO = \"1\"\n";
+        let cfg = parse_config(&toml).expect("parse accepts the unchecked profile name");
+        let err = serialize_config(&cfg).expect_err("serialize must reject the control-char name");
+        assert!(
+            err.to_string().contains("control character"),
+            "expected control-char rejection, got: {err}"
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -520,6 +520,10 @@ fn parse_basecamp_runtime(doc: &DocumentMut) -> DynResult<Option<BasecampConfig>
             if let Some(f) = &profile.env_file {
                 check_toml_value(&format!("basecamp.profiles.{name}.env_file"), f)?;
             }
+            profile.runtime_dir = read_string(ptable, "runtime_dir");
+            if let Some(d) = &profile.runtime_dir {
+                check_toml_value(&format!("basecamp.profiles.{name}.runtime_dir"), d)?;
+            }
             // Drop fully-default profiles so an empty `[basecamp.profiles.foo]`
             // doesn't make `[basecamp]` non-empty and round-trip back.
             if profile != BasecampProfile::default() {
@@ -713,6 +717,9 @@ pub(crate) fn serialize_config(cfg: &Config) -> DynResult<String> {
             if let Some(f) = &p.env_file {
                 check_toml_value(&format!("basecamp.profiles.{profile}.env_file"), f)?;
             }
+            if let Some(d) = &p.runtime_dir {
+                check_toml_value(&format!("basecamp.profiles.{profile}.runtime_dir"), d)?;
+            }
         }
 
         let basecamp = doc.entry("basecamp").or_insert(Item::Table(Table::new()));
@@ -768,6 +775,10 @@ pub(crate) fn serialize_config(cfg: &Config) -> DynResult<String> {
                 let mut wrote_scalar = false;
                 if let Some(f) = &p.env_file {
                     profile_table["env_file"] = value(f);
+                    wrote_scalar = true;
+                }
+                if let Some(d) = &p.runtime_dir {
+                    profile_table["runtime_dir"] = value(d);
                     wrote_scalar = true;
                 }
                 if !p.env.is_empty() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -524,6 +524,10 @@ fn parse_basecamp_runtime(doc: &DocumentMut) -> DynResult<Option<BasecampConfig>
             if let Some(d) = &profile.runtime_dir {
                 check_toml_value(&format!("basecamp.profiles.{name}.runtime_dir"), d)?;
             }
+            profile.log_file = read_string(ptable, "log_file");
+            if let Some(l) = &profile.log_file {
+                check_toml_value(&format!("basecamp.profiles.{name}.log_file"), l)?;
+            }
             // Drop fully-default profiles so an empty `[basecamp.profiles.foo]`
             // doesn't make `[basecamp]` non-empty and round-trip back.
             if profile != BasecampProfile::default() {
@@ -720,6 +724,9 @@ pub(crate) fn serialize_config(cfg: &Config) -> DynResult<String> {
             if let Some(d) = &p.runtime_dir {
                 check_toml_value(&format!("basecamp.profiles.{profile}.runtime_dir"), d)?;
             }
+            if let Some(l) = &p.log_file {
+                check_toml_value(&format!("basecamp.profiles.{profile}.log_file"), l)?;
+            }
         }
 
         let basecamp = doc.entry("basecamp").or_insert(Item::Table(Table::new()));
@@ -779,6 +786,10 @@ pub(crate) fn serialize_config(cfg: &Config) -> DynResult<String> {
                 }
                 if let Some(d) = &p.runtime_dir {
                     profile_table["runtime_dir"] = value(d);
+                    wrote_scalar = true;
+                }
+                if let Some(l) = &p.log_file {
+                    profile_table["log_file"] = value(l);
                     wrote_scalar = true;
                 }
                 if !p.env.is_empty() {
@@ -1247,27 +1258,35 @@ LOGOS_STORAGE_API_PORT = "8081"
     }
 
     #[test]
-    fn basecamp_profile_env_file_and_custom_name_round_trip() {
-        // A custom profile name (not alice/bob) carrying both `env` and an
-        // `env_file` parses, exposes both, and survives serialize -> parse.
+    fn basecamp_profile_scalars_and_custom_name_round_trip() {
+        // A custom profile name (not alice/bob) carrying `env` plus all three
+        // per-profile scalars parses, exposes them, and survives serialize ->
+        // parse so `save_project_config` never drops them.
         let toml = minimal_v0_2_0()
             + r#"
 [basecamp.profiles.carol]
 env_file = ".scaffold/carol.env"
+runtime_dir = "/tmp/lgs-carol"
+log_file = ".scaffold/carol.log"
 
 [basecamp.profiles.carol.env]
 LOGOS_STORAGE_API_PORT = "8083"
 "#;
+        let assert_carol = |c: &BasecampProfile| {
+            assert_eq!(c.env_file.as_deref(), Some(".scaffold/carol.env"));
+            assert_eq!(c.runtime_dir.as_deref(), Some("/tmp/lgs-carol"));
+            assert_eq!(c.log_file.as_deref(), Some(".scaffold/carol.log"));
+            assert_eq!(
+                c.env.get("LOGOS_STORAGE_API_PORT").map(String::as_str),
+                Some("8083")
+            );
+        };
         let cfg = parse_config(&toml).expect("parse");
-        let carol = cfg
-            .basecamp
-            .as_ref()
-            .and_then(|bc| bc.profiles.get("carol"))
-            .expect("carol profile");
-        assert_eq!(carol.env_file.as_deref(), Some(".scaffold/carol.env"));
-        assert_eq!(
-            carol.env.get("LOGOS_STORAGE_API_PORT").map(String::as_str),
-            Some("8083")
+        assert_carol(
+            cfg.basecamp
+                .as_ref()
+                .and_then(|bc| bc.profiles.get("carol"))
+                .expect("carol profile"),
         );
 
         let serialized = serialize_config(&cfg).expect("serialize");
@@ -1278,11 +1297,7 @@ LOGOS_STORAGE_API_PORT = "8083"
             .profiles
             .remove("carol")
             .expect("carol after round-trip");
-        assert_eq!(carol2.env_file.as_deref(), Some(".scaffold/carol.env"));
-        assert_eq!(
-            carol2.env.get("LOGOS_STORAGE_API_PORT").map(String::as_str),
-            Some("8083")
-        );
+        assert_carol(&carol2);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,8 +28,8 @@ use crate::constants::{
     SCAFFOLD_TOML_SCHEMA_VERSION, SPEL_SOURCE,
 };
 use crate::model::{
-    BasecampConfig, Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig, ModuleEntry,
-    ModuleRole, RepoBuild, RepoRef, RunConfig, RunProfile, WatchConfig,
+    BasecampConfig, BasecampProfile, Config, FrameworkConfig, FrameworkIdlConfig, LocalnetConfig,
+    ModuleEntry, ModuleRole, RepoBuild, RepoRef, RunConfig, RunProfile, WatchConfig,
 };
 use crate::DynResult;
 
@@ -505,20 +505,28 @@ fn parse_basecamp_runtime(doc: &DocumentMut) -> DynResult<Option<BasecampConfig>
         }
         any_field = any_field || !cfg.env_append.is_empty();
     }
-    // [basecamp.profiles.<name>.env] — per-profile plain string maps.
+    // [basecamp.profiles.<name>] — per-profile launch config.
     if let Some(profiles) = table.get("profiles").and_then(Item::as_table) {
         for (name, item) in profiles.iter() {
             let ptable = item.as_table().ok_or_else(|| {
                 anyhow!("invalid scaffold.toml: [basecamp.profiles.{name}] is not a table")
             })?;
+            let mut profile = BasecampProfile::default();
             if let Some(env_table) = ptable.get("env").and_then(Item::as_table) {
-                let env = parse_string_map(env_table, &format!("basecamp.profiles.{name}.env"))?;
-                if !env.is_empty() {
-                    cfg.profile_env.insert(name.to_string(), env);
-                }
+                profile.env =
+                    parse_string_map(env_table, &format!("basecamp.profiles.{name}.env"))?;
+            }
+            profile.env_file = read_string(ptable, "env_file");
+            if let Some(f) = &profile.env_file {
+                check_toml_value(&format!("basecamp.profiles.{name}.env_file"), f)?;
+            }
+            // Drop fully-default profiles so an empty `[basecamp.profiles.foo]`
+            // doesn't make `[basecamp]` non-empty and round-trip back.
+            if profile != BasecampProfile::default() {
+                cfg.profiles.insert(name.to_string(), profile);
             }
         }
-        any_field = any_field || !cfg.profile_env.is_empty();
+        any_field = any_field || !cfg.profiles.is_empty();
     }
 
     Ok(if any_field { Some(cfg) } else { None })
@@ -698,9 +706,12 @@ pub(crate) fn serialize_config(cfg: &Config) -> DynResult<String> {
                 check_toml_value(&format!("basecamp.env_append.{k}"), p)?;
             }
         }
-        for (profile, env) in &bc.profile_env {
-            for (k, v) in env {
+        for (profile, p) in &bc.profiles {
+            for (k, v) in &p.env {
                 check_toml_value(&format!("basecamp.profiles.{profile}.env.{k}"), v)?;
+            }
+            if let Some(f) = &p.env_file {
+                check_toml_value(&format!("basecamp.profiles.{profile}.env_file"), f)?;
             }
         }
 
@@ -743,16 +754,30 @@ pub(crate) fn serialize_config(cfg: &Config) -> DynResult<String> {
                 append_table[k] = string_array(list);
             }
         }
-        if !bc.profile_env.is_empty() {
+        if !bc.profiles.is_empty() {
             let profiles = child_table(basecamp_table, "profiles");
-            // Implicit so `[basecamp.profiles.<name>.env]` renders as the
-            // nested header without an empty `[basecamp.profiles]` line.
+            // Implicit so `[basecamp.profiles.<name>]` renders as the nested
+            // header without an empty `[basecamp.profiles]` line.
             profiles.set_implicit(true);
-            for (profile, env) in &bc.profile_env {
+            for (profile, p) in &bc.profiles {
                 let profile_table = child_table(profiles, profile);
-                let env_table = child_table(profile_table, "env");
-                for (k, v) in env {
-                    env_table[k] = value(v);
+                // Scalar keys (env_file) render under the
+                // `[basecamp.profiles.<name>]` header; the `env` child table
+                // follows. With no scalar key, keep the profile table implicit
+                // so only `[basecamp.profiles.<name>.env]` renders.
+                let mut wrote_scalar = false;
+                if let Some(f) = &p.env_file {
+                    profile_table["env_file"] = value(f);
+                    wrote_scalar = true;
+                }
+                if !p.env.is_empty() {
+                    let env_table = child_table(profile_table, "env");
+                    for (k, v) in &p.env {
+                        env_table[k] = value(v);
+                    }
+                }
+                if !wrote_scalar {
+                    profile_table.set_implicit(true);
                 }
             }
         }
@@ -1148,16 +1173,16 @@ LOGOS_STORAGE_API_PORT = "8082"
             )
         );
         assert_eq!(
-            bc.profile_env
+            bc.profiles
                 .get("alice")
-                .and_then(|e| e.get("LOGOS_STORAGE_API_PORT"))
+                .and_then(|p| p.env.get("LOGOS_STORAGE_API_PORT"))
                 .map(String::as_str),
             Some("8081")
         );
         assert_eq!(
-            bc.profile_env
+            bc.profiles
                 .get("bob")
-                .and_then(|e| e.get("LOGOS_STORAGE_API_PORT"))
+                .and_then(|p| p.env.get("LOGOS_STORAGE_API_PORT"))
                 .map(String::as_str),
             Some("8082")
         );
@@ -1202,11 +1227,50 @@ LOGOS_STORAGE_API_PORT = "8081"
             Some(&["/nix/store/a/plugins".to_string()][..])
         );
         assert_eq!(
-            bc.profile_env
+            bc.profiles
                 .get("alice")
-                .and_then(|e| e.get("LOGOS_STORAGE_API_PORT"))
+                .and_then(|p| p.env.get("LOGOS_STORAGE_API_PORT"))
                 .map(String::as_str),
             Some("8081")
+        );
+    }
+
+    #[test]
+    fn basecamp_profile_env_file_and_custom_name_round_trip() {
+        // A custom profile name (not alice/bob) carrying both `env` and an
+        // `env_file` parses, exposes both, and survives serialize -> parse.
+        let toml = minimal_v0_2_0()
+            + r#"
+[basecamp.profiles.carol]
+env_file = ".scaffold/carol.env"
+
+[basecamp.profiles.carol.env]
+LOGOS_STORAGE_API_PORT = "8083"
+"#;
+        let cfg = parse_config(&toml).expect("parse");
+        let carol = cfg
+            .basecamp
+            .as_ref()
+            .and_then(|bc| bc.profiles.get("carol"))
+            .expect("carol profile");
+        assert_eq!(carol.env_file.as_deref(), Some(".scaffold/carol.env"));
+        assert_eq!(
+            carol.env.get("LOGOS_STORAGE_API_PORT").map(String::as_str),
+            Some("8083")
+        );
+
+        let serialized = serialize_config(&cfg).expect("serialize");
+        let carol2 = parse_config(&serialized)
+            .expect("re-parse")
+            .basecamp
+            .expect("basecamp present")
+            .profiles
+            .remove("carol")
+            .expect("carol after round-trip");
+        assert_eq!(carol2.env_file.as_deref(), Some(".scaffold/carol.env"));
+        assert_eq!(
+            carol2.env.get("LOGOS_STORAGE_API_PORT").map(String::as_str),
+            Some("8083")
         );
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -21,7 +21,24 @@ pub(crate) struct RepoRef {
     pub(crate) pin: String,
     pub(crate) build: RepoBuild,
     pub(crate) attr: String,
+    /// `[repos.<name>.attr]` per-platform map (nix system triple -> flake
+    /// output attribute), e.g. `attr.aarch64-darwin = "bin-macos-app"`. Empty
+    /// when `attr` is given in scalar form; `effective_attr` prefers a matching
+    /// entry here and falls back to the scalar `attr`.
+    pub(crate) attr_platform: std::collections::BTreeMap<String, String>,
     pub(crate) path: String,
+}
+
+impl RepoRef {
+    /// Resolve the flake output attribute for `system` (a nix system triple).
+    /// Prefers a per-platform `attr_platform` entry; falls back to the scalar
+    /// `attr` when the platform isn't mapped (or no map was given).
+    pub(crate) fn effective_attr(&self, system: &str) -> &str {
+        self.attr_platform
+            .get(system)
+            .map(String::as_str)
+            .unwrap_or(self.attr.as_str())
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -170,6 +170,9 @@ pub(crate) struct BasecampProfile {
     /// macOS `sun_path == 104` Unix-socket path limit. Project-relative or
     /// absolute; defaults to `/tmp/lgs-<profile>` on macOS when unset.
     pub(crate) runtime_dir: Option<String>,
+    /// `.log_file` — tee basecamp's stdout/stderr to this file on launch
+    /// (project-relative or absolute). Overridden by `launch --log-file`.
+    pub(crate) log_file: Option<String>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -140,10 +140,9 @@ pub(crate) struct BasecampConfig {
     /// appended onto the value `lgs` inherited at launch time (so basecamp's
     /// own paths aren't clobbered). Applied before `env`.
     pub(crate) env_append: std::collections::BTreeMap<String, Vec<String>>,
-    /// `[basecamp.profiles.<name>.env]` — per-profile plain env. Wins over the
-    /// global `[basecamp.env]` for the launched profile.
-    pub(crate) profile_env:
-        std::collections::BTreeMap<String, std::collections::BTreeMap<String, String>>,
+    /// `[basecamp.profiles.<name>]` — per-profile launch config, keyed by an
+    /// arbitrary profile name (no alice/bob gate).
+    pub(crate) profiles: std::collections::BTreeMap<String, BasecampProfile>,
 }
 
 impl Default for BasecampConfig {
@@ -153,9 +152,20 @@ impl Default for BasecampConfig {
             port_stride: 10,
             env: std::collections::BTreeMap::new(),
             env_append: std::collections::BTreeMap::new(),
-            profile_env: std::collections::BTreeMap::new(),
+            profiles: std::collections::BTreeMap::new(),
         }
     }
+}
+
+/// `[basecamp.profiles.<name>]` — per-profile launch configuration.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct BasecampProfile {
+    /// `.env` — per-profile plain env (replace semantics). Wins over the
+    /// global `[basecamp.env]` for the launched profile.
+    pub(crate) env: std::collections::BTreeMap<String, String>,
+    /// `.env_file` — path (project-relative or absolute) to a dotenv-style
+    /// `KEY=VALUE` file sourced before the `env` layers override it.
+    pub(crate) env_file: Option<String>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -166,6 +166,10 @@ pub(crate) struct BasecampProfile {
     /// `.env_file` — path (project-relative or absolute) to a dotenv-style
     /// `KEY=VALUE` file sourced before the `env` layers override it.
     pub(crate) env_file: Option<String>,
+    /// `.runtime_dir` — short `TMPDIR`/`XDG_RUNTIME_DIR` root, to dodge the
+    /// macOS `sun_path == 104` Unix-socket path limit. Project-relative or
+    /// absolute; defaults to `/tmp/lgs-<profile>` on macOS when unset.
+    pub(crate) runtime_dir: Option<String>,
 }
 
 #[derive(Clone, Debug)]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5015,6 +5015,8 @@ fn basecamp_paths_json_resolves_custom_profile_manifest() {
         .stdout(
             predicate::str::contains("\"profile\": \"carol\"")
                 .and(predicate::str::contains("\"modules_dir\""))
-                .and(predicate::str::contains(".scaffold/basecamp/profiles/carol")),
+                .and(predicate::str::contains(
+                    ".scaffold/basecamp/profiles/carol",
+                )),
         );
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4994,3 +4994,27 @@ fn run_no_reset_flag_overrides_config_reset_true() {
         .stdout(predicate::str::contains("[1/5] Building..."))
         .stderr(predicate::str::contains("scaffold.toml requested reset = true").not());
 }
+
+#[test]
+fn basecamp_paths_json_resolves_custom_profile_manifest() {
+    // `basecamp paths` is pure path resolution: it needs only a loadable
+    // project (no setup, no nix) and accepts any profile name.
+    let temp = tempdir().expect("tempdir");
+    let lez_path = temp.path().join("lez");
+    fs::create_dir_all(&lez_path).expect("create lez path");
+    write_scaffold_toml(temp.path(), &lez_path);
+
+    Command::new(assert_cmd::cargo::cargo_bin!("logos-scaffold"))
+        .current_dir(temp.path())
+        .arg("basecamp")
+        .arg("paths")
+        .arg("carol")
+        .arg("--json")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("\"profile\": \"carol\"")
+                .and(predicate::str::contains("\"modules_dir\""))
+                .and(predicate::str::contains(".scaffold/basecamp/profiles/carol")),
+        );
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3224,13 +3224,14 @@ fn basecamp_launch_setup_hint_takes_precedence_over_profile_validation() {
 
 #[cfg(unix)]
 #[test]
-fn basecamp_launch_rejects_unknown_profile() {
+fn basecamp_launch_accepts_custom_profile_name() {
     let temp = tempdir().expect("tempdir");
     let project = temp.path();
     fs::write(project.join("scaffold.toml"), MINIMAL_SCAFFOLD_TOML).expect("write scaffold.toml");
 
-    // Fake a completed setup so we get past the first gate and reach profile
-    // validation. Launch never reaches `exec` because the profile check fails first.
+    // Fake a completed setup so we get past the first gate. A custom profile
+    // name (not alice/bob) is now accepted: launch advances to the
+    // modules-captured check instead of rejecting the name outright.
     let state_dir = project.join(".scaffold/state");
     fs::create_dir_all(&state_dir).expect("mkdir state");
     fs::write(state_dir.join("basecamp.state"), fake_basecamp_state()).expect("write state");
@@ -3242,7 +3243,11 @@ fn basecamp_launch_rejects_unknown_profile() {
         .arg("charlie")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("unknown profile `charlie`"));
+        .stderr(
+            predicate::str::contains("unknown profile")
+                .not()
+                .and(predicate::str::contains("no modules captured")),
+        );
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
Implements scaffold **#171** for the Phase 2 atomic-swaps work: make Basecamp peer profiles configurable in Scaffold instead of managed by project-specific wrapper scripts.

## Feature outcome

Atomic-swaps can now describe real multi-peer Basecamp setups in `scaffold.toml`.

That means named peers, per-peer environment, runtime directories, log files, and host-specific Basecamp package selection can live in project configuration. Developers can ask Scaffold where a peer profile will live, launch it with reproducible environment, and collect logs in known places.

## Before / after

Before this PR, `lgs basecamp` already supported the core Basecamp lifecycle: `setup` seeded the standard `alice` and `bob` profiles, `modules` captured project modules, `install` replayed them, and `launch <profile>` started a clean-slate Basecamp profile. Scaffold also had global/per-profile inline env overrides through `[basecamp.env]`, `[basecamp.env_append]`, and `[basecamp.profiles.<name>.env]`.

That was enough for the first dogfooding shape, but not enough for atomic-swaps' real multi-peer setup:
- launch was still constrained by the old alice/bob profile model
- per-peer dotenv files were outside the profile schema
- runtime-dir and log-file choices needed wrapper-script logic
- there was no `basecamp paths` command to show where a profile's state/logs/modules would resolve
- `[repos.basecamp].attr` was a single scalar, so one `scaffold.toml` could not choose different Basecamp flake attrs per host platform

With this PR:
- any safe `[basecamp.profiles.<name>]` profile can be configured and launched
- each profile can have its own `env_file`, `runtime_dir`, and `log_file`
- `lgs basecamp paths <profile> [--json]` shows exactly where that profile's state, logs, modules, plugins, and runtime directory resolve
- `[repos.basecamp.attr]` can select the right Basecamp flake attr per host platform, with a scalar fallback
- Scaffold owns the reusable profile model instead of atomic-swaps carrying one-off launch glue

## Implementation notes

| Area | What changed |
|---|---|
| Basecamp package selection | Adds a per-platform `[repos.basecamp.attr]` map, while preserving scalar `attr = "app"` as the fallback. |
| Profile model | Replaces the old profile env map shape with `BasecampProfile`, giving profile config a single place to grow. |
| Custom profiles | Allows arbitrary safe profile names instead of only alice/bob, while rejecting escaping, absolute, empty, and control-character names. |
| Env layering | Adds per-profile `env_file`, loaded before inline profile env overrides. |
| Runtime dirs | Adds per-profile `runtime_dir`, with `/tmp/lgs-<profile>` as the macOS default to avoid Unix socket path limits. |
| Logging | Adds `launch --log-file[=PATH]` and per-profile `log_file`, teeing Basecamp output to terminal and file. |
| Path inspection | Adds `basecamp paths <profile> [--json]` for a pure, non-mutating path manifest. |
| Docs | Documents the profile schema, env precedence, platform attr map, log files, paths, and macOS runtime-dir budget. |
| Dogfooding | Updates `DOGFOODING.md` so `B1-B4` cover profiles, paths, env/log/runtime behavior, custom profile names, and rerun guidance. |

## Verification

- `cargo fmt --check` passed.
- `cargo test` (465 lib + 169 CLI integration + 5 doc tests) passed on `danisharora099/scaffold-pr2-basecamp-profiles`; existing warnings are the pre-existing `sha2` cfg warnings in `setup.rs`.
- `cargo clippy --all-targets` exited 0. It still reports existing warnings, including `result_large_err` on the public API error type and several style lints unrelated to this docs follow-up.
- DOGFOODING `B1-B4` runbook updated: profile schema, `basecamp paths`, `env_file`, `runtime_dir`, `log_file`, `launch --log-file`, per-platform attrs, custom profile pairs, and path/profile safety checks are now called out.
- DOGFOODING `B2`/`B4` pure smoke: from a fresh initialized scratch project, `basecamp paths maker --json` resolved custom `env_file`, `/tmp/lgs-maker` runtime, and configured log path; `basecamp paths ../escape` rejected the unsafe profile name before path resolution.
- Full Nix/Basecamp setup, install, launch, and GUI p2p dogfooding were not rerun in this docs follow-up.

---

## Merge order (scaffold Phase 2)

Part of the scaffold Phase 2 trio for atomic-swaps [#27](https://github.com/logos-co/eth-lez-atomic-swaps/issues/27). Land in order:

**#221 (circuits) -> #222 (verbs) -> #223 (profiles)**

- #221 is independent of the other two.
- #222 and #223 both extend the same `basecamp` enums / subcommands (and #223 also changes the `Launch` variant), so **whichever merges second needs a small rebase**.
- Each PR is isolated by concern and individually mergeable against `master`.
