### PR TITLE
ci(template-e2e): make rendered template builds pass end to end

### DIFF
--- a/.github/workflows/template-e2e.yml
+++ b/.github/workflows/template-e2e.yml
@@ -31,12 +31,6 @@ concurrency:
 jobs:
   render-and-build:
     runs-on: ubuntu-latest
-    # The lez-framework template currently can't build: the spel-generated
-    # `#[lez_program]` macro calls an `nssa_core::program` function the pinned
-    # DEFAULT_LEZ removed (a DEFAULT_SPEL <-> DEFAULT_LEZ pin mismatch, not a
-    # template bug). Let that leg fail without blocking, while the `default`
-    # leg gates merges. Tracked in #225 — drop this once the pins realign.
-    continue-on-error: ${{ matrix.template == 'lez-framework' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/template-e2e.yml
+++ b/.github/workflows/template-e2e.yml
@@ -31,6 +31,12 @@ concurrency:
 jobs:
   render-and-build:
     runs-on: ubuntu-latest
+    # The lez-framework template currently can't build: the spel-generated
+    # `#[lez_program]` macro calls an `nssa_core::program` function the pinned
+    # DEFAULT_LEZ removed (a DEFAULT_SPEL <-> DEFAULT_LEZ pin mismatch, not a
+    # template bug). Let that leg fail without blocking, while the `default`
+    # leg gates merges. Tracked in #225 — drop this once the pins realign.
+    continue-on-error: ${{ matrix.template == 'lez-framework' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/template-e2e.yml
+++ b/.github/workflows/template-e2e.yml
@@ -144,9 +144,14 @@ jobs:
       - name: Install Risc Zero toolchain
         run: |
           set -euo pipefail
-          # -fsSL so an HTTP 4xx/5xx error page fails the step instead of being
-          # piped into bash (curl exits 0 on error bodies without -f).
-          curl -fsSL https://risczero.com/install | bash
+          # Download the official rzup installer to disk first rather than
+          # piping it straight into bash: a failed/partial fetch is caught
+          # before anything executes, and the script is on disk if a run needs
+          # debugging. -fsSL fails on an HTTP 4xx/5xx error page; --retry rides
+          # out flaky networking (matches the circuits-fetch curl above).
+          curl -fsSL --retry 3 --retry-delay 2 \
+            https://risczero.com/install -o "$RUNNER_TEMP/rzup-install.sh"
+          bash "$RUNNER_TEMP/rzup-install.sh"
           echo "$HOME/.risc0/bin" >> "$GITHUB_PATH"
           "$HOME/.risc0/bin/rzup" install rust
 

--- a/.github/workflows/template-e2e.yml
+++ b/.github/workflows/template-e2e.yml
@@ -129,6 +129,19 @@ jobs:
             exit 1
           fi
 
+      # The rendered project ships a risc0 guest crate (methods/), whose build
+      # script cross-compiles to riscv32im-risc0-zkvm-elf and needs the Risc Zero
+      # Rust toolchain. Without it the `lgs build` step below panics with
+      # "Risc Zero Rust toolchain not found. Try running `rzup install rust`".
+      # rzup is risc0's toolchain manager; it registers a `risc0` rustup
+      # toolchain that risc0-build then discovers.
+      - name: Install Risc Zero toolchain
+        run: |
+          set -euo pipefail
+          curl -L https://risczero.com/install | bash
+          echo "$HOME/.risc0/bin" >> "$GITHUB_PATH"
+          "$HOME/.risc0/bin/rzup" install rust
+
       - name: Build rendered project workspace
         run: |
           set -euo pipefail

--- a/.github/workflows/template-e2e.yml
+++ b/.github/workflows/template-e2e.yml
@@ -156,6 +156,16 @@ jobs:
           "$HOME/.risc0/bin/rzup" install cpp
 
       - name: Build rendered project workspace
+        env:
+          # risc0-build exports an *unqualified* CC pointing at its riscv32
+          # cross-gcc for the whole guest cargo invocation. Host-side compiles
+          # inside that invocation (proc-macro deps: spel-framework-macros ->
+          # nssa_core -> risc0-zkvm[client] -> bonsai-sdk -> reqwest -> ring)
+          # then pair host x86_64 cflags (-m64) with the riscv compiler and
+          # die. cc-rs consults HOST_CC before CC when target == host, so this
+          # keeps host compiles on the system compiler while guest-target
+          # compiles still fall through to risc0's CC.
+          HOST_CC: cc
         run: |
           set -euo pipefail
           cd "$RUNNER_TEMP/e2e-app"

--- a/.github/workflows/template-e2e.yml
+++ b/.github/workflows/template-e2e.yml
@@ -131,14 +131,16 @@ jobs:
 
       # The rendered project ships a risc0 guest crate (methods/), whose build
       # script cross-compiles to riscv32im-risc0-zkvm-elf and needs the Risc Zero
-      # Rust toolchain. Without it the `lgs build` step below panics with
-      # "Risc Zero Rust toolchain not found. Try running `rzup install rust`".
+      # Rust toolchain. Without it the `logos-scaffold build` step below panics
+      # with "Risc Zero Rust toolchain not found. Try running `rzup install rust`".
       # rzup is risc0's toolchain manager; it registers a `risc0` rustup
       # toolchain that risc0-build then discovers.
       - name: Install Risc Zero toolchain
         run: |
           set -euo pipefail
-          curl -L https://risczero.com/install | bash
+          # -fsSL so an HTTP 4xx/5xx error page fails the step instead of being
+          # piped into bash (curl exits 0 on error bodies without -f).
+          curl -fsSL https://risczero.com/install | bash
           echo "$HOME/.risc0/bin" >> "$GITHUB_PATH"
           "$HOME/.risc0/bin/rzup" install rust
 

--- a/.github/workflows/template-e2e.yml
+++ b/.github/workflows/template-e2e.yml
@@ -148,6 +148,12 @@ jobs:
           bash "$RUNNER_TEMP/rzup-install.sh"
           echo "$HOME/.risc0/bin" >> "$GITHUB_PATH"
           "$HOME/.risc0/bin/rzup" install rust
+          # Guest deps that compile C sources (e.g. `ring` in the lez-framework
+          # guest) additionally need risc0's C++ cross-toolchain. When it is
+          # missing, risc0-build points CC at a sentinel path
+          # (/no_risc0_cpp_toolchain_installed_run_rzup_install_cpp) and the
+          # guest build dies in cc-rs compiler detection.
+          "$HOME/.risc0/bin/rzup" install cpp
 
       - name: Build rendered project workspace
         run: |

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -207,6 +207,8 @@ fn cmd_new_inner(cmd: &NewCommand, target: &Path, template_variant: &str) -> Dyn
     let overlay_ctx = OverlayRenderContext {
         crate_name: &crate_name,
         lez_pin: &cfg.lez.pin,
+        lez_tag: DEFAULT_LEZ.tag,
+        spel_pin: &cfg.spel.pin,
     };
     apply_overlay(target, template_variant, &overlay_ctx)?;
     if template_variant == FRAMEWORK_KIND_LEZ_FRAMEWORK {

--- a/src/template/project.rs
+++ b/src/template/project.rs
@@ -12,6 +12,8 @@ static TEMPLATES_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/templates");
 pub(crate) struct OverlayRenderContext<'a> {
     pub(crate) crate_name: &'a str,
     pub(crate) lez_pin: &'a str,
+    pub(crate) lez_tag: &'a str,
+    pub(crate) spel_pin: &'a str,
 }
 
 pub(crate) fn apply_overlay(
@@ -105,7 +107,9 @@ fn normalize_template_file_name(file_name: &std::ffi::OsStr) -> std::ffi::OsStri
 fn render_template_text(raw: &str, ctx: &OverlayRenderContext<'_>) -> DynResult<String> {
     let rendered = raw
         .replace("{{crate_name}}", ctx.crate_name)
-        .replace("{{lez_pin}}", ctx.lez_pin);
+        .replace("{{lez_pin}}", ctx.lez_pin)
+        .replace("{{lez_tag}}", ctx.lez_tag)
+        .replace("{{spel_pin}}", ctx.spel_pin);
 
     if let Some(token) = find_unresolved_placeholder(&rendered) {
         bail!("unresolved template token `{token}`");
@@ -169,6 +173,8 @@ mod tests {
         let ctx = OverlayRenderContext {
             crate_name: "my-app",
             lez_pin: "abc123",
+            lez_tag: "v1.2.3",
+            spel_pin: "def456",
         };
 
         apply_overlay(&target, "default", &ctx).expect("failed to apply default overlay");
@@ -206,6 +212,8 @@ mod tests {
         let ctx = OverlayRenderContext {
             crate_name: "my-app",
             lez_pin: "abc123",
+            lez_tag: "v1.2.3",
+            spel_pin: "def456",
         };
 
         apply_overlay(&target, "lez-framework", &ctx).expect("failed to apply lez-framework");
@@ -232,6 +240,12 @@ mod tests {
             );
         }
 
+        let cargo = fs::read_to_string(target.join("Cargo.toml"))
+            .expect("failed to read generated Cargo.toml");
+        assert!(cargo.contains("tag = \"v1.2.3\""));
+        assert!(cargo.contains("rev = \"def456\""));
+        assert!(!cargo.contains("{{"));
+
         fs::remove_dir_all(&target).expect("failed to cleanup temporary test directory");
     }
 
@@ -241,6 +255,8 @@ mod tests {
         let ctx = OverlayRenderContext {
             crate_name: "example-name",
             lez_pin: "deadbeef",
+            lez_tag: "v1.2.3",
+            spel_pin: "feedface",
         };
 
         apply_overlay(&target, "default", &ctx).expect("failed to apply default overlay");
@@ -270,6 +286,8 @@ mod tests {
             let ctx = OverlayRenderContext {
                 crate_name: "my-app",
                 lez_pin: "abc123",
+                lez_tag: "v1.2.3",
+                spel_pin: "def456",
             };
             apply_overlay(&target, variant, &ctx)
                 .unwrap_or_else(|e| panic!("apply_overlay({variant}) failed: {e}"));
@@ -295,6 +313,8 @@ mod tests {
         let ctx = OverlayRenderContext {
             crate_name: "my-app",
             lez_pin: "abc123",
+            lez_tag: "v1.2.3",
+            spel_pin: "def456",
         };
 
         apply_overlay(&target, "default", &ctx).expect("failed to apply default overlay");
@@ -326,6 +346,8 @@ mod tests {
         let ctx = OverlayRenderContext {
             crate_name: "my-app",
             lez_pin: "abc123",
+            lez_tag: "v1.2.3",
+            spel_pin: "def456",
         };
 
         apply_overlay(&target, "default", &ctx).expect("failed to apply default overlay");
@@ -369,6 +391,8 @@ mod tests {
         let ctx = OverlayRenderContext {
             crate_name: "my-app",
             lez_pin: "abc123",
+            lez_tag: "v1.2.3",
+            spel_pin: "def456",
         };
 
         let err = render_template_text("name = \"{{unknown_token}}\"", &ctx)

--- a/templates/default/src/bin/run_hello_world_with_authorization_through_tail_call_with_pda.rs
+++ b/templates/default/src/bin/run_hello_world_with_authorization_through_tail_call_with_pda.rs
@@ -32,7 +32,7 @@ async fn main() -> anyhow::Result<()> {
         "tail_call_with_pda",
     )?;
 
-    let pda = AccountId::from((&program.id(), &PDA_SEED));
+    let pda = AccountId::for_public_pda(&program.id(), &PDA_SEED);
     let message = Message::try_new(program.id(), vec![pda], vec![], ())
         .context("failed to build pda transaction message")?;
     let witness_set = WitnessSet::for_message(&message, &[]);

--- a/templates/lez-framework/Cargo.toml.template
+++ b/templates/lez-framework/Cargo.toml.template
@@ -20,17 +20,19 @@ members = [
 unsafe_code = "warn"
 
 [workspace.dependencies]
-nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "{{lez_pin}}" }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "{{lez_pin}}" }
-wallet = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "{{lez_pin}}" }
-common = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "{{lez_pin}}" }
+# Spel v0.5.0 pins LEZ by tag. Match that source form so Cargo uses one
+# nssa_core instance instead of treating equivalent tag and rev sources as distinct.
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "{{lez_tag}}" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "{{lez_tag}}" }
+wallet = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "{{lez_tag}}" }
+common = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "{{lez_tag}}" }
 
 risc0-zkvm = { version = "3.0.5", features = ["std"] }
 risc0-build = "3.0.5"
 
-lez-framework = { git = "https://github.com/jimmy-claw/lez-framework.git", rev = "1e146970d2bba861a32fd3a8b4e13b1e6ff4114d" }
-lez-framework-core = { git = "https://github.com/jimmy-claw/lez-framework.git", rev = "1e146970d2bba861a32fd3a8b4e13b1e6ff4114d" }
-lez-client-gen = { git = "https://github.com/jimmy-claw/lez-framework.git", rev = "1e146970d2bba861a32fd3a8b4e13b1e6ff4114d" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", rev = "{{spel_pin}}" }
+spel-framework-core = { git = "https://github.com/logos-co/spel.git", rev = "{{spel_pin}}" }
+spel-client-gen = { git = "https://github.com/logos-co/spel.git", rev = "{{spel_pin}}" }
 
 hex = "0.4.3"
 bytemuck = "1.24.0"
@@ -46,8 +48,8 @@ nssa.workspace = true
 nssa_core.workspace = true
 wallet.workspace = true
 common.workspace = true
-lez-framework.workspace = true
-lez-framework-core.workspace = true
+spel-framework.workspace = true
+spel-framework-core.workspace = true
 example_program_deployment_methods = { path = "methods" }
 
 serde.workspace = true

--- a/templates/lez-framework/Cargo.toml.template
+++ b/templates/lez-framework/Cargo.toml.template
@@ -20,8 +20,8 @@ members = [
 unsafe_code = "warn"
 
 [workspace.dependencies]
-# Spel v0.5.0 pins LEZ by tag. Match that source form so Cargo uses one
-# nssa_core instance instead of treating equivalent tag and rev sources as distinct.
+# Spel pins LEZ by tag. Match that source form so Cargo resolves a single
+# nssa_core instead of treating equivalent tag and rev sources as distinct.
 nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "{{lez_tag}}" }
 nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "{{lez_tag}}" }
 wallet = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "{{lez_tag}}" }

--- a/templates/lez-framework/README.md
+++ b/templates/lez-framework/README.md
@@ -6,7 +6,7 @@ This project was generated with:
 logos-scaffold new <name> --template lez-framework
 ```
 
-It uses the [LEZ Framework](https://github.com/jimmy-claw/lez-framework) for an
+It uses the [Spel Framework](https://github.com/logos-co/spel) for an
 ergonomic developer experience similar to Anchor on Solana:
 
 - `#[lez_program]` macro eliminates boilerplate
@@ -81,7 +81,7 @@ mod my_program {
         state: AccountWithMetadata,
         #[account(signer)]
         authority: AccountWithMetadata,
-    ) -> LezResult {
+    ) -> SpelResult {
         // your logic here
     }
 }

--- a/templates/lez-framework/README.md
+++ b/templates/lez-framework/README.md
@@ -1,4 +1,4 @@
-# LEZ Framework Template
+# Spel Framework Template
 
 This project was generated with:
 

--- a/templates/lez-framework/crates/lez-client-gen/Cargo.toml.template
+++ b/templates/lez-framework/crates/lez-client-gen/Cargo.toml.template
@@ -2,8 +2,8 @@
 name = "lez-client-gen"
 version = "0.1.0"
 edition = "2021"
-description = "Generates typed Rust client and FFI bindings from LEZ program IDL"
+description = "Generates typed Rust client and FFI bindings from Spel program IDL"
 
 [dependencies]
-lez-client-gen.workspace = true
+spel-client-gen.workspace = true
 serde_json.workspace = true

--- a/templates/lez-framework/crates/lez-client-gen/src/main.rs
+++ b/templates/lez-framework/crates/lez-client-gen/src/main.rs
@@ -1,5 +1,5 @@
 //! Client/FFI code generator for LEZ programs.
-//! Wraps lez-client-gen to support --idl-dir for batch generation.
+//! Wraps spel-client-gen to support --idl-dir for batch generation.
 
 use std::path::PathBuf;
 
@@ -40,7 +40,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         let path = entry.path();
         if path.extension().map(|e| e == "json").unwrap_or(false) {
             let json = std::fs::read_to_string(&path)?;
-            let output = lez_client_gen::generate_from_idl_json(&json)?;
+            let output = spel_client_gen::generate_from_idl_json(&json)?;
 
             let program_name: String = {
                 let idl: serde_json::Value = serde_json::from_str(&json)?;

--- a/templates/lez-framework/crates/lez-client-gen/src/main.rs
+++ b/templates/lez-framework/crates/lez-client-gen/src/main.rs
@@ -1,4 +1,4 @@
-//! Client/FFI code generator for LEZ programs.
+//! Client/FFI code generator for Spel programs.
 //! Wraps spel-client-gen to support --idl-dir for batch generation.
 
 use std::path::PathBuf;

--- a/templates/lez-framework/methods/guest/Cargo.toml.template
+++ b/templates/lez-framework/methods/guest/Cargo.toml.template
@@ -12,8 +12,8 @@ risc0-zkvm.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 borsh.workspace = true
-lez-framework.workspace = true
-lez-framework-core.workspace = true
+spel-framework.workspace = true
+spel-framework-core.workspace = true
 
 [[bin]]
 name = "lez_counter"

--- a/templates/lez-framework/methods/guest/src/bin/lez_counter.rs
+++ b/templates/lez-framework/methods/guest/src/bin/lez_counter.rs
@@ -1,6 +1,6 @@
 #![no_main]
 
-use lez_framework::prelude::*;
+use spel_framework::prelude::*;
 
 #[cfg(not(test))]
 risc0_zkvm::guest::entry!(main);
@@ -16,27 +16,20 @@ mod lez_counter {
         counter: AccountWithMetadata,
         #[account(signer)]
         authority: AccountWithMetadata,
-    ) -> LezResult {
-        Ok(LezOutput::states_only(vec![
-            AccountPostState::new_claimed(counter.account.clone()),
-            AccountPostState::new(authority.account.clone()),
-        ]))
+    ) -> SpelResult {
+        Ok(SpelOutput::execute(vec![counter, authority], vec![]))
     }
 
     #[instruction]
     pub fn increment(
         #[account(mut, pda = literal("counter"))]
-        counter: AccountWithMetadata,
+        mut counter: AccountWithMetadata,
         #[account(signer)]
         authority: AccountWithMetadata,
         amount: u64,
-    ) -> LezResult {
-        let mut counter_post = counter.account.clone();
-        counter_post.balance += amount as u128;
+    ) -> SpelResult {
+        counter.account.balance += amount as u128;
 
-        Ok(LezOutput::states_only(vec![
-            AccountPostState::new(counter_post),
-            AccountPostState::new(authority.account.clone()),
-        ]))
+        Ok(SpelOutput::execute(vec![counter, authority], vec![]))
     }
 }

--- a/templates/lez-framework/src/lib.rs
+++ b/templates/lez-framework/src/lib.rs
@@ -27,10 +27,7 @@ pub mod runner_support {
 
 // Host-side program definition for IDL extraction and testing.
 // The guest binary (methods/guest) handles zkvm execution.
-use lez_framework::prelude::*;
-use lez_framework::error::{LezError, LezResult};
-use lez_framework_core::types::LezOutput;
-use nssa_core::program::AccountPostState;
+use spel_framework::prelude::*;
 use nssa_core::account::AccountWithMetadata;
 
 #[lez_program]
@@ -44,28 +41,21 @@ mod lez_counter {
         counter: AccountWithMetadata,
         #[account(signer)]
         authority: AccountWithMetadata,
-    ) -> LezResult {
-        Ok(LezOutput::states_only(vec![
-            AccountPostState::new_claimed(counter.account.clone()),
-            AccountPostState::new(authority.account.clone()),
-        ]))
+    ) -> SpelResult {
+        Ok(SpelOutput::execute(vec![counter, authority], vec![]))
     }
 
     #[instruction]
     pub fn increment(
         #[account(mut, pda = literal("counter"))]
-        counter: AccountWithMetadata,
+        mut counter: AccountWithMetadata,
         #[account(signer)]
         authority: AccountWithMetadata,
         amount: u64,
-    ) -> LezResult {
-        let mut counter_post = counter.account.clone();
-        counter_post.balance += amount as u128;
+    ) -> SpelResult {
+        counter.account.balance += amount as u128;
 
-        Ok(LezOutput::states_only(vec![
-            AccountPostState::new(counter_post),
-            AccountPostState::new(authority.account.clone()),
-        ]))
+        Ok(SpelOutput::execute(vec![counter, authority], vec![]))
     }
 }
 


### PR DESCRIPTION
## Feature outcome

Template E2E now validates both generated project variants through the complete render, setup, doctor, toolchain, and build flow.

## Before / after

Before this PR, the workflow failed before it could meaningfully validate the templates because the Risc Zero toolchains were missing. Fixing that exposed two real template compatibility problems: the default PDA example used a removed LEZ constructor, and the framework template mixed incompatible `nssa_core` source identities while depending on an outdated framework fork.

After this PR, those problems are fixed and both matrix legs are normal hard failures. There is no `continue-on-error` exception for the framework template.

## What changed

- Installs the Risc Zero Rust and C++ toolchains before building rendered projects.
- Keeps host-side C compilation on the system compiler while the guest build uses Risc Zero's cross-compiler.
- Updates the default PDA example to use `AccountId::for_public_pda`.
- Moves the framework template to the official Spel v0.5.0 dependency.
- Matches direct LEZ dependencies to Spel's v0.1.2 tag so Cargo resolves a single `nssa_core` source.
- Updates the generated program and client generator to Spel's current APIs and naming.
- Removes the temporary allowed-failure behavior from the framework matrix leg.

## Verification

- `cargo test`: 491 library, 181 CLI, 3 API, and 5 doc tests passed.
- CI `validate` passed.
- Template E2E passed both hard-failure legs end to end: `default` in 8m46s and `lez-framework` in 11m9s.
