### PR TITLE
Fix default-template build/deploy against pinned LEZ v0.1.2 + spel v0.5.0

### DIFF
--- a/.github/workflows/template-e2e.yml
+++ b/.github/workflows/template-e2e.yml
@@ -46,17 +46,21 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       # The bootstrap cache holds the cloned lez/spel repos and their target/
-      # dirs (~/.cache/logos-scaffold) AND the extracted circuits release
-      # (~/.logos-blockchain-circuits, where the fetch step below puts it).
-      # Both must be cached, or the multi-MB circuits tarball re-downloads on
-      # every run. Keying on constants.rs means a pin or circuits-version bump
+      # dirs (~/.cache/logos-scaffold), the extracted circuits release
+      # (~/.logos-blockchain-circuits, where the fetch step below puts it),
+      # and the risc0 toolchains (~/.risc0, installed further below). All
+      # must be cached, or the multi-MB circuits tarball and the ~500 MB
+      # risc0 Rust toolchain re-download on every run. rzup is idempotent,
+      # so a cache hit on ~/.risc0 turns the install step into a fast no-op.
+      # Keying on constants.rs means a pin or circuits-version bump
       # invalidates it (rebuild from scratch) while same-pin re-runs stay warm.
-      - name: Cache scaffold bootstrap (repos + circuits)
+      - name: Cache scaffold bootstrap (repos + circuits + risc0)
         uses: actions/cache@v4
         with:
           path: |
             ~/.cache/logos-scaffold
             ~/.logos-blockchain-circuits
+            ~/.risc0
           key: scaffold-bootstrap-${{ runner.os }}-${{ hashFiles('src/constants.rs') }}
 
       - name: Build scaffold CLI

--- a/DOGFOODING.md
+++ b/DOGFOODING.md
@@ -110,6 +110,21 @@ mkdir -p "$EXT" && cp /tmp/cr/r0vm "$EXT/r0vm" && chmod +x "$EXT/r0vm"
 
 `find_r0vm_path_for_lez` looks at `~/.risc0/extensions/v<risc0-zkvm-version>-cargo-risczero-<arch>-<os>/r0vm`; placing r0vm there is what wires it into a spawned sequencer (scaffold sets `RISC0_SERVER_PATH` from it). The sequencer runs with `RISC0_DEV_MODE=1` (the test-node default), so r0vm executes guests without real proving — which is why no GPU/prover is needed.
 
+**2b. Install the risc0 Rust toolchain (needed for `build`/`deploy`, not for the T-series).** `r0vm` alone runs guests; it does *not* compile them. `logos-scaffold build` (and therefore `deploy`/`run`/`D`/`L` scenarios) shells out through `risc0-build`, which asks the `rzup` library for a default-installed Rust toolchain and panics with `Risc Zero Rust toolchain not found. Try running 'rzup install rust'` if none exists. `rzup install rust` fails the same way behind a TLS-intercepting proxy, so install it by hand from the `risc0/rust` release and register it where the `rzup` library looks (`~/.risc0/toolchains/` + `~/.risc0/settings.toml`):
+
+```bash
+RVER=1.94.1   # match the toolchain the risc0 release line ships; `rzup install rust` would pick the latest r0.* tag
+curl -sSL -H "Authorization: Bearer $GH_TOKEN" -o /tmp/rust-toolchain.tgz \
+  "https://github.com/risc0/rust/releases/download/r0.$RVER/rust-toolchain-$TRIPLE.tar.gz"
+VDIR="$HOME/.risc0/toolchains/v$RVER-rust-$TRIPLE"
+mkdir -p "$VDIR" && tar xzf /tmp/rust-toolchain.tgz -C "$VDIR"
+printf '[default_versions]\nrust = "%s"\n' "$RVER" > "$HOME/.risc0/settings.toml"
+ln -sfn "$VDIR" "$HOME/.rustup/toolchains/risc0"
+ls "$VDIR/lib/rustlib" | grep riscv32im   # → riscv32im-risc0-zkvm-elf (guest target present)
+```
+
+Circuits need no equivalent hand-provisioning for generated projects: `build`/`setup` resolve the `[circuits]` table in `scaffold.toml`, materialise the configured release into `[circuits].install_dir` (default `.scaffold/circuits`), and export `LOGOS_BLOCKCHAIN_CIRCUITS` for the rest of the process. A pre-set `LOGOS_BLOCKCHAIN_CIRCUITS` pointing at a populated release short-circuits the download; only older projects without `[circuits]` still require it.
+
 **3. Build the real sequencer.** `test-node prepare` downloads the circuits release (via `curl`, automatically) and builds `sequencer_service`. It is long (~6 min); run it, then confirm doctor is green:
 
 ```bash
@@ -117,9 +132,10 @@ mkdir -p "$EXT" && cp /tmp/cr/r0vm "$EXT/r0vm" && chmod +x "$EXT/r0vm"
 "$SCAFFOLD_BIN" test-node doctor  --project "$P" --json | jq .ok   # → true (all checks pass)
 ```
 
-**4. (Only for real transactions — T4) build the wallet via `setup`.** Two gotchas distinguish `setup` from `test-node prepare`: its circuits precheck does **not** consult the scaffold cache (it only accepts `LOGOS_BLOCKCHAIN_CIRCUITS` or `$HOME/.logos-blockchain-circuits/`), so ensure one of those is present before running it; and it uses cwd discovery, so it must run **inside** the project (no `--project` flag):
+**4. (Only for real transactions — T4) build the wallet via `setup`.** One gotcha distinguishes `setup` from `test-node prepare`: it uses cwd discovery, so it must run **inside** the project (no `--project` flag). Projects with a `[circuits]` table materialise their configured release during `setup` itself; only for older projects without `[circuits]` must `LOGOS_BLOCKCHAIN_CIRCUITS` be exported first:
 
 ```bash
+# Only needed for older projects without [circuits] in scaffold.toml:
 export LOGOS_BLOCKCHAIN_CIRCUITS="$("$SCAFFOLD_BIN" test-node pins --project "$P" --json | jq -r .circuits_path)"
 ( cd "$P" && "$SCAFFOLD_BIN" setup )   # builds wallet + spel, seeds the default wallet (~3 min) → "setup complete"
 ```

--- a/DOGFOODING.md
+++ b/DOGFOODING.md
@@ -114,6 +114,7 @@ mkdir -p "$EXT" && cp /tmp/cr/r0vm "$EXT/r0vm" && chmod +x "$EXT/r0vm"
 
 ```bash
 RVER=1.94.1   # match the toolchain the risc0 release line ships; `rzup install rust` would pick the latest r0.* tag
+TRIPLE=${TRIPLE:-x86_64-unknown-linux-gnu}   # aarch64-apple-darwin on macOS; matches step 2
 curl -sSL -H "Authorization: Bearer $GH_TOKEN" -o /tmp/rust-toolchain.tgz \
   "https://github.com/risc0/rust/releases/download/r0.$RVER/rust-toolchain-$TRIPLE.tar.gz"
 VDIR="$HOME/.risc0/toolchains/v$RVER-rust-$TRIPLE"

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -456,8 +456,10 @@ fn deploy_single_program(
 
 /// Wall-clock cap for `spel program-id`. The CLI typically returns in
 /// milliseconds; a hung binary should not block the deploy summary.
-/// Override with `LOGOS_SCAFFOLD_SPEL_INSPECT_TIMEOUT_MS` if needed.
-const SPEL_INSPECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+/// Override with `LOGOS_SCAFFOLD_SPEL_PROGRAM_ID_TIMEOUT_MS` if needed;
+/// `LOGOS_SCAFFOLD_SPEL_INSPECT_TIMEOUT_MS` is honored as a legacy alias
+/// from when extraction ran `spel inspect`.
+const SPEL_PROGRAM_ID_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 
 /// Run the project-vendored `spel program-id <binary>` and return the risc0
 /// image ID parsed from its output. Returns `None` on any failure (binary
@@ -469,11 +471,12 @@ pub(crate) fn extract_program_id(spel_bin: &Path, binary_path: &Path) -> Option<
     use std::process::Stdio;
     use std::time::Instant;
 
-    let timeout = std::env::var("LOGOS_SCAFFOLD_SPEL_INSPECT_TIMEOUT_MS")
+    let timeout = std::env::var("LOGOS_SCAFFOLD_SPEL_PROGRAM_ID_TIMEOUT_MS")
+        .or_else(|_| std::env::var("LOGOS_SCAFFOLD_SPEL_INSPECT_TIMEOUT_MS"))
         .ok()
         .and_then(|s| s.parse::<u64>().ok())
         .map(std::time::Duration::from_millis)
-        .unwrap_or(SPEL_INSPECT_TIMEOUT);
+        .unwrap_or(SPEL_PROGRAM_ID_TIMEOUT);
 
     let mut child = Command::new(spel_bin)
         .arg("program-id")

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -26,7 +26,7 @@ use super::wallet_support::{
 /// compiles via `crate::constants::METHODS_DIR`; keep them in sync.
 const GUEST_BIN_SEARCH_ROOTS: &[&str] = &["target/riscv-guest", "methods/target"];
 
-/// `spel inspect` line prefix that carries the risc0 image ID — the value the
+/// `spel program-id` line prefix that carries the risc0 image ID — the value the
 /// sequencer uses as the on-chain program ID. Format is whitespace-tolerant:
 /// `   ImageID (hex bytes): <64 hex chars>`.
 const SPEL_IMAGE_ID_PREFIX: &str = "ImageID (hex bytes):";
@@ -454,12 +454,12 @@ fn deploy_single_program(
     })
 }
 
-/// Wall-clock cap for `spel inspect`. The CLI typically returns in
+/// Wall-clock cap for `spel program-id`. The CLI typically returns in
 /// milliseconds; a hung binary should not block the deploy summary.
 /// Override with `LOGOS_SCAFFOLD_SPEL_INSPECT_TIMEOUT_MS` if needed.
 const SPEL_INSPECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 
-/// Run the project-vendored `spel inspect <binary>` and return the risc0
+/// Run the project-vendored `spel program-id <binary>` and return the risc0
 /// image ID parsed from its output. Returns `None` on any failure (binary
 /// missing, non-zero exit, output unparseable, timeout). Callers print an
 /// "unavailable" hint instead of failing the deploy — the deploy itself has
@@ -476,7 +476,7 @@ pub(crate) fn extract_program_id(spel_bin: &Path, binary_path: &Path) -> Option<
         .unwrap_or(SPEL_INSPECT_TIMEOUT);
 
     let mut child = Command::new(spel_bin)
-        .arg("inspect")
+        .arg("program-id")
         .arg(binary_path)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -405,7 +405,7 @@ pub(crate) fn print_report(report: &DoctorReport) {
 /// `DEFAULT_LEZ.tag`). When the two diverge, spel's sequencer-RPC client
 /// speaks a different LEZ protocol than the sequencer scaffold builds,
 /// which can break `lgs spel -- ...` subcommands that hit the sequencer
-/// (image-ID computation via `spel inspect` is unaffected — it only
+/// (image-ID computation via `spel program-id` is unaffected — it only
 /// touches the guest ELF).
 ///
 /// Reads `<spel_path>/spel-cli/Cargo.toml` and looks for either the SHA

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -227,7 +227,7 @@ fn run_pipeline_once(project: &Project, params: &PipelineParams) -> DynResult<()
     // Collect deployed-program metadata for hook env injection regardless
     // of whether deploy ran or was skipped — hooks address programs by
     // name and shouldn't have to care about cache state.
-    // `extract_program_id` shells out to `spel inspect` once per program
+    // `extract_program_id` shells out to `spel program-id` once per program
     // here so the per-hook loop doesn't multiply latency by hook count.
     let deployed = collect_deployed_programs(project, deploy_skipped)?;
 
@@ -510,7 +510,7 @@ fn reseed_after_wipe(project: &Project) -> DynResult<()> {
 }
 
 /// Per-program metadata exposed to post-deploy hooks via env vars.
-/// `program_id` may be `None` when `spel inspect` fails (missing vendored
+/// `program_id` may be `None` when `spel program-id` fails (missing vendored
 /// binary, unreadable ELF).
 #[derive(Clone, Debug)]
 pub(crate) struct DeployedProgram {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3615,13 +3615,16 @@ if [ "${SPEL_FAIL:-0}" = "1" ]; then
   exit 7
 fi
 
-if [ "$#" -ge 2 ] && [ "$1" = "inspect" ]; then
+# `program-id <ELF>` is what `extract_program_id` calls (spel v0.5.0 renamed
+# the old `inspect <ELF>`); `inspect` is still accepted so the `lgs spel --
+# inspect` passthrough-proxy tests exercise arg forwarding.
+if [ "$#" -ge 2 ] && { [ "$1" = "program-id" ] || [ "$1" = "inspect" ]; }; then
   bin_path="$2"
   bin_name="$(basename "$bin_path")"
   if [ -n "${SPEL_PROGRAM_ID_FAIL:-}" ]; then
     case "$bin_name" in
       *"$SPEL_PROGRAM_ID_FAIL"*)
-        echo "spel stub: forced inspect failure for $bin_name" >&2
+        echo "spel stub: forced program-id failure for $bin_name" >&2
         exit 8
         ;;
     esac

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3624,7 +3624,7 @@ if [ "$#" -ge 2 ] && { [ "$1" = "program-id" ] || [ "$1" = "inspect" ]; }; then
   if [ -n "${SPEL_PROGRAM_ID_FAIL:-}" ]; then
     case "$bin_name" in
       *"$SPEL_PROGRAM_ID_FAIL"*)
-        echo "spel stub: forced program-id failure for $bin_name" >&2
+        echo "spel stub: forced $1 failure for $bin_name" >&2
         exit 8
         ;;
     esac


### PR DESCRIPTION
## Summary
Dogfooding the default template against the current pinned deps (LEZ v0.1.2,
spel v0.5.0) surfaced two breakages in the generated-project happy path. Both
are fixed and verified clean-room (fresh `new` → `setup` → `build` → `deploy`).

## Changes
- **Fix PDA runner compile error** — `run_hello_world_with_authorization_through_tail_call_with_pda`
  called `AccountId::from((&program.id(), &PDA_SEED))`, which the pinned LEZ
  `AccountId` doesn't implement, so `logos-scaffold build` failed (E0277).
  Switched to the canonical `AccountId::for_public_pda(...)`.
- **Fix deploy program-id resolution** — spel v0.5.0 renamed its ELF command
  (`spel inspect` now decodes account data; `spel program-id <FILE>` extracts
  the image ID). `extract_program_id` still called `inspect`, so every deploy
  reported `program_id: unavailable` and `$SCAFFOLD_PROGRAM_ID` was unset for
  post-deploy hooks. Switched to `program-id`.
- **Docs** — added the missing risc0 Rust toolchain provisioning step to
  DOGFOODING.md (needed to compile guests for build/deploy).

## Testing
E1–E3, A1, D1–D7, and T1–T4 pass end-to-end against a real sequencer,
including a real committed wallet transaction and exact-state seeding.