### PR TITLE
fix: support nested LEZ repo layout

### DIFF
--- a/src/commands/localnet.rs
+++ b/src/commands/localnet.rs
@@ -9,8 +9,9 @@ use anyhow::{anyhow, bail, Context};
 use serde_json::Value;
 
 use crate::circuits::ensure_circuits_for_subprocess;
-use crate::constants::{SEQUENCER_BIN_REL_PATH, SEQUENCER_CONFIG_REL_PATH};
+use crate::constants::{SEQUENCER_BIN_REL_PATH, SEQUENCER_CONFIG_REL_PATHS};
 use crate::error::{LocalnetError, ResetError};
+use crate::lez_layout::first_existing_lez_path;
 use crate::model::{
     LocalnetLogsReport, LocalnetOwnership, LocalnetState, LocalnetStatusReport, Project,
 };
@@ -727,7 +728,8 @@ fn build_status_report(
 /// deferral, scaffold widens the limit so the documented first-success path
 /// fits in a single block.
 fn prepare_sequencer_config(lez: &Path, dest_dir: &Path, port: u16) -> DynResult<PathBuf> {
-    let src_path = lez.join(SEQUENCER_CONFIG_REL_PATH);
+    let src_path =
+        first_existing_lez_path(lez, SEQUENCER_CONFIG_REL_PATHS, "sequencer debug config")?;
     let text = fs::read_to_string(&src_path)
         .with_context(|| format!("failed to read {}", src_path.display()))?;
     let mut doc: Value =
@@ -1362,6 +1364,27 @@ mod tests {
             git_clean(&lez).unwrap(),
             "lez tree must remain clean after prepare_sequencer_config"
         );
+    }
+
+    #[test]
+    fn prepare_sequencer_config_accepts_nested_lez_layout() {
+        let temp = tempdir().unwrap();
+        let lez = temp.path().join("lez");
+        let state_dir = temp.path().join(".scaffold/state");
+
+        // Newer LEZ pins moved the repository payload under a `lez/` prefix.
+        // `localnet start` must find that config instead of only probing the
+        // pre-reorg flat path.
+        let config_path = lez.join("lez/sequencer/service/configs/debug/sequencer_config.json");
+        fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        fs::write(&config_path, "{\n  \"port\": 3040\n}\n").unwrap();
+
+        let dest = prepare_sequencer_config(&lez, &state_dir, 4050).unwrap();
+        let doc: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&dest).unwrap()).unwrap();
+
+        assert_eq!(doc["port"], serde_json::json!(4050));
+        assert_eq!(doc["max_block_size"], serde_json::json!("8 MiB"));
     }
 
     #[test]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -56,6 +56,11 @@ pub(crate) const CIRCUITS_RELEASE_BASE_URL: &str =
 pub(crate) const DEFAULT_HELLO_WORLD_IMAGE_ID_HEX: &str =
     "4880b298f59699c1e4263c5c2245c80123632d608b9116f4b253c63e6c340771";
 pub(crate) const DEFAULT_WALLET_PASSWORD: &str = "logos-scaffold-v0";
+pub(crate) const WALLET_CONFIG_REL_PATH: &str = "wallet/configs/debug/wallet_config.json";
+pub(crate) const WALLET_CONFIG_NESTED_REL_PATH: &str =
+    "lez/wallet/configs/debug/wallet_config.json";
+pub(crate) const WALLET_CONFIG_REL_PATHS: &[&str] =
+    &[WALLET_CONFIG_NESTED_REL_PATH, WALLET_CONFIG_REL_PATH];
 pub(crate) const WALLET_BIN_REL_PATH: &str = "target/release/wallet";
 pub(crate) const FRAMEWORK_KIND_DEFAULT: &str = "default";
 pub(crate) const FRAMEWORK_KIND_LEZ_FRAMEWORK: &str = "lez-framework";
@@ -70,6 +75,10 @@ pub(crate) const SEQUENCER_BIN_REL_PATH: &str = "target/release/sequencer_servic
 pub(crate) const METHODS_DIR: &str = "methods";
 pub(crate) const SEQUENCER_CONFIG_REL_PATH: &str =
     "sequencer/service/configs/debug/sequencer_config.json";
+pub(crate) const SEQUENCER_CONFIG_NESTED_REL_PATH: &str =
+    "lez/sequencer/service/configs/debug/sequencer_config.json";
+pub(crate) const SEQUENCER_CONFIG_REL_PATHS: &[&str] =
+    &[SEQUENCER_CONFIG_NESTED_REL_PATH, SEQUENCER_CONFIG_REL_PATH];
 pub(crate) const SPEL_BIN_REL_PATH: &str = "target/release/spel";
 /// Default seconds to wait for the sequencer to become ready when `lgs run`
 /// has to start localnet itself. Cold first runs (fresh repo clone, cold

--- a/src/lez_layout.rs
+++ b/src/lez_layout.rs
@@ -1,0 +1,32 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::bail;
+
+use crate::DynResult;
+
+/// Return the first existing LEZ-relative path from `rel_paths`.
+///
+/// LEZ has existed in both a flat repository layout (`sequencer/...`,
+/// `wallet/...`) and a nested layout (`lez/sequencer/...`, `lez/wallet/...`).
+/// Callers use this helper at the boundary where scaffold consumes files from a
+/// checked-out LEZ repo so both layouts stay supported without mutating the LEZ
+/// checkout or requiring symlinks.
+pub(crate) fn first_existing_lez_path(
+    lez: &Path,
+    rel_paths: &[&str],
+    label: &str,
+) -> DynResult<PathBuf> {
+    for rel in rel_paths {
+        let candidate = lez.join(rel);
+        if candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+
+    let tried = rel_paths
+        .iter()
+        .map(|rel| lez.join(rel).display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    bail!("missing {label} in lez repo; tried {tried}");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub(crate) mod config;
 pub(crate) mod constants;
 pub(crate) mod doctor_checks;
 pub(crate) mod error;
+pub(crate) mod lez_layout;
 pub(crate) mod migrate;
 pub(crate) mod model;
 pub(crate) mod process;

--- a/src/state.rs
+++ b/src/state.rs
@@ -5,6 +5,8 @@ use std::path::Path;
 use anyhow::{anyhow, bail};
 
 use crate::commands::wallet_support::WALLET_CONFIG_PRIMARY;
+use crate::constants::WALLET_CONFIG_REL_PATHS;
+use crate::lez_layout::first_existing_lez_path;
 use crate::model::{BasecampState, LocalnetState};
 use crate::DynResult;
 
@@ -129,10 +131,8 @@ pub(crate) fn prepare_wallet_home(lez_repo: &Path, wallet_home: &Path) -> DynRes
     fs::create_dir_all(wallet_home)?;
     let cfg_dst = wallet_home.join(WALLET_CONFIG_PRIMARY);
     if !cfg_dst.exists() {
-        let cfg_src = lez_repo.join("wallet/configs/debug/wallet_config.json");
-        if !cfg_src.exists() {
-            bail!("missing wallet debug config in lez repo");
-        }
+        let cfg_src =
+            first_existing_lez_path(lez_repo, WALLET_CONFIG_REL_PATHS, "wallet debug config")?;
         fs::copy(cfg_src, cfg_dst)?;
     }
     Ok(())
@@ -196,5 +196,25 @@ mod tests {
         .unwrap();
         let loaded = read_basecamp_state(&path).expect("read legacy");
         assert_eq!(loaded.pin, "abc");
+    }
+
+    #[test]
+    fn prepare_wallet_home_accepts_nested_lez_layout() {
+        let tmp = tempdir().expect("tempdir");
+        let lez = tmp.path().join("lez");
+        let wallet_home = tmp.path().join("wallet-home");
+
+        // Newer LEZ pins moved the repository payload under a `lez/` prefix.
+        // Setup/reset reseeding should copy the wallet debug config from that
+        // layout when the old flat path is absent.
+        let cfg_src = lez.join("lez/wallet/configs/debug/wallet_config.json");
+        fs::create_dir_all(cfg_src.parent().unwrap()).expect("create nested wallet config dir");
+        fs::write(&cfg_src, "{ \"network\": \"debug\" }\n").expect("write wallet config");
+
+        prepare_wallet_home(&lez, &wallet_home).expect("prepare wallet home");
+
+        let copied = fs::read_to_string(wallet_home.join(WALLET_CONFIG_PRIMARY))
+            .expect("read copied wallet config");
+        assert_eq!(copied, "{ \"network\": \"debug\" }\n");
     }
 }

--- a/src/testnode/mod.rs
+++ b/src/testnode/mod.rs
@@ -40,7 +40,8 @@ use serde_json::Value;
 use crate::circuits::ensure_circuits_for_subprocess;
 use crate::commands::localnet::find_r0vm_path_for_lez;
 use crate::commands::wallet_support::{rpc_get_last_block_id, RpcReachabilityError};
-use crate::constants::{SEQUENCER_BIN_REL_PATH, SEQUENCER_CONFIG_REL_PATH};
+use crate::constants::{SEQUENCER_BIN_REL_PATH, SEQUENCER_CONFIG_REL_PATHS};
+use crate::lez_layout::first_existing_lez_path;
 use crate::model::Project;
 use crate::process::{pid_running, port_open, spawn_to_log};
 use crate::project::{resolve_cache_root, resolve_repo_path};
@@ -605,7 +606,8 @@ fn copy_dir_recursive(src: &Path, dest: &Path) -> DynResult<()> {
 /// `max_block_size` widened (same rationale as localnet). Returns the config
 /// path and the genesis block id.
 fn write_node_config(lez: &Path, work_dir: &Path, port: u16) -> DynResult<(PathBuf, u64)> {
-    let src_path = lez.join(SEQUENCER_CONFIG_REL_PATH);
+    let src_path =
+        first_existing_lez_path(lez, SEQUENCER_CONFIG_REL_PATHS, "sequencer debug config")?;
     let text = fs::read_to_string(&src_path)
         .with_context(|| format!("failed to read {}", src_path.display()))?;
     let mut doc: Value =
@@ -781,6 +783,7 @@ pub fn acquire_run_slot(cache_root: &Path, max_parallel: usize) -> DynResult<Run
 mod tests {
     use std::fs;
 
+    use crate::constants::SEQUENCER_CONFIG_REL_PATH;
     use tempfile::tempdir;
 
     use super::*;
@@ -814,6 +817,33 @@ mod tests {
             serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
         assert_eq!(src["home"], serde_json::json!("."));
         assert_eq!(src["port"], serde_json::json!(3040));
+    }
+
+    #[test]
+    fn write_node_config_accepts_nested_lez_layout() {
+        let temp = tempdir().unwrap();
+        let lez = temp.path().join("lez");
+        let work = temp.path().join("node");
+        fs::create_dir_all(&work).unwrap();
+
+        // Newer LEZ pins moved the repository payload under a `lez/` prefix.
+        // Test-node startup should use the same config probing as localnet.
+        let config_path = lez.join("lez/sequencer/service/configs/debug/sequencer_config.json");
+        fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        fs::write(
+            &config_path,
+            r#"{ "home": ".", "genesis_id": 7, "port": 3040 }"#,
+        )
+        .unwrap();
+
+        let (dest, genesis) = write_node_config(&lez, &work, 41235).unwrap();
+        assert_eq!(genesis, 7);
+
+        let doc: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&dest).unwrap()).unwrap();
+        assert_eq!(doc["home"], serde_json::json!(work.display().to_string()));
+        assert_eq!(doc["port"], serde_json::json!(41235));
+        assert_eq!(doc["max_block_size"], serde_json::json!("8 MiB"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Support newer LEZ pins whose repository payload is nested under a `lez/` prefix.
- Add shared LEZ layout probing for sequencer debug config and wallet debug config.
- Keep the previous flat layout as a fallback for existing checkouts/tests.

## Fix / Approach
- Added `first_existing_lez_path(...)` to resolve the first available LEZ-relative candidate path with a clear error listing attempted paths.
- Updated localnet/testnode sequencer config setup to probe nested then flat paths.
- Updated wallet home seeding to probe nested then flat wallet config paths.
- Added regression tests for nested LEZ layouts in localnet, testnode, and wallet setup.

## Verification
RED before implementation:
- `cargo test prepare_sequencer_config_accepts_nested_lez_layout -- --nocapture` failed with missing flat sequencer config path.
- `cargo test write_node_config_accepts_nested_lez_layout -- --nocapture` failed with missing flat sequencer config path.
- `cargo test prepare_wallet_home_accepts_nested_lez_layout -- --nocapture` failed with missing wallet debug config.

After the fix:
- `cargo fmt --check` — passed.
- `cargo test prepare_sequencer_config_accepts_nested_lez_layout -- --nocapture` — passed.
- `cargo test write_node_config_accepts_nested_lez_layout -- --nocapture` — passed.
- `cargo test prepare_wallet_home_accepts_nested_lez_layout -- --nocapture` — passed.
- `cargo test --all-targets` — passed (`459` unit tests and `168` integration/CLI tests passed).
- `git diff --check` — passed.

Note: the existing `unexpected cfg condition value: sha2` warnings from `src/commands/setup.rs` still appear during tests and are unrelated to this change.

## Related issue
Fixes logos-co/scaffold#230

<!-- hermes-web3-pr-marathon -->
