### PR TITLE
fix(basecamp): set absolute LOGOS_DATA_DIR on macOS portable launch

### DIFF
--- a/DOGFOODING.md
+++ b/DOGFOODING.md
@@ -1156,6 +1156,7 @@ Within the running UIs, exercise whatever p2p surface the module exposes (chat e
 - Custom profile pairs open against their own profile dirs under `.scaffold/basecamp/profiles/<profile>/` and their configured runtime/log/env paths.
 - Each window shows the project's `.lgx` modules installed and ready.
 - `LOGOS_PROFILE=alice` and `LOGOS_PROFILE=bob` are visible in each respective process environment (helpful for debugging).
+- On the macOS portable stack, each process environment carries an absolute `LOGOS_DATA_DIR` pointing at its own profile's module root — set automatically by `launch`, no manual export needed.
 - The two instances do not collide on Qt remote-objects or any non-module port; per-profile port-override env vars (per the spec) are set on each `launch`.
 - A p2p interaction triggered from `alice` is observable in `bob` (and vice versa) within the module's expected latency window.
 

--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -784,7 +784,9 @@ fn launch_env(
 ///     `.../Logos/LogosBasecamp` for the portable stack) when unset, and
 ///   * rewrites any caller-supplied relative `LOGOS_DATA_DIR` (from
 ///     `[basecamp.env]` / `[basecamp.profiles.<name>.env]`) to absolute against
-///     the project root, so a relative value can't silently break the UI.
+///     the project root, so a relative value can't silently break the UI, and
+///   * treats an empty (or whitespace-only) caller value as unset — absolutizing
+///     `""` would collapse to the project root, which is not a module root.
 ///
 /// The caller gates this to the macOS portable stack; the transform itself is
 /// platform-independent so it stays unit-testable on any host.
@@ -795,7 +797,10 @@ fn set_absolute_logos_data_dir(
     basecamp_repo: Option<&RepoRef>,
 ) {
     const KEY: &str = "LOGOS_DATA_DIR";
-    match env.get(KEY) {
+    match env
+        .get(KEY)
+        .filter(|v| !v.to_string_lossy().trim().is_empty())
+    {
         Some(existing) => {
             let path = PathBuf::from(existing);
             if path.is_relative() {
@@ -816,13 +821,19 @@ fn set_absolute_logos_data_dir(
 
 /// Resolve `path` to an absolute path. Absolute inputs pass through unchanged; a
 /// relative input is joined onto `base` (the project root, itself absolute for
-/// the normal `load_project` discovery path).
+/// the normal `load_project` discovery path). A relative `base` (possible via
+/// `load_project_at`, which accepts any root) is best-effort canonicalized
+/// first so the result is absolute whenever `base` exists on disk.
 fn absolutize(base: &Path, path: &Path) -> PathBuf {
     if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        base.join(path)
+        return path.to_path_buf();
     }
+    if base.is_relative() {
+        if let Ok(abs_base) = base.canonicalize() {
+            return abs_base.join(path);
+        }
+    }
+    base.join(path)
 }
 
 /// Resolve the per-profile runtime dir (`TMPDIR` / `XDG_RUNTIME_DIR` root).
@@ -3813,6 +3824,41 @@ mod tests {
         assert_eq!(
             env.get("LOGOS_DATA_DIR").map(PathBuf::from),
             Some(PathBuf::from("/somewhere/else"))
+        );
+    }
+
+    #[test]
+    fn set_absolute_logos_data_dir_treats_empty_caller_value_as_unset() {
+        let portable = repo_with_attr("bin-macos-app");
+        let project_root = Path::new("/abs/project");
+        let profile_dir = project_root.join("profiles/alice");
+        let mut env: BTreeMap<String, OsString> = BTreeMap::new();
+        // An empty value (e.g. `LOGOS_DATA_DIR = ""` in [basecamp.env]) would
+        // absolutize to the project root itself, which is not a module root;
+        // it must fall back to the profile default instead.
+        env.insert("LOGOS_DATA_DIR".into(), OsString::new());
+        set_absolute_logos_data_dir(&mut env, project_root, &profile_dir, Some(&portable));
+        assert_eq!(
+            env.get("LOGOS_DATA_DIR").map(PathBuf::from),
+            Some(
+                profile_dir
+                    .join("xdg-data")
+                    .join(BASECAMP_XDG_APP_SUBPATH_PORTABLE)
+            )
+        );
+    }
+
+    #[test]
+    fn absolutize_canonicalizes_relative_base() {
+        // `.` always exists, so canonicalize resolves it against the test cwd
+        // without the test itself having to change directories.
+        let resolved = absolutize(Path::new("."), Path::new("custom/data"));
+        assert!(resolved.is_absolute(), "got: {}", resolved.display());
+        assert_eq!(
+            resolved,
+            std::env::current_dir()
+                .expect("test cwd")
+                .join("custom/data")
         );
     }
 

--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -514,6 +514,13 @@ fn cmd_basecamp_launch(
             std::env::var_os(k)
         });
     }
+    // macOS `bin-macos-app` Basecamp ignores XDG and loads its modules from
+    // `LOGOS_DATA_DIR` (see `set_absolute_logos_data_dir`). Apply this after the
+    // scaffold.toml env layering so a user-supplied relative value is absolutized
+    // too. Scoped to the macOS portable stack; a no-op elsewhere.
+    if cfg!(target_os = "macos") && is_portable_basecamp(basecamp_repo) {
+        set_absolute_logos_data_dir(&mut env, &project.root, &profile_dir, basecamp_repo);
+    }
     println!("launching basecamp for profile {profile}");
     let mut cmd = Command::new(&state.basecamp_bin);
     for (k, v) in &env {
@@ -753,6 +760,69 @@ fn launch_env(
     }
     env.insert("LOGOS_PROFILE".into(), profile_name.into());
     env
+}
+
+/// Ensure `LOGOS_DATA_DIR` is set to an **absolute** path pointing at the
+/// profile's installed module/plugin root.
+///
+/// The macOS `bin-macos-app` Basecamp bundle predates the `--user-dir` /
+/// `LOGOS_USER_DIR` flag (see #178) and does **not** honor `XDG_DATA_HOME` on
+/// macOS: it loads its modules/plugins from `LOGOS_DATA_DIR`, falling back to
+/// `~/Library/Application Support/Logos/LogosBasecamp/` when that is unset. So
+/// although `launch_env` isolates the profile via `XDG_DATA_HOME` and scaffold
+/// installs the profile's modules under `<profile>/xdg-data/<subpath>`, the app
+/// never sees them unless `LOGOS_DATA_DIR` points there.
+///
+/// The value **must be absolute**: with a *relative* `LOGOS_DATA_DIR` the app
+/// loads the backend modules but the dlopen'd `main_ui` / `package_manager_ui`
+/// dylibs fail `@rpath` resolution ("shared library was not found") and the
+/// shell UI never renders. Only an absolute path brings up the full stack.
+///
+/// This finalizer therefore:
+///   * defaults `LOGOS_DATA_DIR` to the profile's absolute module root
+///     (`<profile>/xdg-data/<basecamp_xdg_subpath>`, e.g.
+///     `.../Logos/LogosBasecamp` for the portable stack) when unset, and
+///   * rewrites any caller-supplied relative `LOGOS_DATA_DIR` (from
+///     `[basecamp.env]` / `[basecamp.profiles.<name>.env]`) to absolute against
+///     the project root, so a relative value can't silently break the UI.
+///
+/// The caller gates this to the macOS portable stack; the transform itself is
+/// platform-independent so it stays unit-testable on any host.
+fn set_absolute_logos_data_dir(
+    env: &mut BTreeMap<String, OsString>,
+    project_root: &Path,
+    profile_dir: &Path,
+    basecamp_repo: Option<&RepoRef>,
+) {
+    const KEY: &str = "LOGOS_DATA_DIR";
+    match env.get(KEY) {
+        Some(existing) => {
+            let path = PathBuf::from(existing);
+            if path.is_relative() {
+                env.insert(KEY.into(), absolutize(project_root, &path).into_os_string());
+            }
+        }
+        None => {
+            let default_dir = profile_dir
+                .join("xdg-data")
+                .join(basecamp_xdg_subpath(basecamp_repo));
+            env.insert(
+                KEY.into(),
+                absolutize(project_root, &default_dir).into_os_string(),
+            );
+        }
+    }
+}
+
+/// Resolve `path` to an absolute path. Absolute inputs pass through unchanged; a
+/// relative input is joined onto `base` (the project root, itself absolute for
+/// the normal `load_project` discovery path).
+fn absolutize(base: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        base.join(path)
+    }
 }
 
 /// Resolve the per-profile runtime dir (`TMPDIR` / `XDG_RUNTIME_DIR` root).
@@ -3694,6 +3764,55 @@ mod tests {
         assert_eq!(
             basecamp_xdg_subpath(Some(&repo_with_attr("bin-macos-app"))),
             BASECAMP_XDG_APP_SUBPATH_PORTABLE
+        );
+    }
+
+    #[test]
+    fn set_absolute_logos_data_dir_defaults_to_profile_module_root_when_unset() {
+        let portable = repo_with_attr("bin-macos-app");
+        let project_root = Path::new("/abs/project");
+        let profile_dir = project_root
+            .join(".scaffold/basecamp/profiles")
+            .join("alice");
+        let mut env: BTreeMap<String, OsString> = BTreeMap::new();
+        set_absolute_logos_data_dir(&mut env, project_root, &profile_dir, Some(&portable));
+        assert_eq!(
+            env.get("LOGOS_DATA_DIR").map(PathBuf::from),
+            Some(
+                profile_dir
+                    .join("xdg-data")
+                    .join(BASECAMP_XDG_APP_SUBPATH_PORTABLE)
+            )
+        );
+    }
+
+    #[test]
+    fn set_absolute_logos_data_dir_absolutizes_relative_caller_value() {
+        let portable = repo_with_attr("bin-macos-app");
+        let project_root = Path::new("/abs/project");
+        let profile_dir = project_root.join("profiles/alice");
+        let mut env: BTreeMap<String, OsString> = BTreeMap::new();
+        // A relative value (e.g. from [basecamp.profiles.<name>.env]) loads the
+        // backend modules but breaks @rpath resolution of the UI dylibs.
+        env.insert("LOGOS_DATA_DIR".into(), OsString::from("custom/data"));
+        set_absolute_logos_data_dir(&mut env, project_root, &profile_dir, Some(&portable));
+        assert_eq!(
+            env.get("LOGOS_DATA_DIR").map(PathBuf::from),
+            Some(project_root.join("custom/data"))
+        );
+    }
+
+    #[test]
+    fn set_absolute_logos_data_dir_leaves_absolute_caller_value_untouched() {
+        let portable = repo_with_attr("bin-macos-app");
+        let project_root = Path::new("/abs/project");
+        let profile_dir = project_root.join("profiles/alice");
+        let mut env: BTreeMap<String, OsString> = BTreeMap::new();
+        env.insert("LOGOS_DATA_DIR".into(), OsString::from("/somewhere/else"));
+        set_absolute_logos_data_dir(&mut env, project_root, &profile_dir, Some(&portable));
+        assert_eq!(
+            env.get("LOGOS_DATA_DIR").map(PathBuf::from),
+            Some(PathBuf::from("/somewhere/else"))
         );
     }
 


### PR DESCRIPTION
## Your Project or User Demand

Found while dogfooding the [`eth-lez-atomic-swaps`](https://github.com/logos-co/eth-lez-atomic-swaps) Phase 2 scaffold migration — a two-peer atomic-swap app running the distributed (portable) Basecamp stack on macOS `darwin-arm64`. Fixes #236.

## User Story

`lgs basecamp launch <profile>` isolates per-profile state via `XDG_DATA_HOME`, but the `bin-macos-app` Basecamp bundle (`a746cdbc` / `v0.1.1`) **ignores XDG on macOS** — it reads modules/plugins from `LOGOS_DATA_DIR`, falling back to `~/Library/Application Support/Logos/LogosBasecamp/` when unset. So scaffold installs the profile's modules under `<profile>/xdg-data/Logos/LogosBasecamp/{modules,plugins}` but the launched app never sees them: only its built-in `package_manager` + `capability_module` load.

Critically, the value **must be absolute**: a *relative* `LOGOS_DATA_DIR` loads the backend modules but then the dlopen'd `main_ui` / `package_manager_ui` dylibs fail `@rpath` resolution (`"shared library was not found"`) and the shell UI never renders. Only an absolute path brings up the full stack.

Because scaffold can't portably express an absolute per-profile path in a committed `scaffold.toml`, the downstream repo had to ship a launch bridge that re-implements this — exec'ing Basecamp with an absolute `LOGOS_DATA_DIR` plus the profile's XDG/runtime env. With that in place both peers load the full portable stack (`main_ui` + the swap modules + their UI plugins). This PR moves that behavior into `launch` so the glue can be deleted.

## Change Summary

On the macOS portable stack (`cfg!(target_os = "macos")` + `is_portable_basecamp`), `cmd_basecamp_launch` now sets `LOGOS_DATA_DIR` to the profile's **absolute** module root (`<profile>/xdg-data/<basecamp_xdg_subpath>` — the exact dir scaffold already installs into), and absolutizes any caller-supplied *relative* `LOGOS_DATA_DIR` from `[basecamp.env]` / `[basecamp.profiles.<name>.env]` against the project root. No-op on non-macOS and for the dev (XDG-honoring) stack. The transform is applied after the scaffold.toml env layering so caller overrides are still respected (just absolutized).

## Verification

- `cargo test --lib` — 511 passed, 0 failed (3 new unit tests for `set_absolute_logos_data_dir`: default-when-unset, relative→absolute, absolute-untouched).
- Downstream: verified end-to-end in the atomic-swaps repo — both maker + taker peers launch and load the full portable stack (`main_ui` + `swap` + `swap_ui` + `delivery_module`) with the absolute `LOGOS_DATA_DIR` this PR now sets.

## Checklist

- [x] CI is green
- [x] Relevant DOGFOODING scenarios rerun (macOS portable two-peer launch, downstream atomic-swaps)
- [ ] Docs updated (no user-facing config surface changed; behavior is automatic on the macOS portable stack)
- [x] I have read [CONTRIBUTING.md](/CONTRIBUTING.md) and this PR fits within the weekly contribution cap
