### PR TITLE
feat(run): per-profile deploy = false to skip scaffold's deploy step

### DIFF
--- a/DOGFOODING.md
+++ b/DOGFOODING.md
@@ -563,6 +563,18 @@ post_deploy = [
 "$SCAFFOLD_BIN" run --post-deploy "x" --no-post-deploy  # expect clap conflict error
 ```
 
+Then add a profile that owns deployment itself (`deploy = false`) and run it:
+
+```toml
+[run.profiles.self-deploy]
+deploy = false
+post_deploy = ["echo 'deploy skipped:' $SCAFFOLD_DEPLOY_SKIPPED"]
+```
+
+```bash
+"$SCAFFOLD_BIN" run --profile self-deploy   # skips step 5, still fires hooks
+```
+
 ### Expected Success Signals
 
 - The first `run` (no hooks configured) prints a numbered step header for each phase (`[1/5] Building...` through `[5/5] Deploying...`) and ends with a deployed-programs summary.
@@ -572,6 +584,7 @@ post_deploy = [
 - `--no-post-deploy` skips the post-deploy step entirely; the run prints the deployed-programs summary instead.
 - `--post-deploy` with `--no-post-deploy` errors at clap parse time with a `cannot be used with` message; exit code is non-zero.
 - A non-zero hook exit aborts the run with a clear `post-deploy hook exited with status N` message.
+- With `deploy = false` in the selected profile, `run --profile self-deploy` prints ``[5/6] Deploy skipped (`deploy = false` in the run profile; ...)`` instead of `[5/6] Deploying...`, skips the program-hash/deploy work entirely, and still runs the `post_deploy` hooks. Each hook sees `SCAFFOLD_DEPLOY_SKIPPED=1` (here `echo 'deploy skipped:' $SCAFFOLD_DEPLOY_SKIPPED` prints `deploy skipped: 1`).
 
 ### Failure Signals / Common Pitfalls
 
@@ -585,6 +598,7 @@ post_deploy = [
 - Output of `run` after the `[run]` block is added, showing the `===> post_deploy[i/n]:` markers and the resolved env values.
 - Output of `run --post-deploy "echo override"` showing only the override hook fires.
 - Output of `run --no-post-deploy` showing the deployed-programs summary instead of hooks.
+- Output of `run --profile self-deploy` showing the ``[5/6] Deploy skipped (`deploy = false` ...)`` header and the `post_deploy` hook reporting `deploy skipped: 1`.
 
 ## L1. LEZ Template Bootstrap
 
@@ -1643,7 +1657,7 @@ HEAD0=$("$SCAFFOLD_BIN" test-node blocks head --url "$URL" --json | jq -r .block
 - Changes to wallet flows or wallet-related defaults: rerun `D4`.
 - Changes to diagnostics, report contents, or redaction logic: rerun `D5`.
 - Changes to example runner binaries or template `src/bin/*` code: rerun `D6`.
-- Changes to `run` step ordering, post-deploy env vars, post-deploy CLI override flag handling, or `[run]` config parsing: rerun `D7`.
+- Changes to `run` step ordering, the `deploy = false` deploy-skip branch, post-deploy env vars, post-deploy CLI override flag handling, or `[run]` config parsing: rerun `D7`.
 - Changes to LEZ template scaffolding or generated outputs: rerun `L1`, `L2`, `L3`, and `L4`.
 - Changes to CLI argument parsing, help text, or error messages: rerun `E1`.
 - Changes to `create`/`new` flags or template selection logic: rerun `E2`.

--- a/README.md
+++ b/README.md
@@ -275,6 +275,14 @@ deploy = false
 post_deploy = ["scripts/deploy-and-demo.sh"]
 ```
 
+It is equally valid inline under `[run]` (applies to the default, profile-less run):
+
+```toml
+[run]
+deploy = false
+post_deploy = ["scripts/deploy-and-demo.sh"]
+```
+
 `deploy` defaults to `true`; omit it for the normal deploy loop.
 
 #### One-off override / skip

--- a/README.md
+++ b/README.md
@@ -260,6 +260,23 @@ environment variables pre-set:
 multi-program projects so hooks fail loudly rather than silently
 picking up the wrong program.
 
+#### Self-deploying projects (`deploy = false`)
+
+`run` deploys programs it finds under `methods/guest/src/bin`. A project
+that owns deployment itself — it deploys from a `post_deploy` hook, or keeps
+its guest program outside that default directory — can set `deploy = false`
+to skip scaffold's deploy step (step 5). The pipeline then runs
+build → IDL → localnet → topup → `post_deploy`, without requiring the default
+program directory to exist. It works inline under `[run]` or per profile:
+
+```toml
+[run.profiles.demo]
+deploy = false
+post_deploy = ["scripts/deploy-and-demo.sh"]
+```
+
+`deploy` defaults to `true`; omit it for the normal deploy loop.
+
 #### One-off override / skip
 
 To run a different hook without editing `scaffold.toml`:

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -195,33 +195,48 @@ fn run_pipeline_once(project: &Project, params: &PipelineParams) -> DynResult<()
         );
     }
 
-    // Step 5: Deploy (idempotent: skip when guest .bin + IDL + deploy
-    // config hashes match the prior deploy AND the sequencer is the same
-    // instance that received it. A `lgs localnet stop && start` cycle
-    // changes the sequencer PID and wipes on-chain state, so PID equality
-    // is the gate that prevents stale-deploy false positives. To force a
-    // re-deploy without restarting localnet, use `--reset` (which also
-    // clears the cache) or delete `.scaffold/state/run_deploy.json`
-    // manually.
-    let current_hashes = compute_program_hashes(project)?;
-    let current_pid = current_localnet_pid(project);
-    let prior = load_state(project);
-    let deploy_skipped = if deploy_can_be_skipped(&current_hashes, current_pid, &prior) {
+    // Step 5: Deploy. Skipped entirely when the run profile sets
+    // `deploy = false` (project owns deployment); otherwise idempotent —
+    // see the branches below.
+    let deploy_skipped = if !params.resolved.deploy {
+        // `deploy = false`: the project owns program deployment itself (e.g.
+        // from a post_deploy hook, or with its guest program outside the
+        // scaffold-default `methods/guest/src/bin`). Skip scaffold's deploy —
+        // including the program-hash computation, which otherwise bails when
+        // the default program directory is absent — and go straight to hooks.
         println!(
-            "[5/{total_steps}] Deploy skipped (guest binaries + IDL + config + sequencer unchanged; pass `--reset` to wipe and re-deploy, or delete `.scaffold/state/run_deploy.json` to force a re-deploy without a wipe)"
+            "[5/{total_steps}] Deploy skipped (`deploy = false` in the run profile; this project owns program deployment — e.g. via a post_deploy hook)"
         );
         true
     } else {
-        println!("[5/{total_steps}] Deploying programs...");
-        cmd_deploy(None, None, false)?;
-        save_state(
-            project,
-            &RunDeployState {
-                program_hashes: current_hashes,
-                localnet_pid: current_pid,
-            },
-        )?;
-        false
+        // Step 5 deploy is idempotent: skip when guest .bin + IDL + deploy
+        // config hashes match the prior deploy AND the sequencer is the same
+        // instance that received it. A `lgs localnet stop && start` cycle
+        // changes the sequencer PID and wipes on-chain state, so PID equality
+        // is the gate that prevents stale-deploy false positives. To force a
+        // re-deploy without restarting localnet, use `--reset` (which also
+        // clears the cache) or delete `.scaffold/state/run_deploy.json`
+        // manually.
+        let current_hashes = compute_program_hashes(project)?;
+        let current_pid = current_localnet_pid(project);
+        let prior = load_state(project);
+        if deploy_can_be_skipped(&current_hashes, current_pid, &prior) {
+            println!(
+                "[5/{total_steps}] Deploy skipped (guest binaries + IDL + config + sequencer unchanged; pass `--reset` to wipe and re-deploy, or delete `.scaffold/state/run_deploy.json` to force a re-deploy without a wipe)"
+            );
+            true
+        } else {
+            println!("[5/{total_steps}] Deploying programs...");
+            cmd_deploy(None, None, false)?;
+            save_state(
+                project,
+                &RunDeployState {
+                    program_hashes: current_hashes,
+                    localnet_pid: current_pid,
+                },
+            )?;
+            false
+        }
     };
 
     // Collect deployed-program metadata for hook env injection regardless

--- a/src/config.rs
+++ b/src/config.rs
@@ -108,6 +108,11 @@ fn parse_run(doc: &DocumentMut) -> DynResult<RunConfig> {
         .and_then(Item::as_value)
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
+    let inline_deploy = run_table
+        .get("deploy")
+        .and_then(Item::as_value)
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
     let inline_post_deploy = parse_post_deploy(run_table.get("post_deploy"))?;
 
     let mut profiles: std::collections::BTreeMap<String, RunProfile> =
@@ -122,8 +127,20 @@ fn parse_run(doc: &DocumentMut) -> DynResult<RunConfig> {
                 .and_then(Item::as_value)
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
+            let deploy = table
+                .get("deploy")
+                .and_then(Item::as_value)
+                .and_then(|v| v.as_bool())
+                .unwrap_or(true);
             let post_deploy = parse_post_deploy(table.get("post_deploy"))?;
-            profiles.insert(name.to_string(), RunProfile { reset, post_deploy });
+            profiles.insert(
+                name.to_string(),
+                RunProfile {
+                    reset,
+                    post_deploy,
+                    deploy,
+                },
+            );
         }
     }
 
@@ -142,6 +159,7 @@ fn parse_run(doc: &DocumentMut) -> DynResult<RunConfig> {
         inline: RunProfile {
             reset: inline_reset,
             post_deploy: inline_post_deploy,
+            deploy: inline_deploy,
         },
         profiles,
         watch,
@@ -897,7 +915,7 @@ pub(crate) fn serialize_config(cfg: &Config) -> DynResult<String> {
 }
 
 fn write_run_config(doc: &mut DocumentMut, run: &RunConfig) -> DynResult<()> {
-    let has_inline = run.inline.reset || !run.inline.post_deploy.is_empty();
+    let has_inline = run.inline.reset || !run.inline.post_deploy.is_empty() || !run.inline.deploy;
     let has_default_profile = run.default_profile.is_some();
     let has_profiles = !run.profiles.is_empty();
     let has_watch = run.watch != WatchConfig::default();
@@ -913,6 +931,11 @@ fn write_run_config(doc: &mut DocumentMut, run: &RunConfig) -> DynResult<()> {
     }
     if run.inline.reset {
         run_table["reset"] = value(true);
+    }
+    // Only emit `deploy` when it deviates from the `true` default, to keep a
+    // fresh scaffold.toml minimal.
+    if !run.inline.deploy {
+        run_table["deploy"] = value(false);
     }
     if !run.inline.post_deploy.is_empty() {
         for hook in &run.inline.post_deploy {
@@ -938,6 +961,9 @@ fn write_run_config(doc: &mut DocumentMut, run: &RunConfig) -> DynResult<()> {
                 .expect("profile table");
             if profile.reset {
                 profile_table["reset"] = value(true);
+            }
+            if !profile.deploy {
+                profile_table["deploy"] = value(false);
             }
             if !profile.post_deploy.is_empty() {
                 profile_table["post_deploy"] = post_deploy_value(&profile.post_deploy);
@@ -1984,6 +2010,61 @@ role = "project"
     }
 
     #[test]
+    fn run_profile_deploy_defaults_to_true() {
+        // Absent `deploy` key → deploy runs, preserving historical behavior.
+        let toml = minimal_v0_2_0() + "[run.profiles.demo]\npost_deploy = \"echo demo\"\n";
+        let cfg = parse_config(&toml).expect("parse");
+        assert!(cfg.run.profiles.get("demo").expect("demo present").deploy);
+        // The inline/default profile also defaults deploy to true.
+        assert!(RunProfile::default().deploy);
+        assert!(cfg.run.inline.deploy);
+    }
+
+    #[test]
+    fn parse_config_run_profile_deploy_false() {
+        let toml = minimal_v0_2_0()
+            + "[run.profiles.demo]\ndeploy = false\npost_deploy = [\"scripts/self-deploy.sh\"]\n";
+        let cfg = parse_config(&toml).expect("parse");
+        let demo = cfg.run.profiles.get("demo").expect("demo present");
+        assert!(!demo.deploy);
+        assert_eq!(demo.post_deploy, vec!["scripts/self-deploy.sh".to_string()]);
+    }
+
+    #[test]
+    fn parse_config_inline_run_deploy_false() {
+        let toml = minimal_v0_2_0() + "[run]\ndeploy = false\n";
+        let cfg = parse_config(&toml).expect("parse");
+        assert!(!cfg.run.inline.deploy);
+        let resolved = cfg.run.resolve_profile(None).expect("resolve");
+        assert!(!resolved.deploy);
+    }
+
+    #[test]
+    fn run_profile_deploy_round_trips_through_parse_serialize() {
+        let toml = minimal_v0_2_0()
+            + "[run]\ndeploy = false\n[run.profiles.demo]\ndeploy = false\npost_deploy = [\"echo demo\"]\n";
+        let cfg1 = parse_config(&toml).expect("parse");
+        let serialized = serialize_config(&cfg1).expect("serialize");
+        let cfg2 = parse_config(&serialized).expect("re-parse");
+        assert!(!cfg2.run.inline.deploy);
+        let demo = cfg2.run.profiles.get("demo").expect("demo present");
+        assert!(!demo.deploy);
+        assert_eq!(demo.post_deploy, vec!["echo demo".to_string()]);
+    }
+
+    #[test]
+    fn run_profile_deploy_true_is_not_serialized() {
+        // The `true` default must not be emitted, to keep scaffold.toml minimal.
+        let toml = minimal_v0_2_0() + "[run.profiles.demo]\npost_deploy = [\"echo demo\"]\n";
+        let cfg = parse_config(&toml).expect("parse");
+        let serialized = serialize_config(&cfg).expect("serialize");
+        assert!(
+            !serialized.contains("deploy = true"),
+            "default deploy=true should not be serialized:\n{serialized}"
+        );
+    }
+
+    #[test]
     fn serialize_rejects_newline_in_profile_post_deploy() {
         let mut cfg = base_config();
         let mut profiles = std::collections::BTreeMap::new();
@@ -1992,6 +2073,7 @@ role = "project"
             RunProfile {
                 reset: false,
                 post_deploy: vec!["echo a\n[run.profiles.evil]".to_string()],
+                deploy: true,
             },
         );
         cfg.run = RunConfig {

--- a/src/model.rs
+++ b/src/model.rs
@@ -343,7 +343,7 @@ pub(crate) struct FrameworkIdlConfig {
     pub(crate) path: String,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct RunProfile {
     /// Wipe rocksdb + wallet, restart sequencer, re-seed default wallet.
     /// Broader than `lgs localnet reset`: re-establishes the documented
@@ -352,6 +352,28 @@ pub(crate) struct RunProfile {
     /// deterministic test suites where PDA-key collisions force a wipe.
     pub(crate) reset: bool,
     pub(crate) post_deploy: Vec<String>,
+    /// Whether `lgs run` performs its own deploy step. Defaults to `true`.
+    /// Set `deploy = false` for a project that owns program deployment
+    /// itself (e.g. deploys from a `post_deploy` hook, or keeps its guest
+    /// program outside the scaffold-default `methods/guest/src/bin`): the
+    /// pipeline then skips step 5's hash/deploy/save-state and goes straight
+    /// to the post-deploy hooks, instead of bailing on the missing default
+    /// program directory.
+    pub(crate) deploy: bool,
+}
+
+impl Default for RunProfile {
+    fn default() -> Self {
+        // `deploy` defaults to `true` so a project with no `[run]` config (or a
+        // profile that omits the key) keeps the historical behavior of running
+        // scaffold's deploy step. `derive(Default)` would give `false`, which
+        // would silently disable deploy for every existing project.
+        Self {
+            reset: false,
+            post_deploy: Vec::new(),
+            deploy: true,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default)]


### PR DESCRIPTION
## Your Project or User Demand

Found while dogfooding the [`eth-lez-atomic-swaps`](https://github.com/logos-co/eth-lez-atomic-swaps) Phase 2 scaffold migration on macOS `darwin-arm64`. Fixes #237.

## User Story

`lgs run` discovers deployable programs only under the hardcoded `<root>/methods/guest/src/bin` (`discover_deployable_programs`, `deploy.rs:303`), and step 5 always runs it via `compute_program_hashes`. The function **bails** when that directory is absent:

```
missing deployable program directory at <root>/methods/guest/src/bin
```

The atomic-swaps repo keeps its guest program at `programs/lez-htlc/methods/guest/` and deploys it from its own post-deploy command, so scaffold's deploy step is neither wanted nor possible via the hardcoded path — yet `lgs run` bails before ever reaching `post_deploy`, even though the run profile only needs build → localnet → topup → `post_deploy`. There was no way to tell a run profile "the project owns deployment; skip scaffold's deploy step." The workaround was to not use `lgs run` at all.

(Related but distinct from #231 / #59, which concern *binary* auto-discovery paths; this is the *source* dir gate blocking the whole pipeline for self-deploying apps.)

## Change Summary

Adds a `deploy` boolean to `[run]` / `[run.profiles.<name>]`, defaulting to `true`. When `deploy = false`, `run_pipeline_once` skips step 5 entirely — including the program-hash computation that otherwise bails on the missing default program directory — and proceeds straight to the `post_deploy` hooks. Parse/serialize/resolve mirror the existing `reset` boolean; the `true` default is never serialized to keep a fresh `scaffold.toml` minimal.

```toml
[run.profiles.demo]
deploy = false
post_deploy = ["scripts/deploy-and-demo.sh"]
```

## Verification

- `cargo test --lib` — 513 passed, 0 failed. 5 new config tests (default-true, inline `deploy = false`, profile `deploy = false`, round-trip, and "default true is not serialized"); updated the one direct `RunProfile { .. }` literal for the new field.
- `RunProfile` gets a manual `Default` (deploy = true) so a project with no `[run]` config keeps the historical deploy behavior — `derive(Default)` would have given `false` and silently disabled deploy everywhere.
- README: new "Self-deploying projects (`deploy = false`)" subsection under the `run` docs.

## Checklist

- [x] CI is green
- [x] Relevant DOGFOODING scenarios rerun (`L1` run pipeline; new config unit coverage)
- [x] Docs updated (`README.md`)
- [x] I have read [CONTRIBUTING.md](/CONTRIBUTING.md) and this PR fits within the weekly contribution cap
