### PR TITLE
fix(basecamp): set absolute LOGOS_USER_DIR for Basecamp 0.2.x on macOS portable launch

### DIFF
--- a/DOGFOODING.md
+++ b/DOGFOODING.md
@@ -1171,7 +1171,7 @@ Within the running UIs, exercise whatever p2p surface the module exposes (chat e
 - Each window shows the project's `.lgx` modules installed and ready.
 - `LOGOS_PROFILE=alice` and `LOGOS_PROFILE=bob` are visible in each respective process environment (helpful for debugging).
 - On the macOS portable stack, each process environment carries an absolute `LOGOS_DATA_DIR` *and* an absolute `LOGOS_USER_DIR`, both pointing at that profile's own module root (`.scaffold/basecamp/profiles/<profile>/xdg-data/Logos/LogosBasecamp`) — set automatically by `launch`, no manual export needed. Basecamp 0.1.x reads the first and 0.2.x the second, so which one the app actually honors depends on the `[repos.basecamp]` pin; `launch` sets both so the check is the same either way.
-- The two instances do not collide on Qt remote-objects or any non-module port; per-profile port-override env vars (per the spec) are set on each `launch`.
+- The two instances do not collide on Qt remote-objects or any non-module port. Do not go hunting for per-module port-override env vars in the process environment: the registry they would flow in through is empty in v1 (no module has published a name yet), so `launch` exports none. A module-level port collision between `alice` and `bob` is therefore still possible, and belongs to the owning module rather than to scaffold.
 - A p2p interaction triggered from `alice` is observable in `bob` (and vice versa) within the module's expected latency window.
 
 ### Failure Signals / Common Pitfalls
@@ -1187,7 +1187,9 @@ Within the running UIs, exercise whatever p2p surface the module exposes (chat e
 
 - The exact two-terminal command sequence used.
 - A short transcript or screenshot pair showing a p2p interaction propagating from one instance to the other.
-- The env block of each running process (e.g., `tr '\0' '\n' < /proc/<pid>/environ | grep -E 'XDG_|LOGOS_'`).
+- The env block of each running process. `launch` records the basecamp PID in `.scaffold/basecamp/profiles/<profile>/launch.state` as `pid=<pid>`; read the env with:
+  - Linux: `tr '\0' '\n' < /proc/<pid>/environ | grep -E 'XDG_|LOGOS_'`
+  - macOS (no `/proc`): `ps eww -p <pid> | tr ' ' '\n' | grep -E 'XDG_|LOGOS_'`
 - Any port-collision error text verbatim, with the module that owns the colliding port.
 - If custom profiles are used, `basecamp paths <profile> --json` for each profile and the resolved log/runtime dirs.
 

--- a/DOGFOODING.md
+++ b/DOGFOODING.md
@@ -1179,7 +1179,7 @@ Within the running UIs, exercise whatever p2p surface the module exposes (chat e
 - Two windows opening but sharing identity keys, profile state, or message history is a clean-slate / XDG-isolation regression.
 - On the macOS portable stack, both windows showing only basecamp's bundled modules — none of the project's `.lgx` modules — while their logs report a base data directory under the shared `~/Library/Application Support/Logos/LogosBasecamp` is the profile-collapse signature: the app is not reading the per-profile module root at all. Check that both `LOGOS_DATA_DIR` and `LOGOS_USER_DIR` are present, absolute, and distinct per profile in each process environment.
 - A non-module port collision (Qt remote objects, etc.) is a real finding — file upstream against the affected component, do not patch around it inside scaffold.
-- A module that does not honor an externally-provided port override is documented as a known gap pending an upstream fix on that module; capture the module name, the env var that should have worked, and the observed collision.
+- A module that hardcodes its port is a known gap pending an upstream fix on that module. Scaffold exports no override for it to honor (see the signal above), so capture the module name and the observed collision — not a missing env var.
 - One window crashing while the other survives is recordable evidence; capture the crashing instance's logs from `.scaffold/basecamp/profiles/<name>/` before relaunching.
 - Running `basecamp launch alice` twice in parallel is undefined in v1 — record the behavior if you trip it accidentally, but don't treat it as a supported scenario.
 
@@ -1189,7 +1189,7 @@ Within the running UIs, exercise whatever p2p surface the module exposes (chat e
 - A short transcript or screenshot pair showing a p2p interaction propagating from one instance to the other.
 - The env block of each running process. `launch` records the basecamp PID in `.scaffold/basecamp/profiles/<profile>/launch.state` as `pid=<pid>`; read the env with:
   - Linux: `tr '\0' '\n' < /proc/<pid>/environ | grep -E 'XDG_|LOGOS_'`
-  - macOS (no `/proc`): `ps eww -p <pid> | tr ' ' '\n' | grep -E 'XDG_|LOGOS_'`
+  - macOS (no `/proc`): `ps eww -p <pid>` — read the `XDG_*` / `LOGOS_*` assignments off the line directly rather than splitting on spaces, since the profile-collapse target (`~/Library/Application Support/…`) contains one and would be truncated at `Application`.
 - Any port-collision error text verbatim, with the module that owns the colliding port.
 - If custom profiles are used, `basecamp paths <profile> --json` for each profile and the resolved log/runtime dirs.
 

--- a/DOGFOODING.md
+++ b/DOGFOODING.md
@@ -1170,13 +1170,14 @@ Within the running UIs, exercise whatever p2p surface the module exposes (chat e
 - Custom profile pairs open against their own profile dirs under `.scaffold/basecamp/profiles/<profile>/` and their configured runtime/log/env paths.
 - Each window shows the project's `.lgx` modules installed and ready.
 - `LOGOS_PROFILE=alice` and `LOGOS_PROFILE=bob` are visible in each respective process environment (helpful for debugging).
-- On the macOS portable stack, each process environment carries an absolute `LOGOS_DATA_DIR` pointing at its own profile's module root — set automatically by `launch`, no manual export needed.
+- On the macOS portable stack, each process environment carries an absolute `LOGOS_DATA_DIR` *and* an absolute `LOGOS_USER_DIR`, both pointing at that profile's own module root (`.scaffold/basecamp/profiles/<profile>/xdg-data/Logos/LogosBasecamp`) — set automatically by `launch`, no manual export needed. Basecamp 0.1.x reads the first and 0.2.x the second, so which one the app actually honors depends on the `[repos.basecamp]` pin; `launch` sets both so the check is the same either way.
 - The two instances do not collide on Qt remote-objects or any non-module port; per-profile port-override env vars (per the spec) are set on each `launch`.
 - A p2p interaction triggered from `alice` is observable in `bob` (and vice versa) within the module's expected latency window.
 
 ### Failure Signals / Common Pitfalls
 
 - Two windows opening but sharing identity keys, profile state, or message history is a clean-slate / XDG-isolation regression.
+- On the macOS portable stack, both windows showing only basecamp's bundled modules — none of the project's `.lgx` modules — while their logs report a base data directory under the shared `~/Library/Application Support/Logos/LogosBasecamp` is the profile-collapse signature: the app is not reading the per-profile module root at all. Check that both `LOGOS_DATA_DIR` and `LOGOS_USER_DIR` are present, absolute, and distinct per profile in each process environment.
 - A non-module port collision (Qt remote objects, etc.) is a real finding — file upstream against the affected component, do not patch around it inside scaffold.
 - A module that does not honor an externally-provided port override is documented as a known gap pending an upstream fix on that module; capture the module name, the env var that should have worked, and the observed collision.
 - One window crashing while the other survives is recordable evidence; capture the crashing instance's logs from `.scaffold/basecamp/profiles/<name>/` before relaunching.

--- a/docs/basecamp-module-requirements.md
+++ b/docs/basecamp-module-requirements.md
@@ -173,7 +173,7 @@ logos-scaffold basecamp build-portable
 
 `build-portable` does not touch profiles, `basecamp.state`, or the AppImage itself — it only produces artefacts. Load them into your AppImage in the printed order via its "install lgx" button; scaffold is intentionally unaware of the AppImage's install path.
 
-If you launch the AppImage with `--user-dir <path>` (the `bin-macos-app` flag that sets `LOGOS_USER_DIR`), the AppImage stores its state at `<path>` rather than its default XDG data root — orthogonal to scaffold's per-profile XDG isolation under `.scaffold/basecamp/profiles/{alice,bob}/`. The two are independent mechanisms at different layers: scaffold's profiles isolate dev-stack runs; `--user-dir` isolates a single AppImage launch's installed-modules + identity state.
+If you launch a portable basecamp build by hand with `--user-dir <path>` (basecamp 0.2.x; `LOGOS_USER_DIR` is its env equivalent), the app stores its installed-modules + identity state at `<path>` rather than at its default data root. `build-portable` never sets that — it only produces artefacts — but `launch` does: on the macOS portable stack it exports an absolute per-profile `LOGOS_USER_DIR` (and `LOGOS_DATA_DIR`, the 0.1.x name for the same override) pointing at that profile's own module root, because the portable bundle does not honor `XDG_DATA_HOME` on macOS and would otherwise collapse every profile onto the shared `~/Library/Application Support/Logos/LogosBasecamp`. So hand-launching with `--user-dir` and `launch`-ing a profile are the same data-tree redirect reached from two entry points, not independent mechanisms: the flag isolates one ad-hoc launch, while `launch` wires the env equivalent per profile so scaffold's isolation under `.scaffold/basecamp/profiles/{alice,bob}/` actually reaches the app. A `LOGOS_USER_DIR` / `LOGOS_DATA_DIR` you declare yourself in `[basecamp.env]` or `[basecamp.profiles.<name>.env]` is honored rather than overwritten — `launch` only rewrites it to absolute against the project root when it is relative (see "Env exported to the basecamp process" below).
 
 The `.scaffold/basecamp/portable/` directory is wiped and recreated on every `build-portable` run, so re-running after you've removed a module via `basecamp modules` doesn't leave stale symlinks behind.
 
@@ -206,6 +206,25 @@ A project that ships more than one basecamp variant can map the flake attr per h
 aarch64-darwin = "bin-macos-app"
 aarch64-linux  = "bin-appimage"
 ```
+
+### Env exported to the basecamp process
+
+`launch` sets the variables below on the basecamp child, on top of the environment `lgs` itself inherited (nothing is cleared). `<profile-dir>` is `.scaffold/basecamp/profiles/<profile>/`, and the env layering above can override any of them.
+
+| Variable | Value | Set when |
+|---|---|---|
+| `XDG_CONFIG_HOME` | `<profile-dir>/xdg-config` | always |
+| `XDG_DATA_HOME` | `<profile-dir>/xdg-data` | always |
+| `XDG_CACHE_HOME` | `<profile-dir>/xdg-cache` | always |
+| `TMPDIR` | the resolved `runtime_dir`, else `<profile-dir>/xdg-tmp` | always |
+| `XDG_RUNTIME_DIR` | the resolved `runtime_dir` | only when one resolves — a configured `runtime_dir`, or the `/tmp/lgs-<profile>` macOS default |
+| `LOGOS_PROFILE` | the profile name | always |
+| `LOGOS_DATA_DIR` | `<profile-dir>/xdg-data/Logos/LogosBasecamp` | macOS **and** a portable `[repos.basecamp].attr` (`bin-macos-app`, `bin-appimage`, `bin-bundle-dir`) |
+| `LOGOS_USER_DIR` | same as `LOGOS_DATA_DIR` | as above |
+
+Module-owned port-override variables are not in this list: no module has published a name yet, so scaffold exports none.
+
+The last two rows are finalized *after* the env layering, so they are the one place a declared value is post-processed rather than simply taken as-is: an absolute value you declared is kept, a relative one is rewritten to absolute against the project root, and an empty (or whitespace-only) one is treated as unset and replaced by the profile default. Both keys are written because basecamp 0.1.x reads `LOGOS_DATA_DIR` while 0.2.x reads `LOGOS_USER_DIR`, so setting both keeps `launch` agnostic to the pinned generation.
 
 ### The macOS `sun_path == 104` socket-path budget
 

--- a/docs/basecamp-module-requirements.md
+++ b/docs/basecamp-module-requirements.md
@@ -173,7 +173,7 @@ logos-scaffold basecamp build-portable
 
 `build-portable` does not touch profiles, `basecamp.state`, or the AppImage itself — it only produces artefacts. Load them into your AppImage in the printed order via its "install lgx" button; scaffold is intentionally unaware of the AppImage's install path.
 
-If you launch a portable basecamp build by hand with `--user-dir <path>` (basecamp 0.2.x; `LOGOS_USER_DIR` is its env equivalent), the app stores its installed-modules + identity state at `<path>` rather than at its default data root. `build-portable` never sets that — it only produces artefacts — but `launch` does: on the macOS portable stack it exports an absolute per-profile `LOGOS_USER_DIR` (and `LOGOS_DATA_DIR`, the 0.1.x name for the same override) pointing at that profile's own module root, because the portable bundle does not honor `XDG_DATA_HOME` on macOS and would otherwise collapse every profile onto the shared `~/Library/Application Support/Logos/LogosBasecamp`. So hand-launching with `--user-dir` and `launch`-ing a profile are the same data-tree redirect reached from two entry points, not independent mechanisms: the flag isolates one ad-hoc launch, while `launch` wires the env equivalent per profile so scaffold's isolation under `.scaffold/basecamp/profiles/{alice,bob}/` actually reaches the app. A `LOGOS_USER_DIR` / `LOGOS_DATA_DIR` you declare yourself in `[basecamp.env]` or `[basecamp.profiles.<name>.env]` is honored rather than overwritten — `launch` only rewrites it to absolute against the project root when it is relative (see "Env exported to the basecamp process" below).
+If you launch a portable basecamp build by hand with `--user-dir <path>` (basecamp 0.2.x; `LOGOS_USER_DIR` is its env equivalent), the app stores its installed-modules + identity state at `<path>` rather than at its default data root. `build-portable` never sets that — it only produces artefacts — but `launch` does: on the macOS portable stack it exports an absolute per-profile `LOGOS_USER_DIR` (and `LOGOS_DATA_DIR`, the 0.1.x name for the same override) pointing at that profile's own module root, because the portable bundle does not honor `XDG_DATA_HOME` on macOS and would otherwise collapse every profile onto the shared `~/Library/Application Support/Logos/LogosBasecamp`. So hand-launching with `--user-dir` and `launch`-ing a profile are the same data-tree redirect reached from two entry points, not independent mechanisms: the flag isolates one ad-hoc launch, while `launch` wires the env equivalent per profile so scaffold's isolation under `.scaffold/basecamp/profiles/{alice,bob}/` actually reaches the app. A non-empty `LOGOS_USER_DIR` / `LOGOS_DATA_DIR` you declare yourself in `[basecamp.env]` or `[basecamp.profiles.<name>.env]` is honored rather than overwritten — `launch` only rewrites it to absolute against the project root when it is relative. An empty or whitespace-only value is the exception: it counts as unset and is replaced by the profile default (see "Env exported to the basecamp process" below).
 
 The `.scaffold/basecamp/portable/` directory is wiped and recreated on every `build-portable` run, so re-running after you've removed a module via `basecamp modules` doesn't leave stale symlinks behind.
 
@@ -220,25 +220,25 @@ aarch64-linux  = "bin-appimage"
 | `XDG_RUNTIME_DIR` | the resolved `runtime_dir` | only when one resolves — a configured `runtime_dir`, or the `/tmp/lgs-<profile>` macOS default |
 | `LOGOS_PROFILE` | the profile name | always |
 | `LOGOS_DATA_DIR` | `<profile-dir>/xdg-data/Logos/LogosBasecamp` | macOS **and** a portable `[repos.basecamp].attr` (`bin-macos-app`, `bin-appimage`, `bin-bundle-dir`) |
-| `LOGOS_USER_DIR` | same as `LOGOS_DATA_DIR` | as above |
+| `LOGOS_USER_DIR` | same default as `LOGOS_DATA_DIR`, resolved independently of it | as above |
 
 Module-owned port-override variables are not in this list: no module has published a name yet, so scaffold exports none.
 
-The last two rows are finalized *after* the env layering, so they are the one place a declared value is post-processed rather than simply taken as-is: an absolute value you declared is kept, a relative one is rewritten to absolute against the project root, and an empty (or whitespace-only) one is treated as unset and replaced by the profile default. Both keys are written because basecamp 0.1.x reads `LOGOS_DATA_DIR` while 0.2.x reads `LOGOS_USER_DIR`, so setting both keeps `launch` agnostic to the pinned generation.
+The last two rows are finalized *after* the env layering, so they are the one place a declared value is post-processed rather than simply taken as-is: an absolute value you declared is kept, a relative one is rewritten to absolute against the project root, and an empty (or whitespace-only) one is treated as unset and replaced by the profile default. Each of the two keys goes through that on its own, so declaring only one of them leaves the other at the profile default and the two can end up pointing at different trees. Both keys are written because basecamp 0.1.x reads `LOGOS_DATA_DIR` while 0.2.x reads `LOGOS_USER_DIR`, so setting both keeps `launch` agnostic to the pinned generation.
 
 ### The macOS `sun_path == 104` socket-path budget
 
-When a module loads, liblogos opens a Unix-domain socket (a `QLocalServer` named `logos_token_<module>_<pid>`) under `XDG_RUNTIME_DIR`. macOS caps the full socket path (`sockaddr_un.sun_path`) at **104 bytes**, so a long runtime root overflows it and basecamp aborts module loading with:
+When a module loads, liblogos opens a Unix-domain socket (a `QLocalServer` named `logos_token_<module>_<pid>`) under the temp root — `TMPDIR`, which `launch` always sets. macOS caps the full socket path (`sockaddr_un.sun_path`) at **104 bytes**, so a long runtime root overflows it and basecamp aborts module loading with:
 
 ```
 [SubprocessContainer] Unix socket path too long (122 >= 104)
 ```
 
-the in-profile runtime root `…/.scaffold/basecamp/profiles/<profile>/xdg-tmp` is long: for a typical project path plus the `logos_token_<module>_<pid>` socket name it easily blows the 104-byte budget. To avoid that, `launch` resolves `runtime_dir` with this precedence and exports it as both `TMPDIR` and `XDG_RUNTIME_DIR`:
+the in-profile runtime root `…/.scaffold/basecamp/profiles/<profile>/xdg-tmp` is long: for a typical project path plus the `logos_token_<module>_<pid>` socket name it easily blows the 104-byte budget. To avoid that, `launch` resolves `runtime_dir` with this precedence, exporting a resolved value as both `TMPDIR` and `XDG_RUNTIME_DIR`:
 
 1. **`[basecamp.profiles.<name>].runtime_dir`** if set (project-relative paths are joined to the project root).
 2. **`/tmp/lgs-<profile>`** — the automatic default on macOS (short, well under the budget).
-3. The in-profile `xdg-tmp` on Linux, where the path budget is far larger and not a practical concern.
+3. The in-profile `xdg-tmp` on Linux, where the path budget is far larger and not a practical concern. Nothing resolves in this case, so `TMPDIR` points at `xdg-tmp` and no `XDG_RUNTIME_DIR` is exported at all (matching the table above).
 
 If you override `runtime_dir` on macOS, keep it short (a `/tmp/…` root is safest) — a deep or project-relative path can still exceed 104 bytes once the socket name is appended.
 

--- a/docs/basecamp-module-requirements.md
+++ b/docs/basecamp-module-requirements.md
@@ -228,17 +228,17 @@ The last two rows are finalized *after* the env layering, so they are the one pl
 
 ### The macOS `sun_path == 104` socket-path budget
 
-When a module loads, liblogos opens a Unix-domain socket (a `QLocalServer` named `logos_token_<module>_<pid>`) under the temp root — `TMPDIR`, which `launch` always sets. macOS caps the full socket path (`sockaddr_un.sun_path`) at **104 bytes**, so a long runtime root overflows it and basecamp aborts module loading with:
+When a module loads, liblogos opens a Unix-domain socket (a `QLocalServer` named `logos_token_<module>`) under the temp root — `TMPDIR`, which `launch` always sets. macOS caps the full socket path (`sockaddr_un.sun_path`) at **104 bytes**, so a long runtime root overflows it and basecamp aborts module loading with:
 
 ```
 [SubprocessContainer] Unix socket path too long (122 >= 104)
 ```
 
-the in-profile runtime root `…/.scaffold/basecamp/profiles/<profile>/xdg-tmp` is long: for a typical project path plus the `logos_token_<module>_<pid>` socket name it easily blows the 104-byte budget. To avoid that, `launch` resolves `runtime_dir` with this precedence, exporting a resolved value as both `TMPDIR` and `XDG_RUNTIME_DIR`:
+the in-profile runtime root `…/.scaffold/basecamp/profiles/<profile>/xdg-tmp` is long: for a typical project path plus the `logos_token_<module>` socket name it easily blows the 104-byte budget. To avoid that, `launch` resolves `runtime_dir` with this precedence, exporting a resolved value as both `TMPDIR` and `XDG_RUNTIME_DIR`:
 
 1. **`[basecamp.profiles.<name>].runtime_dir`** if set (project-relative paths are joined to the project root).
 2. **`/tmp/lgs-<profile>`** — the automatic default on macOS (short, well under the budget).
-3. The in-profile `xdg-tmp` on Linux, where the path budget is far larger and not a practical concern. Nothing resolves in this case, so `TMPDIR` points at `xdg-tmp` and no `XDG_RUNTIME_DIR` is exported at all (matching the table above).
+3. The in-profile `xdg-tmp` on Linux, whose `sun_path` budget is 108 bytes — four more than macOS, so a deep project root can overflow there too; set `runtime_dir` explicitly if you hit it. Nothing resolves in this case, so `TMPDIR` points at `xdg-tmp` and `launch` exports no `XDG_RUNTIME_DIR` of its own (matching the table above) — the child still inherits whatever ambient value the shell had, since `launch` clears nothing.
 
 If you override `runtime_dir` on macOS, keep it short (a `/tmp/…` root is safest) — a deep or project-relative path can still exceed 104 bytes once the socket name is appended.
 

--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -517,8 +517,23 @@ fn cmd_basecamp_launch(
     // macOS `bin-macos-app` Basecamp ignores XDG and loads its modules from
     // `LOGOS_DATA_DIR` (0.1.x) / `LOGOS_USER_DIR` (0.2.x) — see
     // `set_absolute_basecamp_data_dirs`. Apply this after the scaffold.toml env
-    // layering so a user-supplied relative value is absolutized too. Scoped to
-    // the macOS portable stack; a no-op elsewhere.
+    // layering so a user-supplied relative value is absolutized too.
+    //
+    // Why the gate is this narrow: `is_portable_basecamp` matches every attr in
+    // `BASECAMP_PORTABLE_ATTRS` — `bin-macos-app`, `bin-appimage` and
+    // `bin-bundle-dir` — but the XDG-ignoring behaviour that makes this override
+    // necessary has only been observed on `bin-macos-app`, so the
+    // `cfg!(target_os = "macos")` conjunct keeps the write to that stack and
+    // makes it a no-op everywhere else. The Linux portable stacks are *untested*
+    // here rather than known-good: whether basecamp resolves its data tree from
+    // an `XDG_DATA_HOME`-backed location on Linux (in which case `launch_env`'s
+    // isolation already covers them) has not been verified for either
+    // generation. If a Linux AppImage or bundle-dir turns out to ignore XDG too,
+    // the fix is to drop the `cfg!` conjunct: for an unset key the value written
+    // is the same `<profile>/xdg-data/<subpath>` root `XDG_DATA_HOME` already
+    // implies. Note that widening it is not purely additive — it would also
+    // start rewriting relative `LOGOS_*_DIR` values declared in
+    // `[basecamp.env]` on Linux — so it needs a live check, not a guess.
     if cfg!(target_os = "macos") && is_portable_basecamp(basecamp_repo) {
         set_absolute_basecamp_data_dirs(&mut env, &project.root, &profile_dir, basecamp_repo);
     }

--- a/src/commands/basecamp.rs
+++ b/src/commands/basecamp.rs
@@ -515,11 +515,12 @@ fn cmd_basecamp_launch(
         });
     }
     // macOS `bin-macos-app` Basecamp ignores XDG and loads its modules from
-    // `LOGOS_DATA_DIR` (see `set_absolute_logos_data_dir`). Apply this after the
-    // scaffold.toml env layering so a user-supplied relative value is absolutized
-    // too. Scoped to the macOS portable stack; a no-op elsewhere.
+    // `LOGOS_DATA_DIR` (0.1.x) / `LOGOS_USER_DIR` (0.2.x) — see
+    // `set_absolute_basecamp_data_dirs`. Apply this after the scaffold.toml env
+    // layering so a user-supplied relative value is absolutized too. Scoped to
+    // the macOS portable stack; a no-op elsewhere.
     if cfg!(target_os = "macos") && is_portable_basecamp(basecamp_repo) {
-        set_absolute_logos_data_dir(&mut env, &project.root, &profile_dir, basecamp_repo);
+        set_absolute_basecamp_data_dirs(&mut env, &project.root, &profile_dir, basecamp_repo);
     }
     println!("launching basecamp for profile {profile}");
     let mut cmd = Command::new(&state.basecamp_bin);
@@ -762,49 +763,75 @@ fn launch_env(
     env
 }
 
-/// Ensure `LOGOS_DATA_DIR` is set to an **absolute** path pointing at the
-/// profile's installed module/plugin root.
+/// Ensure `LOGOS_DATA_DIR` (Basecamp 0.1.x) and `LOGOS_USER_DIR` (Basecamp
+/// 0.2.x) are each set to an **absolute** path pointing at the profile's
+/// installed module/plugin root.
 ///
-/// The macOS `bin-macos-app` Basecamp bundle predates the `--user-dir` /
-/// `LOGOS_USER_DIR` flag (see #178) and does **not** honor `XDG_DATA_HOME` on
-/// macOS: it loads its modules/plugins from `LOGOS_DATA_DIR`, falling back to
+/// The macOS `bin-macos-app` Basecamp bundle does **not** honor
+/// `XDG_DATA_HOME` on macOS: it loads its modules/plugins from its data-tree
+/// override env var, falling back to
 /// `~/Library/Application Support/Logos/LogosBasecamp/` when that is unset. So
 /// although `launch_env` isolates the profile via `XDG_DATA_HOME` and scaffold
 /// installs the profile's modules under `<profile>/xdg-data/<subpath>`, the app
-/// never sees them unless `LOGOS_DATA_DIR` points there.
+/// never sees them unless the override points there.
 ///
-/// The value **must be absolute**: with a *relative* `LOGOS_DATA_DIR` the app
-/// loads the backend modules but the dlopen'd `main_ui` / `package_manager_ui`
-/// dylibs fail `@rpath` resolution ("shared library was not found") and the
-/// shell UI never renders. Only an absolute path brings up the full stack.
+/// Which env var *is* the override depends on the Basecamp generation: 0.1.x
+/// reads `LOGOS_DATA_DIR`; 0.2.x renamed it to `LOGOS_USER_DIR` / `--user-dir`
+/// (basecamp #164, resolved in `LogosBasecampPaths.h::baseDirectory()`) and
+/// drops `LOGOS_DATA_DIR` entirely — with only the old key set, every 0.2.x
+/// profile silently collapses onto the shared fallback dir and none of the
+/// project's modules appear. The two keys are read by disjoint basecamp
+/// versions, so this sets both and stays pin-agnostic.
 ///
-/// This finalizer therefore:
-///   * defaults `LOGOS_DATA_DIR` to the profile's absolute module root
+/// The values **must be absolute**, for a different reason per generation:
+///   * 0.1.x: with a *relative* `LOGOS_DATA_DIR` the app loads the backend
+///     modules but the dlopen'd `main_ui` / `package_manager_ui` dylibs fail
+///     `@rpath` resolution ("shared library was not found") and the shell UI
+///     never renders.
+///   * 0.2.x: basecamp absolutizes the `--user-dir` *flag* but consumes the
+///     `LOGOS_USER_DIR` *env var* verbatim, so a relative value scatters the
+///     app's state under whatever cwd it was launched from.
+///
+/// This finalizer therefore, for each key independently:
+///   * defaults it to the profile's absolute module root
 ///     (`<profile>/xdg-data/<basecamp_xdg_subpath>`, e.g.
 ///     `.../Logos/LogosBasecamp` for the portable stack) when unset, and
-///   * rewrites any caller-supplied relative `LOGOS_DATA_DIR` (from
-///     `[basecamp.env]` / `[basecamp.profiles.<name>.env]`) to absolute against
-///     the project root, so a relative value can't silently break the UI, and
+///   * rewrites any caller-supplied relative value (from `[basecamp.env]` /
+///     `[basecamp.profiles.<name>.env]`) to absolute against the project root,
+///     so a relative value can't silently break the launch, and
 ///   * treats an empty (or whitespace-only) caller value as unset — absolutizing
 ///     `""` would collapse to the project root, which is not a module root.
 ///
 /// The caller gates this to the macOS portable stack; the transform itself is
 /// platform-independent so it stays unit-testable on any host.
-fn set_absolute_logos_data_dir(
+fn set_absolute_basecamp_data_dirs(
     env: &mut BTreeMap<String, OsString>,
     project_root: &Path,
     profile_dir: &Path,
     basecamp_repo: Option<&RepoRef>,
 ) {
-    const KEY: &str = "LOGOS_DATA_DIR";
+    for key in ["LOGOS_DATA_DIR", "LOGOS_USER_DIR"] {
+        set_absolute_module_root_var(env, key, project_root, profile_dir, basecamp_repo);
+    }
+}
+
+/// Per-key transform behind `set_absolute_basecamp_data_dirs`; see its doc
+/// comment for the semantics.
+fn set_absolute_module_root_var(
+    env: &mut BTreeMap<String, OsString>,
+    key: &str,
+    project_root: &Path,
+    profile_dir: &Path,
+    basecamp_repo: Option<&RepoRef>,
+) {
     match env
-        .get(KEY)
+        .get(key)
         .filter(|v| !v.to_string_lossy().trim().is_empty())
     {
         Some(existing) => {
             let path = PathBuf::from(existing);
             if path.is_relative() {
-                env.insert(KEY.into(), absolutize(project_root, &path).into_os_string());
+                env.insert(key.into(), absolutize(project_root, &path).into_os_string());
             }
         }
         None => {
@@ -812,7 +839,7 @@ fn set_absolute_logos_data_dir(
                 .join("xdg-data")
                 .join(basecamp_xdg_subpath(basecamp_repo));
             env.insert(
-                KEY.into(),
+                key.into(),
                 absolutize(project_root, &default_dir).into_os_string(),
             );
         }
@@ -3779,26 +3806,29 @@ mod tests {
     }
 
     #[test]
-    fn set_absolute_logos_data_dir_defaults_to_profile_module_root_when_unset() {
+    fn set_absolute_basecamp_data_dirs_defaults_both_keys_to_profile_module_root_when_unset() {
         let portable = repo_with_attr("bin-macos-app");
         let project_root = Path::new("/abs/project");
         let profile_dir = project_root
             .join(".scaffold/basecamp/profiles")
             .join("alice");
         let mut env: BTreeMap<String, OsString> = BTreeMap::new();
-        set_absolute_logos_data_dir(&mut env, project_root, &profile_dir, Some(&portable));
+        set_absolute_basecamp_data_dirs(&mut env, project_root, &profile_dir, Some(&portable));
+        let expected = profile_dir
+            .join("xdg-data")
+            .join(BASECAMP_XDG_APP_SUBPATH_PORTABLE);
+        // 0.1.x reads LOGOS_DATA_DIR, 0.2.x reads LOGOS_USER_DIR; both must
+        // point at the same profile module root for the launch to be
+        // pin-agnostic.
         assert_eq!(
             env.get("LOGOS_DATA_DIR").map(PathBuf::from),
-            Some(
-                profile_dir
-                    .join("xdg-data")
-                    .join(BASECAMP_XDG_APP_SUBPATH_PORTABLE)
-            )
+            Some(expected.clone())
         );
+        assert_eq!(env.get("LOGOS_USER_DIR").map(PathBuf::from), Some(expected));
     }
 
     #[test]
-    fn set_absolute_logos_data_dir_absolutizes_relative_caller_value() {
+    fn set_absolute_basecamp_data_dirs_absolutizes_relative_logos_data_dir() {
         let portable = repo_with_attr("bin-macos-app");
         let project_root = Path::new("/abs/project");
         let profile_dir = project_root.join("profiles/alice");
@@ -3806,7 +3836,7 @@ mod tests {
         // A relative value (e.g. from [basecamp.profiles.<name>.env]) loads the
         // backend modules but breaks @rpath resolution of the UI dylibs.
         env.insert("LOGOS_DATA_DIR".into(), OsString::from("custom/data"));
-        set_absolute_logos_data_dir(&mut env, project_root, &profile_dir, Some(&portable));
+        set_absolute_basecamp_data_dirs(&mut env, project_root, &profile_dir, Some(&portable));
         assert_eq!(
             env.get("LOGOS_DATA_DIR").map(PathBuf::from),
             Some(project_root.join("custom/data"))
@@ -3814,21 +3844,43 @@ mod tests {
     }
 
     #[test]
-    fn set_absolute_logos_data_dir_leaves_absolute_caller_value_untouched() {
+    fn set_absolute_basecamp_data_dirs_absolutizes_relative_logos_user_dir() {
+        let portable = repo_with_attr("bin-macos-app");
+        let project_root = Path::new("/abs/project");
+        let profile_dir = project_root.join("profiles/alice");
+        let mut env: BTreeMap<String, OsString> = BTreeMap::new();
+        // Basecamp 0.2.x consumes the LOGOS_USER_DIR env var verbatim (only
+        // the --user-dir flag is absolutized app-side), so a relative value
+        // would scatter state under the app's cwd.
+        env.insert("LOGOS_USER_DIR".into(), OsString::from("custom/user"));
+        set_absolute_basecamp_data_dirs(&mut env, project_root, &profile_dir, Some(&portable));
+        assert_eq!(
+            env.get("LOGOS_USER_DIR").map(PathBuf::from),
+            Some(project_root.join("custom/user"))
+        );
+    }
+
+    #[test]
+    fn set_absolute_basecamp_data_dirs_leaves_absolute_caller_values_untouched() {
         let portable = repo_with_attr("bin-macos-app");
         let project_root = Path::new("/abs/project");
         let profile_dir = project_root.join("profiles/alice");
         let mut env: BTreeMap<String, OsString> = BTreeMap::new();
         env.insert("LOGOS_DATA_DIR".into(), OsString::from("/somewhere/else"));
-        set_absolute_logos_data_dir(&mut env, project_root, &profile_dir, Some(&portable));
+        env.insert("LOGOS_USER_DIR".into(), OsString::from("/another/place"));
+        set_absolute_basecamp_data_dirs(&mut env, project_root, &profile_dir, Some(&portable));
         assert_eq!(
             env.get("LOGOS_DATA_DIR").map(PathBuf::from),
             Some(PathBuf::from("/somewhere/else"))
         );
+        assert_eq!(
+            env.get("LOGOS_USER_DIR").map(PathBuf::from),
+            Some(PathBuf::from("/another/place"))
+        );
     }
 
     #[test]
-    fn set_absolute_logos_data_dir_treats_empty_caller_value_as_unset() {
+    fn set_absolute_basecamp_data_dirs_treats_empty_caller_values_as_unset() {
         let portable = repo_with_attr("bin-macos-app");
         let project_root = Path::new("/abs/project");
         let profile_dir = project_root.join("profiles/alice");
@@ -3837,7 +3889,32 @@ mod tests {
         // absolutize to the project root itself, which is not a module root;
         // it must fall back to the profile default instead.
         env.insert("LOGOS_DATA_DIR".into(), OsString::new());
-        set_absolute_logos_data_dir(&mut env, project_root, &profile_dir, Some(&portable));
+        env.insert("LOGOS_USER_DIR".into(), OsString::new());
+        set_absolute_basecamp_data_dirs(&mut env, project_root, &profile_dir, Some(&portable));
+        let expected = profile_dir
+            .join("xdg-data")
+            .join(BASECAMP_XDG_APP_SUBPATH_PORTABLE);
+        assert_eq!(
+            env.get("LOGOS_DATA_DIR").map(PathBuf::from),
+            Some(expected.clone())
+        );
+        assert_eq!(env.get("LOGOS_USER_DIR").map(PathBuf::from), Some(expected));
+    }
+
+    #[test]
+    fn set_absolute_basecamp_data_dirs_handles_each_key_independently() {
+        let portable = repo_with_attr("bin-macos-app");
+        let project_root = Path::new("/abs/project");
+        let profile_dir = project_root.join("profiles/alice");
+        let mut env: BTreeMap<String, OsString> = BTreeMap::new();
+        // Only one key overridden (relative): it must be absolutized while the
+        // other still gets the profile default — no cross-key leakage.
+        env.insert("LOGOS_USER_DIR".into(), OsString::from("custom/user"));
+        set_absolute_basecamp_data_dirs(&mut env, project_root, &profile_dir, Some(&portable));
+        assert_eq!(
+            env.get("LOGOS_USER_DIR").map(PathBuf::from),
+            Some(project_root.join("custom/user"))
+        );
         assert_eq!(
             env.get("LOGOS_DATA_DIR").map(PathBuf::from),
             Some(


### PR DESCRIPTION
Closes #242.

## Problem

`lgs basecamp launch` exports an absolute per-profile `LOGOS_DATA_DIR` (#236 / #238) — a Basecamp **0.1.x** name. Basecamp 0.2.x renamed the data-tree override to `LOGOS_USER_DIR` / `--user-dir` (logos-basecamp#164, resolved in `LogosBasecampPaths.h::baseDirectory()`) and drops the old key entirely. Since Qt's `AppDataLocation` ignores `XDG_DATA_HOME` on macOS, launching against a 0.2.x pin silently collapses every profile onto the shared `~/Library/Application Support/Logos/LogosBasecamp`: only the embedded bundle modules load, none of the project's modules appear, and multi-peer profile isolation is gone.

Extra subtlety: basecamp absolutizes the `--user-dir` **flag** (`QFileInfo::absoluteFilePath()` + `qputenv`) but consumes the `LOGOS_USER_DIR` **env var** verbatim, so a relative env value scatters state under the app's cwd. Scaffold must export an absolute path, exactly as #238 already does for the old key.

## Fix

Generalizes `set_absolute_logos_data_dir` into `set_absolute_basecamp_data_dirs`, which applies the identical per-key transform (private helper `set_absolute_module_root_var`) to both `LOGOS_DATA_DIR` and `LOGOS_USER_DIR` independently:

- default to the profile's absolute module root (`<profile>/xdg-data/<basecamp_xdg_subpath>`) when unset;
- absolutize a caller-supplied relative value (from `[basecamp.env]` / `[basecamp.profiles.<name>.env]`) against the project root;
- treat an empty/whitespace-only value as unset.

The two keys are read by disjoint basecamp generations, so setting both keeps the launch pin-agnostic — projects on 0.1.x pins see no behavior change.

### Gating rationale

Kept #238's gate unchanged (`cfg!(target_os = "macos") && is_portable_basecamp(...)`): the profile-collapse failure only exists where `XDG_DATA_HOME` is ignored, i.e. the macOS portable stack. On Linux, Qt honors `XDG_DATA_HOME`, so `launch_env`'s existing XDG isolation already covers both basecamp generations there. The transform itself stays platform-independent for unit-testability, as before.

## Tests

The four `set_absolute_logos_data_dir_*` tests are extended into six `set_absolute_basecamp_data_dirs_*` tests: default-both-keys-when-unset, absolutize-relative for each key, absolute-values-untouched for both, empty-treated-as-unset for both, and a per-key independence test (one key overridden relative, the other unset). `cargo fmt --check`, `cargo check`, and `cargo test` (709 tests) all pass locally.

## Downstream verification

Verified in `eth-lez-atomic-swaps` (tracker entry TR-21; basecamp pin `8a36a839`, tag 0.2.1, aarch64-darwin), which until now bridged this with a `LOGOS_USER_DIR=... lgs basecamp launch` Makefile wrapper — the wrapped stack was verified there with a full two-peer GUI swap on 2026-07-30. With this branch's `lgs` installed (`cargo install --locked`), a **bare** `lgs basecamp launch maker --log-file` (no wrapper):

`ps eww <app pid>`:

```
LOGOS_DATA_DIR=/Users/.../eth-lez-atomic-swaps/nashville/.scaffold/basecamp/profiles/maker/xdg-data/Logos/LogosBasecamp
LOGOS_USER_DIR=/Users/.../eth-lez-atomic-swaps/nashville/.scaffold/basecamp/profiles/maker/xdg-data/Logos/LogosBasecamp
LOGOS_PROFILE=maker
```

Profile `basecamp.log` (previously this line read the shared `~/Library/Application Support/Logos/LogosBasecamp` — the failure signature):

```
Base data directory: /Users/.../nashville/.scaffold/basecamp/profiles/maker/xdg-data/Logos/LogosBasecamp
... ModuleProxy: callRemoteMethod "setUserModulesDirectory" args: QList(QVariant(QString, ".../profiles/maker/xdg-data/Logos/LogosBasecamp/modules"))
... ModuleProxy: callRemoteMethod "setUserUiPluginsDirectory" args: QList(QVariant(QString, ".../profiles/maker/xdg-data/Logos/LogosBasecamp/plugins"))
... ModuleProxy: callRemoteMethod "getInstalledUiPlugins" args: QList()
```

Zero `shared library was not found` occurrences. Enumerating the exact dirs the app was pointed at (bundled 0.2.1 lgpm, the same enumeration source `package_manager` reads):

```
NAME                           VERSION         TYPE       CATEGORY
delivery_module                1.1.0           core       protocol
swap                           0.2.0           core       defi
swap_ui                        0.2.0           ui_qml     defi
```

`swap_ui`'s installed manifest carries `"view": "qml/Main.qml"`, so it passes 0.2.x's `UIPluginManager` `ui_qml` empty-view filter and shows up in the launcher.