### PR TITLE
feat(run): per-profile topup = false to skip scaffold's wallet-topup step

### DIFF
--- a/DOGFOODING.md
+++ b/DOGFOODING.md
@@ -601,6 +601,18 @@ post_deploy = ["echo 'deploy skipped:' $SCAFFOLD_DEPLOY_SKIPPED"]
 "$SCAFFOLD_BIN" run --profile self-deploy   # skips step 5, still fires hooks
 ```
 
+Then add a profile that funds its own accounts (`topup = false`) and run it:
+
+```toml
+[run.profiles.self-fund]
+topup = false
+post_deploy = ["echo 'self-fund hook ran'"]
+```
+
+```bash
+"$SCAFFOLD_BIN" run --profile self-fund   # skips step 4, still deploys + fires hooks
+```
+
 ### Expected Success Signals
 
 - The first `run` (no hooks configured) prints a numbered step header for each phase (`[1/5] Building...` through `[5/5] Deploying...`) and ends with a deployed-programs summary.
@@ -611,6 +623,7 @@ post_deploy = ["echo 'deploy skipped:' $SCAFFOLD_DEPLOY_SKIPPED"]
 - `--post-deploy` with `--no-post-deploy` errors at clap parse time with a `cannot be used with` message; exit code is non-zero.
 - A non-zero hook exit aborts the run with a clear `post-deploy hook exited with status N` message.
 - With `deploy = false` in the selected profile, `run --profile self-deploy` prints ``[5/6] Deploy skipped (`deploy = false` in the run profile; ...)`` instead of `[5/6] Deploying...`, skips the program-hash/deploy work entirely, and still runs the `post_deploy` hooks. Each hook sees `SCAFFOLD_DEPLOY_SKIPPED=1` (here `echo 'deploy skipped:' $SCAFFOLD_DEPLOY_SKIPPED` prints `deploy skipped: 1`).
+- With `topup = false` in the selected profile, `run --profile self-fund` prints ``[4/6] Topup skipped (`topup = false` in the run profile; ...)`` instead of `[4/6] Topping up wallet...`, skips the wallet-topup call entirely (no default-wallet-address requirement), and still runs deploy and the `post_deploy` hooks.
 
 ### Failure Signals / Common Pitfalls
 
@@ -625,6 +638,7 @@ post_deploy = ["echo 'deploy skipped:' $SCAFFOLD_DEPLOY_SKIPPED"]
 - Output of `run --post-deploy "echo override"` showing only the override hook fires.
 - Output of `run --no-post-deploy` showing the deployed-programs summary instead of hooks.
 - Output of `run --profile self-deploy` showing the ``[5/6] Deploy skipped (`deploy = false` ...)`` header and the `post_deploy` hook reporting `deploy skipped: 1`.
+- Output of `run --profile self-fund` showing the ``[4/6] Topup skipped (`topup = false` ...)`` header followed by the deploy step and hooks.
 
 ## L1. LEZ Template Bootstrap
 
@@ -1687,7 +1701,7 @@ HEAD0=$("$SCAFFOLD_BIN" test-node blocks head --url "$URL" --json | jq -r .block
 - Changes to wallet flows or wallet-related defaults: rerun `D4`.
 - Changes to diagnostics, report contents, or redaction logic: rerun `D5`.
 - Changes to example runner binaries or template `src/bin/*` code: rerun `D6`.
-- Changes to `run` step ordering, the `deploy = false` deploy-skip branch, post-deploy env vars, post-deploy CLI override flag handling, or `[run]` config parsing: rerun `D7`.
+- Changes to `run` step ordering, the `deploy = false` deploy-skip branch, the `topup = false` topup-skip branch, post-deploy env vars, post-deploy CLI override flag handling, or `[run]` config parsing: rerun `D7`.
 - Changes to LEZ template scaffolding or generated outputs: rerun `L1`, `L2`, `L3`, and `L4`.
 - Changes to CLI argument parsing, help text, or error messages: rerun `E1`.
 - Changes to `create`/`new` flags or template selection logic: rerun `E2`.

--- a/DOGFOODING.md
+++ b/DOGFOODING.md
@@ -606,11 +606,13 @@ Then add a profile that funds its own accounts (`topup = false`) and run it:
 ```toml
 [run.profiles.self-fund]
 topup = false
-post_deploy = ["echo 'self-fund hook ran'"]
+post_deploy = ["echo 'topup skipped:' $SCAFFOLD_TOPUP_SKIPPED"]
 ```
 
 ```bash
 "$SCAFFOLD_BIN" run --profile self-fund   # skips step 4, still deploys + fires hooks
+# same hook without the profile: topup runs, so the variable reports 0
+"$SCAFFOLD_BIN" run --post-deploy 'echo "topup skipped:" $SCAFFOLD_TOPUP_SKIPPED'
 ```
 
 ### Expected Success Signals
@@ -623,7 +625,7 @@ post_deploy = ["echo 'self-fund hook ran'"]
 - `--post-deploy` with `--no-post-deploy` errors at clap parse time with a `cannot be used with` message; exit code is non-zero.
 - A non-zero hook exit aborts the run with a clear `post-deploy hook exited with status N` message.
 - With `deploy = false` in the selected profile, `run --profile self-deploy` prints ``[5/6] Deploy skipped (`deploy = false` in the run profile; ...)`` instead of `[5/6] Deploying...`, skips the program-hash/deploy work entirely, and still runs the `post_deploy` hooks. Each hook sees `SCAFFOLD_DEPLOY_SKIPPED=1` (here `echo 'deploy skipped:' $SCAFFOLD_DEPLOY_SKIPPED` prints `deploy skipped: 1`).
-- With `topup = false` in the selected profile, `run --profile self-fund` prints ``[4/6] Topup skipped (`topup = false` in the run profile; ...)`` instead of `[4/6] Topping up wallet...`, skips the wallet-topup call entirely (no default-wallet-address requirement), and still runs deploy and the `post_deploy` hooks.
+- With `topup = false` in the selected profile, `run --profile self-fund` prints ``[4/6] Topup skipped (`topup = false` in the run profile; ...)`` instead of `[4/6] Topping up wallet...`, skips the wallet-topup call entirely (no destination-address requirement), and still runs deploy and the `post_deploy` hooks. Each hook sees `SCAFFOLD_TOPUP_SKIPPED=1` (here `echo 'topup skipped:' $SCAFFOLD_TOPUP_SKIPPED` prints `topup skipped: 1`). The same hook run without `--profile self-fund` prints `topup skipped: 0` — the variable is always set, never absent.
 
 ### Failure Signals / Common Pitfalls
 
@@ -638,7 +640,7 @@ post_deploy = ["echo 'self-fund hook ran'"]
 - Output of `run --post-deploy "echo override"` showing only the override hook fires.
 - Output of `run --no-post-deploy` showing the deployed-programs summary instead of hooks.
 - Output of `run --profile self-deploy` showing the ``[5/6] Deploy skipped (`deploy = false` ...)`` header and the `post_deploy` hook reporting `deploy skipped: 1`.
-- Output of `run --profile self-fund` showing the ``[4/6] Topup skipped (`topup = false` ...)`` header followed by the deploy step and hooks.
+- Output of `run --profile self-fund` showing the ``[4/6] Topup skipped (`topup = false` ...)`` header followed by the deploy step and the `post_deploy` hook reporting `topup skipped: 1`, plus the profile-less run of the same hook reporting `topup skipped: 0`.
 
 ## L1. LEZ Template Bootstrap
 

--- a/README.md
+++ b/README.md
@@ -311,11 +311,11 @@ post_deploy = ["cargo run --bin demo"]
 
 Hooks see `SCAFFOLD_TOPUP_SKIPPED=1` on such a run, so a funding hook can
 claim only when scaffold did not. The topup step itself needs a destination
-address, but step 1 of every `lgs run` chains `lgs setup`, which seeds one
-into `.scaffold/state/wallet.state` from the first preconfigured public
-account in the wallet config whenever that file is missing. So on a pin that
-ships those accounts the address is in place before step 4 — including after
-the file is deleted, and after `--reset` wipes the wallet.
+address, but on a pin whose wallet config ships preconfigured accounts one is
+already in place by step 4: step 1 of every `lgs run` chains `lgs setup`,
+which seeds `.scaffold/state/wallet.state` from the first preconfigured
+public account whenever that file is missing — and `--reset`, which wipes the
+wallet later, at step 3, re-seeds it before the run continues.
 
 `topup` defaults to `true`; omit it for the normal topup-then-deploy loop.
 

--- a/README.md
+++ b/README.md
@@ -259,9 +259,10 @@ environment variables pre-set:
 | `SCAFFOLD_GUEST_BIN` | Absolute path to the guest `.bin`. Set only when the project has exactly one deployable program |
 
 `SCAFFOLD_TOPUP_SKIPPED` and `SCAFFOLD_DEPLOY_SKIPPED` describe the run as a
-whole, so unlike the program-specific variables they are always set — including
-for projects with no deployable programs. Hooks should branch on their value,
-not on whether they exist.
+whole, so they are set on every hook invocation — including for projects with
+no deployable programs, where `SCAFFOLD_PROGRAM_ID` and `SCAFFOLD_GUEST_BIN`
+are absent. Hooks should branch on their `1`/`0` value, not on whether they
+exist.
 
 `SCAFFOLD_PROGRAM_ID` and `SCAFFOLD_GUEST_BIN` are unset for
 multi-program projects so hooks fail loudly rather than silently
@@ -310,9 +311,11 @@ post_deploy = ["cargo run --bin demo"]
 
 Hooks see `SCAFFOLD_TOPUP_SKIPPED=1` on such a run, so a funding hook can
 claim only when scaffold did not. The topup step itself needs a destination
-address, but `lgs setup` seeds one into `.scaffold/state/wallet.state` from
-the first preconfigured public account in the wallet config, so on a pin
-that ships those accounts it is already there.
+address, but step 1 of every `lgs run` chains `lgs setup`, which seeds one
+into `.scaffold/state/wallet.state` from the first preconfigured public
+account in the wallet config whenever that file is missing. So on a pin that
+ships those accounts the address is in place before step 4 — including after
+the file is deleted, and after `--reset` wipes the wallet.
 
 `topup` defaults to `true`; omit it for the normal topup-then-deploy loop.
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,25 @@ post_deploy = ["scripts/deploy-and-demo.sh"]
 
 `deploy` defaults to `true`; omit it for the normal deploy loop.
 
+#### Self-funding projects (`topup = false`)
+
+`run` tops up the project's default wallet before deploying (step 4), and
+hard-fails when no default wallet address is configured. A project that
+funds its own accounts — e.g. its demo binary claims from the faucet at
+runtime, or a `post_deploy` hook handles funding — can set `topup = false`
+to skip scaffold's topup step. The pipeline then runs
+build → IDL → localnet → deploy → `post_deploy`, without requiring a
+default wallet address to be set. It works inline under `[run]` or per
+profile, and combines with `deploy = false`:
+
+```toml
+[run.profiles.demo]
+topup = false
+post_deploy = ["cargo run --bin demo"]
+```
+
+`topup` defaults to `true`; omit it for the normal topup-then-deploy loop.
+
 #### One-off override / skip
 
 To run a different hook without editing `scaffold.toml`:

--- a/README.md
+++ b/README.md
@@ -253,8 +253,15 @@ environment variables pre-set:
 | `NSSA_WALLET_HOME_DIR` | Absolute path to project wallet directory |
 | `SCAFFOLD_PROJECT_ROOT` | Absolute path to project root |
 | `SCAFFOLD_IDL_DIR` | Absolute path to IDL output directory |
+| `SCAFFOLD_TOPUP_SKIPPED` | `1` when step 4 was skipped (`topup = false`), `0` when scaffold topped up the wallet. Always set |
+| `SCAFFOLD_DEPLOY_SKIPPED` | `1` when step 5 deployed nothing — either `deploy = false`, or the deploy cache found guest binaries, IDL, config and sequencer unchanged — and `0` when it deployed. Always set |
 | `SCAFFOLD_PROGRAM_ID` | risc0 image ID (hex) of the deployed program. Set only when the project has exactly one deployable program; unset if `spel program-id` cannot extract the ID |
 | `SCAFFOLD_GUEST_BIN` | Absolute path to the guest `.bin`. Set only when the project has exactly one deployable program |
+
+`SCAFFOLD_TOPUP_SKIPPED` and `SCAFFOLD_DEPLOY_SKIPPED` describe the run as a
+whole, so unlike the program-specific variables they are always set — including
+for projects with no deployable programs. Hooks should branch on their value,
+not on whether they exist.
 
 `SCAFFOLD_PROGRAM_ID` and `SCAFFOLD_GUEST_BIN` are unset for
 multi-program projects so hooks fail loudly rather than silently
@@ -287,20 +294,25 @@ post_deploy = ["scripts/deploy-and-demo.sh"]
 
 #### Self-funding projects (`topup = false`)
 
-`run` tops up the project's default wallet before deploying (step 4), and
-hard-fails when no default wallet address is configured. A project that
-funds its own accounts — e.g. its demo binary claims from the faucet at
-runtime, or a `post_deploy` hook handles funding — can set `topup = false`
-to skip scaffold's topup step. The pipeline then runs
-build → IDL → localnet → deploy → `post_deploy`, without requiring a
-default wallet address to be set. It works inline under `[run]` or per
-profile, and combines with `deploy = false`:
+`run` tops up the project's default wallet before deploying (step 4). A
+project that funds its own accounts — e.g. its demo binary claims from the
+faucet at runtime, or a `post_deploy` hook handles funding — can set
+`topup = false` to skip that step and keep funding in one place instead of
+splitting it between scaffold and the project. The pipeline then runs
+build → IDL → localnet → deploy → `post_deploy`. It works inline under
+`[run]` or per profile, and combines with `deploy = false`:
 
 ```toml
 [run.profiles.demo]
 topup = false
 post_deploy = ["cargo run --bin demo"]
 ```
+
+Hooks see `SCAFFOLD_TOPUP_SKIPPED=1` on such a run, so a funding hook can
+claim only when scaffold did not. The topup step itself needs a destination
+address, but `lgs setup` seeds one into `.scaffold/state/wallet.state` from
+the first preconfigured public account in the wallet config, so on a pin
+that ships those accounts it is already there.
 
 `topup` defaults to `true`; omit it for the normal topup-then-deploy loop.
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -185,8 +185,19 @@ fn run_pipeline_once(project: &Project, params: &PipelineParams) -> DynResult<()
     }
 
     // Step 4: Wallet topup. Skipped entirely when the run profile sets
-    // `topup = false` (project funds its own accounts).
-    let topup_skipped = if params.resolved.topup {
+    // `topup = false` (project funds its own accounts). The branch below and
+    // the value hooks read from `SCAFFOLD_TOPUP_SKIPPED` come from the same
+    // expression, so what the hook is told can't drift from what step 4 did.
+    let topup_skipped = topup_step_skipped(&params.resolved);
+    if topup_skipped {
+        // `topup = false`: the project funds its own accounts (e.g. claims
+        // from the faucet at runtime, from a demo binary or a post_deploy
+        // hook). Skip scaffold's topup — including its requirement that a
+        // destination address be resolvable — and proceed to deploy/hooks.
+        println!(
+            "[4/{total_steps}] Topup skipped (`topup = false` in the run profile; this project funds its own accounts — e.g. via faucet claims at runtime)"
+        );
+    } else {
         println!("[4/{total_steps}] Topping up wallet...");
         let outcome = cmd_wallet_topup_inner(project, None, false, false)?;
         if let TopupOutcome::ConfirmationTimeout { message } = outcome {
@@ -196,17 +207,7 @@ fn run_pipeline_once(project: &Project, params: &PipelineParams) -> DynResult<()
                  Hint: retry `logos-scaffold run` or run `logos-scaffold wallet topup` manually."
             );
         }
-        false
-    } else {
-        // `topup = false`: the project funds its own accounts (e.g. claims
-        // from the faucet at runtime, from a demo binary or a post_deploy
-        // hook). Skip scaffold's topup — including its requirement that a
-        // destination address be resolvable — and proceed to deploy/hooks.
-        println!(
-            "[4/{total_steps}] Topup skipped (`topup = false` in the run profile; this project funds its own accounts — e.g. via faucet claims at runtime)"
-        );
-        true
-    };
+    }
 
     // Step 5: Deploy. Skipped entirely when the run profile sets
     // `deploy = false` (project owns deployment); otherwise idempotent —
@@ -275,6 +276,16 @@ fn run_pipeline_once(project: &Project, params: &PipelineParams) -> DynResult<()
     }
 
     Ok(())
+}
+
+/// Whether step 4 skips scaffold's wallet topup for `resolved` — which is
+/// also the value hooks read from `SCAFFOLD_TOPUP_SKIPPED`.
+///
+/// Extracted as its own function so a unit test can pin the polarity
+/// directly: `run_pipeline_once` needs a real sequencer to drive, so an
+/// inverted signal here would otherwise reach every hook unchallenged.
+fn topup_step_skipped(resolved: &RunProfile) -> bool {
+    !resolved.topup
 }
 
 fn reset_for_run(project: &Project, verify_timeout_sec: u64) -> DynResult<()> {
@@ -1394,6 +1405,27 @@ mod tests {
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "0");
+    }
+
+    /// The two tests above pass `topup_skipped` in explicitly, so they pin
+    /// how `build_hook_command` renders the flag but not how step 4 decides
+    /// it. This one pins the decision: swapping the polarity would hand every
+    /// hook the exact inverse of what the pipeline did, and no test that
+    /// stops at `build_hook_command` can notice.
+    #[test]
+    fn topup_step_skipped_follows_the_profile_flag() {
+        // Default profile (`topup = true`) tops up, so nothing was skipped.
+        assert!(
+            !topup_step_skipped(&RunProfile::default()),
+            "`topup = true` must report SCAFFOLD_TOPUP_SKIPPED=0"
+        );
+        assert!(
+            topup_step_skipped(&RunProfile {
+                topup: false,
+                ..RunProfile::default()
+            }),
+            "`topup = false` must report SCAFFOLD_TOPUP_SKIPPED=1"
+        );
     }
 
     #[test]

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -184,14 +184,25 @@ fn run_pipeline_once(project: &Project, params: &PipelineParams) -> DynResult<()
         ensure_localnet(project, params.localnet_timeout_sec)?;
     }
 
-    // Step 4: Wallet topup
-    println!("[4/{total_steps}] Topping up wallet...");
-    let outcome = cmd_wallet_topup_inner(project, None, false, false)?;
-    if let TopupOutcome::ConfirmationTimeout { message } = outcome {
-        bail!(
-            "{message}\n\
-             Run aborted before deploy to avoid deploying with uncertain funding.\n\
-             Hint: retry `logos-scaffold run` or run `logos-scaffold wallet topup` manually."
+    // Step 4: Wallet topup. Skipped entirely when the run profile sets
+    // `topup = false` (project funds its own accounts).
+    if params.resolved.topup {
+        println!("[4/{total_steps}] Topping up wallet...");
+        let outcome = cmd_wallet_topup_inner(project, None, false, false)?;
+        if let TopupOutcome::ConfirmationTimeout { message } = outcome {
+            bail!(
+                "{message}\n\
+                 Run aborted before deploy to avoid deploying with uncertain funding.\n\
+                 Hint: retry `logos-scaffold run` or run `logos-scaffold wallet topup` manually."
+            );
+        }
+    } else {
+        // `topup = false`: the project funds its own accounts (e.g. claims
+        // from the faucet at runtime, from a demo binary or a post_deploy
+        // hook). Skip scaffold's topup — which otherwise hard-fails when no
+        // default wallet address is configured — and proceed to deploy/hooks.
+        println!(
+            "[4/{total_steps}] Topup skipped (`topup = false` in the run profile; this project funds its own accounts — e.g. via faucet claims at runtime)"
         );
     }
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -186,7 +186,7 @@ fn run_pipeline_once(project: &Project, params: &PipelineParams) -> DynResult<()
 
     // Step 4: Wallet topup. Skipped entirely when the run profile sets
     // `topup = false` (project funds its own accounts).
-    if params.resolved.topup {
+    let topup_skipped = if params.resolved.topup {
         println!("[4/{total_steps}] Topping up wallet...");
         let outcome = cmd_wallet_topup_inner(project, None, false, false)?;
         if let TopupOutcome::ConfirmationTimeout { message } = outcome {
@@ -196,15 +196,17 @@ fn run_pipeline_once(project: &Project, params: &PipelineParams) -> DynResult<()
                  Hint: retry `logos-scaffold run` or run `logos-scaffold wallet topup` manually."
             );
         }
+        false
     } else {
         // `topup = false`: the project funds its own accounts (e.g. claims
         // from the faucet at runtime, from a demo binary or a post_deploy
-        // hook). Skip scaffold's topup — which otherwise hard-fails when no
-        // default wallet address is configured — and proceed to deploy/hooks.
+        // hook). Skip scaffold's topup — including its requirement that a
+        // destination address be resolvable — and proceed to deploy/hooks.
         println!(
             "[4/{total_steps}] Topup skipped (`topup = false` in the run profile; this project funds its own accounts — e.g. via faucet claims at runtime)"
         );
-    }
+        true
+    };
 
     // Step 5: Deploy. Skipped entirely when the run profile sets
     // `deploy = false` (project owns deployment); otherwise idempotent —
@@ -265,7 +267,7 @@ fn run_pipeline_once(project: &Project, params: &PipelineParams) -> DynResult<()
         warn_on_rewritten_program_names(&deployed.programs);
         for (i, hook) in params.hooks.iter().enumerate() {
             println!("===> post_deploy[{}/{n}]: {hook}", i + 1);
-            run_post_deploy_hook(project, hook, &deployed)?;
+            run_post_deploy_hook(project, hook, &deployed, topup_skipped)?;
             println!("<=== post_deploy[{}/{n}] OK", i + 1);
         }
     } else {
@@ -744,10 +746,14 @@ fn print_deploy_summary(project: &Project) -> DynResult<()> {
     Ok(())
 }
 
+/// `topup_skipped` is threaded in as its own parameter rather than carried
+/// on `DeployedPrograms`: step 4's outcome has no per-program dimension, so
+/// it does not belong on a struct that describes deployed programs.
 fn build_hook_command(
     project: &Project,
     hook_command: &str,
     deployed: &DeployedPrograms,
+    topup_skipped: bool,
 ) -> Command {
     let sequencer_url =
         crate::commands::wallet_support::default_sequencer_http_url_for_project(project);
@@ -782,6 +788,14 @@ fn build_hook_command(
             "SCAFFOLD_DEPLOY_SKIPPED",
             if run_deploy_skipped { "1" } else { "0" },
         )
+        // Always-on for the same reason: topup-skip is run-level state with
+        // no per-program dimension at all. A hook that funds accounts itself
+        // (the `topup = false` case) needs it to decide whether to claim,
+        // rather than always claiming and tolerating an already-funded wallet.
+        .env(
+            "SCAFFOLD_TOPUP_SKIPPED",
+            if topup_skipped { "1" } else { "0" },
+        )
         .current_dir(&project.root);
 
     // Per-program metadata: `SCAFFOLD_PROGRAMS` holds the space-separated
@@ -803,8 +817,8 @@ fn build_hook_command(
     }
     // Single-program shortcut: only set when there's exactly one program.
     // Hooks that handle multi-program projects must use the indexed forms.
-    // `SCAFFOLD_DEPLOY_SKIPPED` is set unconditionally above (run-level),
-    // so it's not duplicated here.
+    // `SCAFFOLD_DEPLOY_SKIPPED` and `SCAFFOLD_TOPUP_SKIPPED` are set
+    // unconditionally above (run-level), so they're not duplicated here.
     if let [single] = deployed.programs.as_slice() {
         cmd.env("SCAFFOLD_PROGRAM_NAME", &single.name);
         if let Some(id) = &single.program_id {
@@ -819,8 +833,9 @@ fn run_post_deploy_hook(
     project: &Project,
     hook_command: &str,
     deployed: &DeployedPrograms,
+    topup_skipped: bool,
 ) -> DynResult<()> {
-    let status = build_hook_command(project, hook_command, deployed)
+    let status = build_hook_command(project, hook_command, deployed, topup_skipped)
         .status()
         .context("failed to execute post-deploy hook")?;
 
@@ -1005,7 +1020,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$SEQUENCER_URL\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default())
+        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default(), false)
             .expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
@@ -1019,7 +1034,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$NSSA_WALLET_HOME_DIR\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default())
+        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default(), false)
             .expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
@@ -1036,7 +1051,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$SCAFFOLD_PROJECT_ROOT\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default())
+        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default(), false)
             .expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
@@ -1054,7 +1069,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("echo \"$SCAFFOLD_IDL_DIR\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default())
+        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default(), false)
             .expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
@@ -1072,7 +1087,7 @@ mod tests {
         project.config.localnet.port = 9999;
 
         let hook = format!("echo \"$SEQUENCER_URL\" > '{}'", env_file.display());
-        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default())
+        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default(), false)
             .expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
@@ -1084,7 +1099,7 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let project = make_test_project(temp.path().to_path_buf());
 
-        let result = run_post_deploy_hook(&project, "exit 42", &DeployedPrograms::default());
+        let result = run_post_deploy_hook(&project, "exit 42", &DeployedPrograms::default(), false);
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(
@@ -1100,7 +1115,7 @@ mod tests {
         let project = make_test_project(temp.path().to_path_buf());
 
         let hook = format!("pwd > '{}'", pwd_file.display());
-        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default())
+        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default(), false)
             .expect("hook should succeed");
 
         let content = std::fs::read_to_string(&pwd_file).expect("read pwd output");
@@ -1169,7 +1184,7 @@ mod tests {
             }} > '{}'",
             env_file.display()
         );
-        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default())
+        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default(), false)
             .expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
@@ -1232,7 +1247,7 @@ mod tests {
             "echo \"$SCAFFOLD_PROGRAM_ID|$SCAFFOLD_GUEST_BIN\" > '{}'",
             env_file.display()
         );
-        run_post_deploy_hook(&project, &hook, &deployed).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &deployed, false).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         let expected_bin = temp.path().join("counter.bin");
@@ -1264,7 +1279,7 @@ mod tests {
             "if [ -z \"${{SCAFFOLD_PROGRAM_ID+set}}\" ]; then echo unset; else echo set; fi > '{}'",
             env_file.display()
         );
-        run_post_deploy_hook(&project, &hook, &deployed).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &deployed, false).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "unset");
@@ -1282,7 +1297,7 @@ mod tests {
             "echo \"id=${{SCAFFOLD_PROGRAM_ID+set}}|bin=${{SCAFFOLD_GUEST_BIN+set}}\" > '{}'",
             env_file.display()
         );
-        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default())
+        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default(), false)
             .expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
@@ -1310,7 +1325,7 @@ mod tests {
             "echo \"$SCAFFOLD_DEPLOY_SKIPPED\" > '{}'",
             env_file.display()
         );
-        run_post_deploy_hook(&project, &hook, &deployed).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &deployed, false).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "1");
@@ -1329,7 +1344,52 @@ mod tests {
             "echo \"$SCAFFOLD_DEPLOY_SKIPPED\" > '{}'",
             env_file.display()
         );
-        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default())
+        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default(), false)
+            .expect("hook should succeed");
+
+        let content = std::fs::read_to_string(&env_file).expect("read env output");
+        assert_eq!(content.trim(), "0");
+    }
+
+    #[test]
+    fn hook_receives_topup_skipped_env_for_multiprogram_run() {
+        // `SCAFFOLD_TOPUP_SKIPPED` is run-level state (step 4 has no
+        // per-program dimension), so it must reach multi-program hooks too —
+        // a self-funding hook decides whether to claim based on it.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env_file = temp.path().join("env_out.txt");
+        let project = make_test_project(temp.path().to_path_buf());
+        let deployed = programs(
+            vec![
+                fake_deployed("a", Some("h1")),
+                fake_deployed("b", Some("h2")),
+            ],
+            false,
+        );
+
+        let hook = format!(
+            "echo \"$SCAFFOLD_TOPUP_SKIPPED\" > '{}'",
+            env_file.display()
+        );
+        run_post_deploy_hook(&project, &hook, &deployed, true).expect("hook should succeed");
+
+        let content = std::fs::read_to_string(&env_file).expect("read env output");
+        assert_eq!(content.trim(), "1");
+    }
+
+    #[test]
+    fn hook_receives_topup_skipped_zero_when_topup_ran() {
+        // The var is always set, so a hook can branch on it directly rather
+        // than treating "unset" as "scaffold topped up".
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env_file = temp.path().join("env_out.txt");
+        let project = make_test_project(temp.path().to_path_buf());
+
+        let hook = format!(
+            "echo \"$SCAFFOLD_TOPUP_SKIPPED\" > '{}'",
+            env_file.display()
+        );
+        run_post_deploy_hook(&project, &hook, &DeployedPrograms::default(), false)
             .expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
@@ -1347,7 +1407,7 @@ mod tests {
             "echo \"$SCAFFOLD_PROGRAM_ID_counter\" > '{}'",
             env_file.display()
         );
-        run_post_deploy_hook(&project, &hook, &deployed).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &deployed, false).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "deadbeef");
@@ -1364,7 +1424,7 @@ mod tests {
             "printf '%s|%s|%s' \"$SCAFFOLD_PROGRAM_NAME\" \"$SCAFFOLD_PROGRAM_ID\" \"$SCAFFOLD_DEPLOY_SKIPPED\" > '{}'",
             env_file.display()
         );
-        run_post_deploy_hook(&project, &hook, &deployed).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &deployed, false).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content, "counter|abc123|0");
@@ -1387,7 +1447,7 @@ mod tests {
             "echo \"[${{SCAFFOLD_PROGRAM_NAME:-unset}}]\" > '{}'",
             env_file.display()
         );
-        run_post_deploy_hook(&project, &hook, &deployed).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &deployed, false).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "[unset]");
@@ -1407,7 +1467,7 @@ mod tests {
             "printf '%s|%s|%s' \"$SCAFFOLD_PROGRAMS\" \"$SCAFFOLD_DEPLOY_SKIPPED_a\" \"$SCAFFOLD_DEPLOY_SKIPPED_b\" > '{}'",
             env_file.display()
         );
-        run_post_deploy_hook(&project, &hook, &deployed).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &deployed, false).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content, "a b|1|1");
@@ -1424,7 +1484,7 @@ mod tests {
             "echo \"[${{SCAFFOLD_PROGRAM_ID_noid:-unset}}]\" > '{}'",
             env_file.display()
         );
-        run_post_deploy_hook(&project, &hook, &deployed).expect("hook should succeed");
+        run_post_deploy_hook(&project, &hook, &deployed, false).expect("hook should succeed");
 
         let content = std::fs::read_to_string(&env_file).expect("read env output");
         assert_eq!(content.trim(), "[unset]");

--- a/src/config.rs
+++ b/src/config.rs
@@ -113,6 +113,11 @@ fn parse_run(doc: &DocumentMut) -> DynResult<RunConfig> {
         .and_then(Item::as_value)
         .and_then(|v| v.as_bool())
         .unwrap_or(true);
+    let inline_topup = run_table
+        .get("topup")
+        .and_then(Item::as_value)
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
     let inline_post_deploy = parse_post_deploy(run_table.get("post_deploy"))?;
 
     let mut profiles: std::collections::BTreeMap<String, RunProfile> =
@@ -132,6 +137,11 @@ fn parse_run(doc: &DocumentMut) -> DynResult<RunConfig> {
                 .and_then(Item::as_value)
                 .and_then(|v| v.as_bool())
                 .unwrap_or(true);
+            let topup = table
+                .get("topup")
+                .and_then(Item::as_value)
+                .and_then(|v| v.as_bool())
+                .unwrap_or(true);
             let post_deploy = parse_post_deploy(table.get("post_deploy"))?;
             profiles.insert(
                 name.to_string(),
@@ -139,6 +149,7 @@ fn parse_run(doc: &DocumentMut) -> DynResult<RunConfig> {
                     reset,
                     post_deploy,
                     deploy,
+                    topup,
                 },
             );
         }
@@ -160,6 +171,7 @@ fn parse_run(doc: &DocumentMut) -> DynResult<RunConfig> {
             reset: inline_reset,
             post_deploy: inline_post_deploy,
             deploy: inline_deploy,
+            topup: inline_topup,
         },
         profiles,
         watch,
@@ -915,7 +927,10 @@ pub(crate) fn serialize_config(cfg: &Config) -> DynResult<String> {
 }
 
 fn write_run_config(doc: &mut DocumentMut, run: &RunConfig) -> DynResult<()> {
-    let has_inline = run.inline.reset || !run.inline.post_deploy.is_empty() || !run.inline.deploy;
+    let has_inline = run.inline.reset
+        || !run.inline.post_deploy.is_empty()
+        || !run.inline.deploy
+        || !run.inline.topup;
     let has_default_profile = run.default_profile.is_some();
     let has_profiles = !run.profiles.is_empty();
     let has_watch = run.watch != WatchConfig::default();
@@ -932,10 +947,13 @@ fn write_run_config(doc: &mut DocumentMut, run: &RunConfig) -> DynResult<()> {
     if run.inline.reset {
         run_table["reset"] = value(true);
     }
-    // Only emit `deploy` when it deviates from the `true` default, to keep a
-    // fresh scaffold.toml minimal.
+    // Only emit `deploy`/`topup` when they deviate from the `true` default,
+    // to keep a fresh scaffold.toml minimal.
     if !run.inline.deploy {
         run_table["deploy"] = value(false);
+    }
+    if !run.inline.topup {
+        run_table["topup"] = value(false);
     }
     if !run.inline.post_deploy.is_empty() {
         for hook in &run.inline.post_deploy {
@@ -964,6 +982,9 @@ fn write_run_config(doc: &mut DocumentMut, run: &RunConfig) -> DynResult<()> {
             }
             if !profile.deploy {
                 profile_table["deploy"] = value(false);
+            }
+            if !profile.topup {
+                profile_table["topup"] = value(false);
             }
             if !profile.post_deploy.is_empty() {
                 profile_table["post_deploy"] = post_deploy_value(&profile.post_deploy);
@@ -2065,6 +2086,61 @@ role = "project"
     }
 
     #[test]
+    fn run_profile_topup_defaults_to_true() {
+        // Absent `topup` key → topup runs, preserving historical behavior.
+        let toml = minimal_v0_2_0() + "[run.profiles.demo]\npost_deploy = \"echo demo\"\n";
+        let cfg = parse_config(&toml).expect("parse");
+        assert!(cfg.run.profiles.get("demo").expect("demo present").topup);
+        // The inline/default profile also defaults topup to true.
+        assert!(RunProfile::default().topup);
+        assert!(cfg.run.inline.topup);
+    }
+
+    #[test]
+    fn parse_config_run_profile_topup_false() {
+        let toml = minimal_v0_2_0()
+            + "[run.profiles.demo]\ntopup = false\npost_deploy = [\"cargo run --bin demo\"]\n";
+        let cfg = parse_config(&toml).expect("parse");
+        let demo = cfg.run.profiles.get("demo").expect("demo present");
+        assert!(!demo.topup);
+        assert_eq!(demo.post_deploy, vec!["cargo run --bin demo".to_string()]);
+    }
+
+    #[test]
+    fn parse_config_inline_run_topup_false() {
+        let toml = minimal_v0_2_0() + "[run]\ntopup = false\n";
+        let cfg = parse_config(&toml).expect("parse");
+        assert!(!cfg.run.inline.topup);
+        let resolved = cfg.run.resolve_profile(None).expect("resolve");
+        assert!(!resolved.topup);
+    }
+
+    #[test]
+    fn run_profile_topup_round_trips_through_parse_serialize() {
+        let toml = minimal_v0_2_0()
+            + "[run]\ntopup = false\n[run.profiles.demo]\ntopup = false\npost_deploy = [\"echo demo\"]\n";
+        let cfg1 = parse_config(&toml).expect("parse");
+        let serialized = serialize_config(&cfg1).expect("serialize");
+        let cfg2 = parse_config(&serialized).expect("re-parse");
+        assert!(!cfg2.run.inline.topup);
+        let demo = cfg2.run.profiles.get("demo").expect("demo present");
+        assert!(!demo.topup);
+        assert_eq!(demo.post_deploy, vec!["echo demo".to_string()]);
+    }
+
+    #[test]
+    fn run_profile_topup_true_is_not_serialized() {
+        // The `true` default must not be emitted, to keep scaffold.toml minimal.
+        let toml = minimal_v0_2_0() + "[run.profiles.demo]\npost_deploy = [\"echo demo\"]\n";
+        let cfg = parse_config(&toml).expect("parse");
+        let serialized = serialize_config(&cfg).expect("serialize");
+        assert!(
+            !serialized.contains("topup = true"),
+            "default topup=true should not be serialized:\n{serialized}"
+        );
+    }
+
+    #[test]
     fn serialize_rejects_newline_in_profile_post_deploy() {
         let mut cfg = base_config();
         let mut profiles = std::collections::BTreeMap::new();
@@ -2074,6 +2150,7 @@ role = "project"
                 reset: false,
                 post_deploy: vec!["echo a\n[run.profiles.evil]".to_string()],
                 deploy: true,
+                topup: true,
             },
         );
         cfg.run = RunConfig {

--- a/src/model.rs
+++ b/src/model.rs
@@ -360,18 +360,27 @@ pub(crate) struct RunProfile {
     /// to the post-deploy hooks, instead of bailing on the missing default
     /// program directory.
     pub(crate) deploy: bool,
+    /// Whether `lgs run` performs its own wallet-topup step. Defaults to
+    /// `true`. Set `topup = false` for a project that funds its own accounts
+    /// (e.g. claims from the faucet at runtime, from a demo binary or a
+    /// `post_deploy` hook): the pipeline then skips step 4's topup — which
+    /// otherwise hard-fails when no default wallet address is configured —
+    /// and proceeds straight to deploy/hooks.
+    pub(crate) topup: bool,
 }
 
 impl Default for RunProfile {
     fn default() -> Self {
-        // `deploy` defaults to `true` so a project with no `[run]` config (or a
-        // profile that omits the key) keeps the historical behavior of running
-        // scaffold's deploy step. `derive(Default)` would give `false`, which
-        // would silently disable deploy for every existing project.
+        // `deploy` and `topup` default to `true` so a project with no `[run]`
+        // config (or a profile that omits the keys) keeps the historical
+        // behavior of running scaffold's deploy and topup steps.
+        // `derive(Default)` would give `false`, which would silently disable
+        // those steps for every existing project.
         Self {
             reset: false,
             post_deploy: Vec::new(),
             deploy: true,
+            topup: true,
         }
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -363,9 +363,10 @@ pub(crate) struct RunProfile {
     /// Whether `lgs run` performs its own wallet-topup step. Defaults to
     /// `true`. Set `topup = false` for a project that funds its own accounts
     /// (e.g. claims from the faucet at runtime, from a demo binary or a
-    /// `post_deploy` hook): the pipeline then skips step 4's topup — which
-    /// otherwise hard-fails when no default wallet address is configured —
-    /// and proceeds straight to deploy/hooks.
+    /// `post_deploy` hook): the pipeline then skips step 4's topup — along
+    /// with its requirement that a destination address be resolvable — and
+    /// proceeds straight to deploy/hooks. Hooks observe the choice through
+    /// `SCAFFOLD_TOPUP_SKIPPED`.
     pub(crate) topup: bool,
 }
 


### PR DESCRIPTION
Closes #243.

## What

Adds a `topup` boolean to run profiles — the structural twin of the `deploy = false` toggle from #239 (which solved the same problem for the deploy step, per #237):

```toml
[run.profiles.demo]
topup = false
post_deploy = ["cargo run --bin demo"]
```

- **Defaults to `true`** — every existing project and every profile that omits the key keeps the historical build → IDL → localnet → topup → deploy pipeline. Enforced by the manual `Default` impl on `RunProfile` (same rationale as `deploy`: `derive(Default)` would give `false` and silently disable the step everywhere).
- **Parsed** inline under `[run]` and per profile under `[run.profiles.<name>]` (`src/config.rs`), mirroring the `deploy` parse sites.
- **Serialized** only when it deviates from the default, keeping fresh `scaffold.toml` files minimal (same emit rule as `deploy`).
- **Pipeline gate** (`src/commands/run.rs`): when `false`, step 4 prints
  ``[4/N] Topup skipped (`topup = false` in the run profile; this project funds its own accounts — e.g. via faucet claims at runtime)``
  instead of `[4/N] Topping up wallet...`, skips the wallet-topup call entirely, and proceeds to deploy/hooks.
- **`SCAFFOLD_TOPUP_SKIPPED`** is exported to every post-deploy hook as `1`/`0`, alongside the existing `SCAFFOLD_DEPLOY_SKIPPED`. A project whose funding lives in a `post_deploy` hook needs to know whether scaffold already funded the wallet — without this it would have to be written "always claim, tolerate already-funded" rather than "claim only if scaffold didn't". The flag is produced by the same expression that executes (or skips) step 4, so what a hook is told cannot drift from what actually happened.
- `resolve_profile` needs no changes — it clones whole profiles, so the new field flows through inline/default-profile/`--profile` selection automatically.

## Why

Self-funding projects have no use for step 4. Downstream, the eth-lez-atomic-swaps demo binary funds its own LEZ accounts via bounded faucet claims at runtime (`src/demo.rs`), so scaffold's topup is duplicated work ahead of the project's own funding logic — and it splits responsibility for funding across two places. `topup = false` keeps it in one. Details in #243.

To be precise about a claim in an earlier revision of this description: step 4 *does* require a destination address, and `resolve_wallet_address` bails with `wallet topup requires a destination address.` when it can't find one. But on the scaffold-default LEZ v0.1.2 pin that path is effectively unreachable — `lgs setup` (which step 1 of `run` chains) seeds `.scaffold/state/wallet.state` from the first preconfigured public account in the wallet config, and v0.1.x debug configs ship those accounts. It becomes reachable on a pin whose config ships none, i.e. LEZ v0.2.0, which is what #246 addresses from the other side. So this PR stands on "my project owns funding", not on "otherwise it breaks". Thanks @weboko for catching that the original framing didn't reproduce.

## Tests

New unit tests in `src/config.rs`, mirroring the #239 deploy tests one-for-one:

- `run_profile_topup_defaults_to_true`
- `parse_config_run_profile_topup_false`
- `parse_config_inline_run_topup_false`
- `run_profile_topup_round_trips_through_parse_serialize`
- `run_profile_topup_true_is_not_serialized`

Plus hook-env tests in `src/commands/run.rs` that drive `build_hook_command` through a real `sh -c` and read the value back, covering both the `1` and `0` cases, and a test pinning the step-4 skip decision to the profile flag.

`cargo test` green (526 lib + 181 CLI + 3 testnode + 5 doc = 715, 0 failures); `cargo fmt --check` clean; `cargo clippy --all-targets` introduces no new warnings vs master.

**Residual risk worth naming:** the *polarity* of the step-4 decision is guarded by one test at the decision site, but the pipeline itself (`run_pipeline_once`) is not covered end-to-end without a real LEZ toolchain, so an inverted branch condition would not be caught by unit tests alone. The D7 scenario below is what actually exercises it.

Docs updated in README (new "Self-funding projects (`topup = false`)" section next to the self-deploying one, plus table rows for `SCAFFOLD_TOPUP_SKIPPED` and `SCAFFOLD_DEPLOY_SKIPPED` — the latter was previously undocumented outside DOGFOODING) and DOGFOODING D7 (self-fund profile scenario asserting the new env var in both states, expected `[4/6] Topup skipped` signal, rerun-trigger line).
